### PR TITLE
[3/3] Add regression test run UI and guideline metadata

### DIFF
--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -1297,7 +1297,12 @@ class Guidelines(BuiltInScorer):
             name=self.name,
             model=self.model,
         )
-        return _sanitize_scorer_feedback(feedback)
+        sanitized = _sanitize_scorer_feedback(feedback)
+        guidelines_text = (
+            self.guidelines if isinstance(self.guidelines, str) else "\n".join(self.guidelines)
+        )
+        sanitized.metadata = {**(sanitized.metadata or {}), "guideline": guidelines_text}
+        return sanitized
 
 
 @format_docstring(_MODEL_API_DOC)
@@ -1455,7 +1460,10 @@ class ExpectationsGuidelines(BuiltInScorer):
             name=self.name,
             model=self.model,
         )
-        return _sanitize_scorer_feedback(feedback)
+        sanitized = _sanitize_scorer_feedback(feedback)
+        guidelines_text = guidelines if isinstance(guidelines, str) else "\n".join(guidelines)
+        sanitized.metadata = {**(sanitized.metadata or {}), "guideline": guidelines_text}
+        return sanitized
 
 
 @format_docstring(_MODEL_API_DOC)

--- a/mlflow/server/js/src/experiment-tracking/components/evaluations/RegressionTestCasesTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/evaluations/RegressionTestCasesTable.tsx
@@ -1,0 +1,535 @@
+import type { RowSelectionState } from '@tanstack/react-table';
+import { isNil } from 'lodash';
+import { ParagraphSkeleton, Typography, Empty, Drawer } from '@databricks/design-system';
+import { type KeyValueEntity } from '../../../common/types';
+import { useDesignSystemTheme } from '@databricks/design-system';
+import { useCompareToRunUuid } from './hooks/useCompareToRunUuid';
+import Utils from '@mlflow/mlflow/src/common/utils/Utils';
+import { FormattedMessage } from 'react-intl';
+import { RunColorPill } from '../experiment-page/components/RunColorPill';
+import { getTrace as getTraceV3 } from '@mlflow/mlflow/src/experiment-tracking/utils/TraceUtils';
+import type { TracesTableColumn, TraceActions, GetTraceFunction } from '@databricks/web-shared/regression-test-table';
+import {
+  EXECUTION_DURATION_COLUMN_ID,
+  GenAiTracesMarkdownConverterProvider,
+  RUN_EVALUATION_RESULTS_TAB_COMPARE_RUNS,
+  RUN_EVALUATION_RESULTS_TAB_SINGLE_RUN,
+  getTracesTagKeys,
+  STATE_COLUMN_ID,
+  RESPONSE_COLUMN_ID,
+  TracesTableColumnType,
+  useMlflowTracesTableMetadata,
+  useSelectedColumns,
+  useSearchMlflowTraces,
+  GenAITracesTableToolbar,
+  GenAITracesTableProvider,
+  GenAITracesTableBodyContainer,
+  useGenAiTraceEvaluationArtifacts,
+  useFilters,
+  useTableSort,
+  TOKENS_COLUMN_ID,
+  invalidateMlflowSearchTracesCache,
+  TRACE_ID_COLUMN_ID,
+  createAssessmentColumnId,
+  shouldUseTracesV4API,
+  createTraceLocationForExperiment,
+  createTraceLocationForDestinationPath,
+  useFetchTraceV4LazyQuery,
+  doesTraceSupportV4API,
+  SESSION_COLUMN_ID,
+  SIMULATION_GOAL_COLUMN_ID,
+  SIMULATION_PERSONA_COLUMN_ID,
+} from '@databricks/web-shared/regression-test-table';
+import { GenAiTraceTableRowSelectionProvider } from '@databricks/web-shared/regression-test-table';
+import { useRegisterSelectedIds } from '@mlflow/mlflow/src/assistant';
+import { useRunLoggedTraceTableArtifacts } from './hooks/useRunLoggedTraceTableArtifacts';
+import { useMarkdownConverter } from '../../../common/utils/MarkdownUtils';
+import { useEditExperimentTraceTags } from '../traces/hooks/useEditExperimentTraceTags';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { RunViewEvaluationsTabArtifacts } from './RunViewEvaluationsTabArtifacts';
+import { useGetExperimentRunColor } from '../experiment-page/hooks/useExperimentRunColor';
+import { useQueryClient } from '@databricks/web-shared/query-client';
+import { checkColumnContents } from '../experiment-page/components/traces-v3/utils/columnUtils';
+import type { ModelTraceSearchLocation } from '@databricks/web-shared/model-trace-explorer';
+import {
+  isV3ModelTraceInfo,
+  ModelTraceExplorerContextProvider,
+  SESSION_ID_METADATA_KEY,
+  type ModelTraceInfoV3,
+} from '@databricks/web-shared/model-trace-explorer';
+import type { UseGetRunQueryResponseExperiment } from '../run-page/hooks/useGetRunQuery';
+import type { ExperimentEntity } from '../../types';
+import { useGetDeleteTracesAction } from '../experiment-page/components/traces-v3/hooks/useGetDeleteTracesAction';
+import { useIntl } from 'react-intl';
+import { ExportTracesToDatasetModal } from '../../pages/experiment-evaluation-datasets/components/ExportTracesToDatasetModal';
+import { AssistantAwareDrawer } from '@mlflow/mlflow/src/common/components/AssistantAwareDrawer';
+import { useCountInfo } from '../experiment-page/components/traces-v3/hooks/useCountInfo';
+import { useAssessmentCountMetrics } from '../experiment-page/components/traces-v3/hooks/useAssessmentCountMetrics';
+import { useSearchRunsQuery } from '../run-page/hooks/useSearchRunsQuery';
+
+const ContextProviders = ({
+  children,
+  makeHtmlFromMarkdown,
+  experimentId,
+}: {
+  makeHtmlFromMarkdown: (markdown?: string) => string;
+  experimentId?: string;
+  children: React.ReactNode;
+}) => {
+  return (
+    <GenAiTracesMarkdownConverterProvider makeHtml={makeHtmlFromMarkdown}>
+      {children}
+    </GenAiTracesMarkdownConverterProvider>
+  );
+};
+
+const RegressionTestCasesTableInner = ({
+  experimentId,
+  runUuid,
+  runDisplayName,
+  setCurrentRunUuid,
+  showCompareSelector = false,
+  showRefreshButton = false,
+  hideCompareSelector = false,
+}: {
+  experimentId: string;
+  runUuid: string;
+  runDisplayName: string;
+  setCurrentRunUuid?: (runUuid: string) => void;
+  showCompareSelector?: boolean;
+  compareToRunUuid?: string;
+  showRefreshButton?: boolean;
+  hideCompareSelector?: boolean;
+}) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+  const makeHtmlFromMarkdown = useMarkdownConverter();
+  const [compareToRunUuid, setCompareToRunUuid] = useCompareToRunUuid();
+  const [isGroupedBySession, setIsGroupedBySession] = useState(false);
+
+  const traceLocations = useMemo(() => [createTraceLocationForExperiment(experimentId)], [experimentId]);
+  const getTrace = getTraceV3;
+  const isQueryDisabled = false;
+
+  // Get table metadata
+  const {
+    assessmentInfos,
+    allColumns: allColumnsRaw,
+    totalCount,
+    evaluatedTraces,
+    otherEvaluatedTraces,
+    isLoading: isTableMetadataLoading,
+    error: tableMetadataError,
+    tableFilterOptions,
+  } = useMlflowTracesTableMetadata({
+    locations: traceLocations,
+    runUuid,
+    otherRunUuid: compareToRunUuid,
+    disabled: isQueryDisabled,
+    filterByAssessmentSourceRun: true,
+  });
+
+  // Restrict the column set (and thus the column selector) to the columns that
+  // make sense for a regression-test run, and order them: Test, Request,
+  // Response, Tokens, Latency, then the single "Result" assessment.
+  const allColumns = useMemo(() => {
+    const orderIndex = (col: TracesTableColumn) => {
+      if (col.type === TracesTableColumnType.TRACE_INFO && col.id === TRACE_ID_COLUMN_ID) return 0;
+      if (col.type === TracesTableColumnType.INPUT) return 1;
+      if (col.type === TracesTableColumnType.TRACE_INFO && col.id === RESPONSE_COLUMN_ID) return 2;
+      if (col.type === TracesTableColumnType.TRACE_INFO && col.id === TOKENS_COLUMN_ID) return 3;
+      if (col.type === TracesTableColumnType.TRACE_INFO && col.id === EXECUTION_DURATION_COLUMN_ID) return 4;
+      if (col.type === TracesTableColumnType.ASSESSMENT && col.id === createAssessmentColumnId('Result')) return 5;
+      return 99;
+    };
+    return allColumnsRaw.filter((col) => orderIndex(col) < 99).sort((a, b) => orderIndex(a) - orderIndex(b));
+  }, [allColumnsRaw]);
+
+  // Setup table states
+  // Row selection state - lifted to provide shared state via context
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  useRegisterSelectedIds('selectedTraceIds', rowSelection);
+
+  const [searchQuery, setSearchQuery] = useState<string>('');
+  const [filters, setFilters] = useFilters();
+  const getRunColor = useGetExperimentRunColor();
+  const queryClient = useQueryClient();
+
+  const defaultSelectedColumns = useCallback(
+    (columns: TracesTableColumn[]) => {
+      const allTraces = evaluatedTraces.concat(otherEvaluatedTraces);
+      const { responseHasContent, inputHasContent, tokensHasContent } = checkColumnContents(allTraces);
+      const hasSessionIds = allTraces.some((t) => Boolean(t.traceInfo?.trace_metadata?.[SESSION_ID_METADATA_KEY]));
+
+      return columns.filter(
+        (col) =>
+          // Only the synthetic overall "Result" assessment column (per-scorer
+          // assessment columns are hidden for the regression-test view).
+          (col.type === TracesTableColumnType.ASSESSMENT && col.id === createAssessmentColumnId('Result')) ||
+          (inputHasContent && col.type === TracesTableColumnType.INPUT) ||
+          (responseHasContent && col.type === TracesTableColumnType.TRACE_INFO && col.id === RESPONSE_COLUMN_ID) ||
+          (tokensHasContent && col.type === TracesTableColumnType.TRACE_INFO && col.id === TOKENS_COLUMN_ID) ||
+          (col.type === TracesTableColumnType.TRACE_INFO &&
+            // State column intentionally omitted for the regression-test view.
+            [TRACE_ID_COLUMN_ID, EXECUTION_DURATION_COLUMN_ID].includes(col.id)) ||
+          (hasSessionIds &&
+            [SESSION_COLUMN_ID, SIMULATION_GOAL_COLUMN_ID, SIMULATION_PERSONA_COLUMN_ID].includes(col.id)),
+      );
+    },
+    [evaluatedTraces, otherEvaluatedTraces],
+  );
+
+  const { selectedColumns, toggleColumns, setSelectedColumns } = useSelectedColumns(
+    experimentId,
+    allColumns,
+    defaultSelectedColumns,
+    runUuid,
+  );
+
+  const [tableSort, setTableSort] = useTableSort(selectedColumns);
+
+  // Get traces data
+  const {
+    data: traceInfos,
+    isLoading: traceInfosLoading,
+    isFetching: traceInfosFetching,
+    error: traceInfosError,
+    refetchMlflowTraces,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useSearchMlflowTraces({
+    locations: traceLocations,
+    currentRunDisplayName: runDisplayName,
+    searchQuery,
+    filters,
+    runUuid,
+    tableSort,
+    disabled: isQueryDisabled,
+    filterByAssessmentSourceRun: true,
+    // Disable pagination in comparison mode — both runs need complete data to join on inputs
+    enablePagination: isNil(compareToRunUuid),
+  });
+
+  const {
+    data: compareToRunData,
+    displayName: compareToRunDisplayName,
+    loading: compareToRunLoading,
+  } = useGetCompareToData({
+    experimentId,
+    traceLocations,
+    compareToRunUuid,
+    isQueryDisabled,
+  });
+
+  // Handler for toggling session grouping
+  const onToggleSessionGrouping = useCallback(() => {
+    setIsGroupedBySession((prev) => !prev);
+  }, []);
+
+  const hasSetInitialGrouping = useRef(false);
+  useEffect(() => {
+    if (!hasSetInitialGrouping.current && traceInfos && traceInfos.length > 0) {
+      const hasSessionIds = traceInfos.some((trace) => Boolean(trace.trace_metadata?.[SESSION_ID_METADATA_KEY]));
+      if (hasSessionIds) {
+        setIsGroupedBySession(true);
+      }
+      hasSetInitialGrouping.current = true;
+    }
+  }, [traceInfos]);
+
+  const experimentIds = useMemo(() => [experimentId], [experimentId]);
+
+  const countInfo = useCountInfo({
+    experimentIds,
+    runUuid,
+    traceInfos,
+    traceInfosCount: traceInfos?.length,
+    traceInfosLoading,
+    metadataTotalCount: totalCount,
+    disabled: isQueryDisabled,
+  });
+
+  const assessmentCountMetrics = useAssessmentCountMetrics({
+    experimentIds,
+    runUuid,
+    disabled: isQueryDisabled,
+  });
+
+  const compareAssessmentCountMetrics = useAssessmentCountMetrics({
+    experimentIds,
+    runUuid: compareToRunUuid,
+    disabled: isQueryDisabled || isNil(compareToRunUuid),
+  });
+
+  // TODO: We should update this to use web-shared/unified-tagging components for the
+  // tag editor and react-query mutations for the apis.
+  const { showEditTagsModalForTrace, EditTagsModal } = useEditExperimentTraceTags({
+    onSuccess: () => invalidateMlflowSearchTracesCache({ queryClient }),
+    existingTagKeys: getTracesTagKeys(traceInfos || []),
+  });
+
+  const deleteTracesAction = useGetDeleteTracesAction({ traceSearchLocations: traceLocations });
+  const renderCustomExportTracesToDatasetsModal = ExportTracesToDatasetModal;
+
+  const traceActions: TraceActions = useMemo(() => {
+    return {
+      deleteTracesAction,
+      exportToEvals: true,
+      // Enable unified tags modal if V4 APIs is enabled
+      editTags: {
+        showEditTagsModalForTrace,
+        EditTagsModal,
+      },
+    };
+  }, [deleteTracesAction, showEditTagsModalForTrace, EditTagsModal]);
+
+  const isTableLoading = traceInfosLoading || compareToRunLoading;
+
+  const selectedRunColor = getRunColor(runUuid);
+  const compareToRunColor = compareToRunUuid ? getRunColor(compareToRunUuid) : undefined;
+  const [warehousesLoading, setWarehousesLoading] = useState(false);
+
+  if (isTableMetadataLoading) {
+    return <LoadingSkeleton />;
+  }
+
+  if (tableMetadataError) {
+    return (
+      <div>
+        <pre>{String(tableMetadataError)}</pre>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      css={{
+        marginTop: theme.spacing.sm,
+        width: '100%',
+        overflowY: 'hidden',
+      }}
+    >
+      {showCompareSelector && compareToRunUuid && (
+        <div
+          css={{
+            display: 'flex',
+            alignItems: 'center',
+            width: '100%',
+            paddingBottom: theme.spacing.sm,
+            gap: theme.spacing.sm,
+          }}
+        >
+          <Typography.Text>
+            <FormattedMessage defaultMessage="Comparing" description="Comparing" />
+          </Typography.Text>
+          <span css={{ display: 'inline-flex', alignItems: 'center', gap: theme.spacing.xs }}>
+            {selectedRunColor && <RunColorPill color={selectedRunColor} />}
+            <Typography.Text bold>{runDisplayName}</Typography.Text>
+          </span>
+          <Typography.Text>
+            <FormattedMessage defaultMessage="to" description="to" />
+          </Typography.Text>
+          <span css={{ display: 'inline-flex', alignItems: 'center', gap: theme.spacing.xs }}>
+            {compareToRunColor && <RunColorPill color={compareToRunColor} />}
+            <Typography.Text bold>{compareToRunDisplayName}</Typography.Text>
+          </span>
+        </div>
+      )}
+      <ModelTraceExplorerContextProvider
+        renderExportTracesToDatasetsModal={renderCustomExportTracesToDatasetsModal}
+        DrawerComponent={AssistantAwareDrawer}
+      >
+        <GenAiTraceTableRowSelectionProvider rowSelection={rowSelection} setRowSelection={setRowSelection}>
+          <GenAITracesTableProvider
+            experimentId={experimentId}
+            getTrace={getTrace}
+            isGroupedBySession={isGroupedBySession}
+            DrawerComponent={AssistantAwareDrawer}
+          >
+            <div
+              css={{
+                overflowY: 'hidden',
+                height: '100%',
+                display: 'flex',
+                flexDirection: 'column',
+              }}
+            >
+              <GenAITracesTableToolbar
+                experimentId={experimentId}
+                searchQuery={searchQuery}
+                pageSource="run-view-traces"
+                setSearchQuery={setSearchQuery}
+                filters={filters}
+                setFilters={setFilters}
+                assessmentInfos={assessmentInfos}
+                countInfo={countInfo}
+                // Regression-test view: hide bulk Actions + session grouping.
+                traceActions={undefined}
+                tableSort={tableSort}
+                setTableSort={setTableSort}
+                allColumns={allColumns}
+                selectedColumns={selectedColumns}
+                setSelectedColumns={setSelectedColumns}
+                toggleColumns={toggleColumns}
+                traceInfos={traceInfos}
+                tableFilterOptions={tableFilterOptions}
+                onRefresh={showRefreshButton ? refetchMlflowTraces : undefined}
+                isRefreshing={showRefreshButton ? traceInfosFetching : undefined}
+                isGroupedBySession={false}
+                onToggleSessionGrouping={undefined}
+              />
+              {
+                // prettier-ignore
+                isTableLoading ? (
+                <LoadingSkeleton />
+              ) : traceInfosError ? (
+                <div>
+                  <pre>{String(traceInfosError)}</pre>
+                </div>
+              ) : (
+                <ContextProviders makeHtmlFromMarkdown={makeHtmlFromMarkdown} experimentId={experimentId}>
+                  <GenAITracesTableBodyContainer
+                    experimentId={experimentId}
+                    currentRunDisplayName={runDisplayName}
+                    compareToRunDisplayName={compareToRunDisplayName}
+                    runUuid={runUuid}
+                    compareToRunUuid={compareToRunUuid}
+                    getTrace={getTrace}
+                    getRunColor={getRunColor}
+                    assessmentInfos={assessmentInfos}
+                    setFilters={setFilters}
+                    filters={filters}
+                    selectedColumns={selectedColumns}
+                    allColumns={allColumns}
+                    tableSort={tableSort}
+                    currentTraceInfoV3={traceInfos || []}
+                    compareToTraceInfoV3={compareToRunData}
+                    onTraceTagsEdit={showEditTagsModalForTrace}
+                    isTableLoading={isTableLoading}
+                    isGroupedBySession={isGroupedBySession}
+                    fetchNextPage={fetchNextPage}
+                    hasNextPage={hasNextPage}
+                    isFetchingNextPage={isFetchingNextPage}
+                    assessmentCountMetrics={assessmentCountMetrics}
+                    compareAssessmentCountMetrics={compareAssessmentCountMetrics}
+                    fitToContainer
+                  />
+                </ContextProviders>
+              )
+              }
+              {EditTagsModal}
+            </div>
+          </GenAITracesTableProvider>
+        </GenAiTraceTableRowSelectionProvider>
+      </ModelTraceExplorerContextProvider>
+    </div>
+  );
+};
+
+export const RegressionTestCasesTable = ({
+  experimentId,
+  experiment,
+  runUuid,
+  runTags,
+  runDisplayName,
+  setCurrentRunUuid,
+  showCompareSelector = false,
+  showRefreshButton = false,
+  hideCompareSelector = false,
+}: {
+  experimentId: string;
+  experiment?: ExperimentEntity | UseGetRunQueryResponseExperiment;
+  runUuid: string;
+  runTags?: Record<string, KeyValueEntity>;
+  runDisplayName: string;
+  // used in evaluation runs tab
+  setCurrentRunUuid?: (runUuid: string) => void;
+  showCompareSelector?: boolean;
+  showRefreshButton?: boolean;
+  hideCompareSelector?: boolean;
+}) => {
+  // Determine which tables are logged in the run
+  const traceTablesLoggedInRun = useRunLoggedTraceTableArtifacts(runTags);
+  const isArtifactCallEnabled = Boolean(runUuid);
+
+  const { data: artifactData, isLoading: isArtifactLoading } = useGenAiTraceEvaluationArtifacts(
+    {
+      runUuid: runUuid || '',
+      ...{ artifacts: traceTablesLoggedInRun ? traceTablesLoggedInRun : undefined },
+    },
+    { disabled: !isArtifactCallEnabled },
+  );
+
+  if (isArtifactLoading) {
+    return <LoadingSkeleton />;
+  }
+
+  if (!isNil(artifactData) && artifactData.length > 0) {
+    return (
+      <RunViewEvaluationsTabArtifacts
+        experimentId={experimentId}
+        runUuid={runUuid}
+        runDisplayName={runDisplayName}
+        data={artifactData}
+        runTags={runTags}
+      />
+    );
+  }
+
+  return (
+    <RegressionTestCasesTableInner
+      experimentId={experimentId}
+      runUuid={runUuid}
+      runDisplayName={runDisplayName}
+      setCurrentRunUuid={setCurrentRunUuid}
+      showCompareSelector={showCompareSelector}
+      showRefreshButton={showRefreshButton}
+      hideCompareSelector={hideCompareSelector}
+    />
+  );
+};
+
+const LoadingSkeleton = () => {
+  const { theme } = useDesignSystemTheme();
+  return (
+    <div css={{ display: 'block', marginTop: theme.spacing.md, height: '100%', width: '100%' }}>
+      {[...Array(10).keys()].map((i) => (
+        <ParagraphSkeleton label="Loading..." key={i} seed={`s-${i}`} />
+      ))}
+    </div>
+  );
+};
+
+const useGetCompareToData = (params: {
+  experimentId: string;
+  traceLocations: ModelTraceSearchLocation[];
+  compareToRunUuid: string | undefined;
+  isQueryDisabled?: boolean;
+}): {
+  data: ModelTraceInfoV3[] | undefined;
+  displayName: string;
+  loading: boolean;
+} => {
+  const { compareToRunUuid, experimentId, traceLocations, isQueryDisabled } = params;
+  const { data: traceInfos, isLoading: traceInfosLoading } = useSearchMlflowTraces({
+    locations: traceLocations,
+    currentRunDisplayName: undefined,
+    runUuid: compareToRunUuid,
+    disabled: isNil(compareToRunUuid) || isQueryDisabled,
+    filterByAssessmentSourceRun: true,
+    enablePagination: false,
+  });
+
+  const { data: runData, loading: runDetailsLoading } = useSearchRunsQuery({
+    experimentIds: [experimentId],
+    filter: `attributes.run_id = "${compareToRunUuid}"`,
+    disabled: isNil(compareToRunUuid),
+  });
+
+  return {
+    data: traceInfos,
+    displayName: Utils.getRunDisplayName(runData?.info, compareToRunUuid),
+    loading: traceInfosLoading || runDetailsLoading,
+  };
+};

--- a/mlflow/server/js/src/experiment-tracking/constants.ts
+++ b/mlflow/server/js/src/experiment-tracking/constants.ts
@@ -88,6 +88,7 @@ export const MLFLOW_RUN_SOURCE_TYPE_TAG = 'mlflow.runSourceType';
 export const MLFLOW_RUN_TYPE_VALUE_EVALUATION = 'evaluation';
 export const MLFLOW_RUN_TYPE_VALUE_GENAI_EVALUATE = 'genai_evaluate';
 export const MLFLOW_RUN_TYPE_VALUE_ISSUE_DETECTION = 'issue_detection';
+export const MLFLOW_RUN_TYPE_VALUE_REGRESSION_TEST = 'regression_test';
 export const MLFLOW_ISSUE_DETECTION_JOB_ID_TAG = 'mlflow.issueDetection.jobId';
 export const MLFLOW_ISSUE_DETECTION_RESULT_ISSUES_TAG = 'mlflow.issueDetection.result.issues';
 export const MLFLOW_ISSUE_DETECTION_RESULT_TOTAL_TRACES_TAG = 'mlflow.issueDetection.result.totalTracesAnalyzed';
@@ -188,3 +189,4 @@ export enum ExperimentKind {
 }
 
 export const CREATE_NEW_VERSION_QUERY_PARAM = 'create_new_version';
+// touch Wed May 27 00:58:08 PDT 2026

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsPage.tsx
@@ -23,6 +23,7 @@ import {
 import { invalidateMlflowSearchTracesCache } from '@databricks/web-shared/genai-traces-table';
 import { useQueryClient } from '@databricks/web-shared/query-client';
 import { FormattedMessage } from 'react-intl';
+import { MLFLOW_RUN_TYPE_TAG, MLFLOW_RUN_TYPE_VALUE_REGRESSION_TEST } from '../../constants';
 import {
   useSelectedRunUuid,
   SELECTED_RUN_UUID_QUERY_PARAM,
@@ -69,6 +70,7 @@ const ExperimentEvaluationRunsPageImpl = () => {
   const [searchFilter, setSearchFilter] = useState('');
   const [selectedDatasetWithRun, setSelectedDatasetWithRun] = useState<DatasetWithRunType>();
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const [typeFilter, setTypeFilter] = useState<'all' | 'eval' | 'test'>('all');
   const [selectedColumns, setSelectedColumns] = useState<{ [key: string]: boolean }>(
     EVAL_RUNS_TABLE_BASE_SELECTION_STATE,
   );
@@ -282,7 +284,21 @@ const ExperimentEvaluationRunsPageImpl = () => {
 
   const isEmpty = runUuids.length === 0 && !searchFilter && !isLoading;
 
-  const runsAndGroupValues = getGroupByRunsData(runs ?? [], groupBy);
+  // Client-side Type filter (All / Eval / Test). Tag-based: runs tagged
+  // `mlflow.runType=regression_test` are "Test"; everything else is "Eval".
+  const filteredRuns = useMemo(() => {
+    if (typeFilter === 'all' || !runs) {
+      return runs ?? [];
+    }
+    return runs.filter((run) => {
+      const isTest = (run.data?.tags ?? []).some(
+        (tag) => tag.key === MLFLOW_RUN_TYPE_TAG && tag.value === MLFLOW_RUN_TYPE_VALUE_REGRESSION_TEST,
+      );
+      return typeFilter === 'test' ? isTest : !isTest;
+    });
+  }, [runs, typeFilter]);
+
+  const runsAndGroupValues = getGroupByRunsData(filteredRuns, groupBy);
 
   const handleCompare = useCallback(
     (runUuid1: string, runUuid2: string) => {
@@ -352,6 +368,8 @@ const ExperimentEvaluationRunsPageImpl = () => {
       setSelectedColumns={setSelectedColumns}
       groupByConfig={groupBy}
       setGroupByConfig={setGroupBy}
+      typeFilter={typeFilter}
+      setTypeFilter={setTypeFilter}
       viewMode={viewMode}
       setViewMode={setViewMode}
       onCompare={handleCompare}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTable.constants.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTable.constants.tsx
@@ -8,6 +8,7 @@ import {
   RunNameCell,
   SortableHeaderCell,
   StatusCell,
+  TypeCell,
   VisiblityCell,
 } from './ExperimentEvaluationRunsTableCellRenderers';
 import type { ColumnDef } from '@tanstack/react-table';
@@ -37,6 +38,7 @@ export enum EvalRunsTableColumnId {
   visibility = 'visibility',
   runName = 'run_name',
   status = 'status',
+  type = 'type',
   dataset = 'dataset',
   modelVersion = 'model_version',
   createdAt = 'created_at',
@@ -60,6 +62,7 @@ export const EVAL_RUNS_TABLE_BASE_SELECTION_STATE: { [key: string]: boolean } = 
   [EvalRunsTableColumnId.visibility]: true,
   [EvalRunsTableColumnId.runName]: true,
   [EvalRunsTableColumnId.status]: true,
+  [EvalRunsTableColumnId.type]: true,
   [EvalRunsTableColumnId.createdAt]: true,
   [EvalRunsTableColumnId.dataset]: true,
   [EvalRunsTableColumnId.modelVersion]: false,
@@ -81,6 +84,10 @@ export const EVAL_RUNS_COLUMN_LABELS: Record<EvalRunsTableColumnId, MessageDescr
   [EvalRunsTableColumnId.status]: defineMessage({
     defaultMessage: 'Status',
     description: 'Column header for run status in the evaluation runs table',
+  }),
+  [EvalRunsTableColumnId.type]: defineMessage({
+    defaultMessage: 'Type',
+    description: 'Column header for run type (Eval vs Test) in the evaluation runs table',
   }),
   [EvalRunsTableColumnId.createdAt]: defineMessage({
     defaultMessage: 'Created at',
@@ -168,6 +175,18 @@ export const getExperimentEvalRunsDefaultColumns = (
         styles: {
           minWidth: 60,
           maxWidth: 80,
+        },
+      },
+    },
+    {
+      id: EvalRunsTableColumnId.type,
+      header: () => <FormattedMessage {...EVAL_RUNS_COLUMN_LABELS[EvalRunsTableColumnId.type]} />,
+      cell: TypeCell,
+      enableResizing: false,
+      meta: {
+        styles: {
+          minWidth: 80,
+          maxWidth: 110,
         },
       },
     },

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableCellRenderers.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableCellRenderers.tsx
@@ -34,7 +34,12 @@ import {
   shouldEnableImprovedEvalRunsComparison,
   shouldShowEvalRunsIssuesPanel,
 } from '../../../common/utils/FeatureUtils';
-import { MLFLOW_RUN_TYPE_TAG, MLFLOW_RUN_TYPE_VALUE_ISSUE_DETECTION } from '../../constants';
+import {
+  MLFLOW_RUN_TYPE_TAG,
+  MLFLOW_RUN_TYPE_VALUE_ISSUE_DETECTION,
+  MLFLOW_RUN_TYPE_VALUE_REGRESSION_TEST,
+} from '../../constants';
+import { BeakerIcon, ChartLineIcon } from '@databricks/design-system';
 import { DatasetLink } from '../experiment-evaluation-datasets/DatasetLink';
 import { RunStatusIcon } from '../../components/RunStatusIcon';
 
@@ -80,13 +85,19 @@ export const RunNameCell: ColumnDef<RunEntityOrGroupData>['cell'] = ({
   const runUuid = row.original.info.runUuid;
   const experimentId = row.original.info.experimentId;
   const tags = row.original.data?.tags ?? [];
-  const isIssueDetectionRun = tags.some(
-    (tag) => tag.key === MLFLOW_RUN_TYPE_TAG && tag.value === MLFLOW_RUN_TYPE_VALUE_ISSUE_DETECTION,
-  );
+  const runTypeTag = tags.find((tag) => tag.key === MLFLOW_RUN_TYPE_TAG);
+  const isIssueDetectionRun = runTypeTag?.value === MLFLOW_RUN_TYPE_VALUE_ISSUE_DETECTION;
+  const isRegressionTestRun = runTypeTag?.value === MLFLOW_RUN_TYPE_VALUE_REGRESSION_TEST;
   const showIssuesPanelFlag = shouldShowEvalRunsIssuesPanel();
 
   const handleClick = (e: React.MouseEvent) => {
     e.stopPropagation();
+    // Regression-test runs navigate to their dedicated page (with the three
+    // Test cases / History / Configuration tabs).
+    if (isRegressionTestRun) {
+      navigate(Routes.getRegressionTestRunDetailsRoute(experimentId, runUuid));
+      return;
+    }
     // When flag is ON and clicking on an issue detection run, navigate to the issue detection run details page
     if (isIssueDetectionRun && showIssuesPanelFlag) {
       const route = Routes.getIssueDetectionRunDetailsRoute(experimentId, runUuid);
@@ -377,3 +388,41 @@ export const StatusCell: ColumnDef<RunEntityOrGroupData>['cell'] = ({ row }) => 
 
   return <RunStatusIcon status={status} />;
 };
+
+/**
+ * Renders the run's Type pill: a purple "Test" pill with a beaker icon for
+ * runs produced by an ``@mlflow.assertions`` pytest session (tagged
+ * ``mlflow.runType=regression_test``), and a default "Eval" pill with a
+ * chart-line icon for everything else. Lets users tell regression-test
+ * runs apart from ordinary ``evaluate()`` runs at a glance.
+ */
+export const TypeCell: ColumnDef<RunEntityOrGroupData>['cell'] = ({ row }) => {
+  if ('subRuns' in row.original) {
+    return <div>-</div>;
+  }
+  const tags = row.original.data?.tags ?? [];
+  const isTest = tags.some(
+    (tag) => tag.key === MLFLOW_RUN_TYPE_TAG && tag.value === MLFLOW_RUN_TYPE_VALUE_REGRESSION_TEST,
+  );
+  return (
+    <Tag
+      componentId={isTest ? 'mlflow.eval-runs.type-cell.test' : 'mlflow.eval-runs.type-cell.eval'}
+      color={isTest ? 'purple' : 'turquoise'}
+      css={{ display: 'inline-flex', alignItems: 'center', gap: 4, margin: 0 }}
+    >
+      {isTest ? <BeakerIcon /> : <ChartLineIcon />}
+      {isTest ? (
+        <FormattedMessage
+          defaultMessage="Test"
+          description="Type pill text for a regression-test run in the evaluation runs table"
+        />
+      ) : (
+        <FormattedMessage
+          defaultMessage="Eval"
+          description="Type pill text for a regular evaluation run in the evaluation runs table"
+        />
+      )}
+    </Tag>
+  );
+};
+// touch Wed May 27 12:14:45 PDT 2026

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableControls.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableControls.tsx
@@ -81,6 +81,8 @@ export const ExperimentEvaluationRunsTableControls = ({
   setSelectedColumns,
   groupByConfig,
   setGroupByConfig,
+  typeFilter,
+  setTypeFilter,
   viewMode,
   setViewMode,
   onCompare,
@@ -102,6 +104,8 @@ export const ExperimentEvaluationRunsTableControls = ({
   setSelectedColumns: (columns: { [key: string]: boolean }) => void;
   groupByConfig: RunsGroupByConfig | null;
   setGroupByConfig: (groupBy: RunsGroupByConfig | null) => void;
+  typeFilter: 'all' | 'eval' | 'test';
+  setTypeFilter: (typeFilter: 'all' | 'eval' | 'test') => void;
   viewMode?: ExperimentEvaluationRunsPageMode;
   setViewMode?: (mode: ExperimentEvaluationRunsPageMode) => void;
   onCompare: (runUuid1: string, runUuid2: string) => void;
@@ -213,6 +217,31 @@ export const ExperimentEvaluationRunsTableControls = ({
         </Tooltip>
       </div>
       <div css={{ display: 'flex', gap: theme.spacing.sm }}>
+        <SegmentedControlGroup
+          name="mlflow.eval-runs.type-filter"
+          componentId="mlflow.eval-runs.type-filter"
+          value={typeFilter}
+          css={{ flexShrink: 0 }}
+        >
+          <SegmentedControlButton value="all" onClick={() => setTypeFilter('all')}>
+            <FormattedMessage
+              defaultMessage="All"
+              description="Type filter option in the evaluation runs table: show every run"
+            />
+          </SegmentedControlButton>
+          <SegmentedControlButton value="eval" onClick={() => setTypeFilter('eval')}>
+            <FormattedMessage
+              defaultMessage="Eval"
+              description="Type filter option in the evaluation runs table: show only evaluation runs"
+            />
+          </SegmentedControlButton>
+          <SegmentedControlButton value="test" onClick={() => setTypeFilter('test')}>
+            <FormattedMessage
+              defaultMessage="Test"
+              description="Type filter option in the evaluation runs table: show only regression-test runs"
+            />
+          </SegmentedControlButton>
+        </SegmentedControlGroup>
         <DialogCombobox componentId="mlflow.eval-runs.table-column-selector" label="Columns" multiSelect>
           <DialogComboboxTrigger />
           <DialogComboboxContent>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableRow.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableRow.tsx
@@ -19,7 +19,7 @@ import { RunGroupingMode } from '../../components/experiment-page/utils/experime
 import { FormattedMessage } from 'react-intl';
 import { useNavigate } from '../../../common/utils/RoutingUtils';
 import Routes from '../../routes';
-import { RunPageTabName } from '../../constants';
+import { MLFLOW_RUN_TYPE_TAG, MLFLOW_RUN_TYPE_VALUE_REGRESSION_TEST, RunPageTabName } from '../../constants';
 
 type TracesViewTableRowProps = {
   row: Row<RunEntityOrGroupData>;
@@ -74,16 +74,32 @@ export const ExperimentEvaluationRunsTableRow = React.memo(
     const { theme } = useDesignSystemTheme();
     const navigate = useNavigate();
 
-    // Row click navigation - only enabled when feature flag is on
+    // Whether this row represents a regression-test run (tagged with
+    // ``mlflow.runType=regression_test``). Those rows always navigate to the
+    // dedicated regression-test page, regardless of the improved-comparison
+    // flag, because there is no useful "open side panel" behavior for them.
+    const isRegressionTestRow =
+      'info' in row.original &&
+      (row.original.data?.tags ?? []).some(
+        (tag) => tag.key === MLFLOW_RUN_TYPE_TAG && tag.value === MLFLOW_RUN_TYPE_VALUE_REGRESSION_TEST,
+      );
+
+    // Row click navigation - always enabled for regression-test rows, and
+    // enabled for other rows only when the feature flag is on.
     const handleRowClick = useCallback(() => {
+      if (!('info' in row.original)) {
+        return;
+      }
+      const { experimentId, runUuid } = row.original.info;
+      if (isRegressionTestRow) {
+        navigate(Routes.getRegressionTestRunDetailsRoute(experimentId, runUuid));
+        return;
+      }
       if (!enableImprovedComparison) {
         return;
       }
-      if ('info' in row.original) {
-        const { experimentId, runUuid } = row.original.info;
-        navigate(Routes.getRunPageTabRoute(experimentId, runUuid, RunPageTabName.EVALUATIONS));
-      }
-    }, [enableImprovedComparison, navigate, row.original]);
+      navigate(Routes.getRunPageTabRoute(experimentId, runUuid, RunPageTabName.EVALUATIONS));
+    }, [enableImprovedComparison, isRegressionTestRow, navigate, row.original]);
 
     if ('groupValues' in row.original) {
       return (
@@ -117,9 +133,9 @@ export const ExperimentEvaluationRunsTableRow = React.memo(
       <TableRow
         key={row.id}
         className="eval-runs-table-row"
-        onClick={enableImprovedComparison ? handleRowClick : undefined}
+        onClick={enableImprovedComparison || isRegressionTestRow ? handleRowClick : undefined}
         css={{
-          cursor: enableImprovedComparison ? 'pointer' : undefined,
+          cursor: enableImprovedComparison || isRegressionTestRow ? 'pointer' : undefined,
           marginLeft: enableImprovedComparison && isGrouped && row.depth > 0 ? theme.spacing.lg : undefined,
         }}
       >

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/RegressionTestRunPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/RegressionTestRunPage.tsx
@@ -1,0 +1,146 @@
+/**
+ * Per-run page for a regression-test session (a run tagged with
+ * ``mlflow.runType=regression_test``, produced by an ``@mlflow.assertions``
+ * pytest invocation).
+ *
+ * Renders the test cases table for the run, with a compare-to-run selector so
+ * two regression-test runs can be diffed side by side.
+ */
+import { BeakerIcon, InfoPopover, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { useMemo } from 'react';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { Link, useParams } from '../../../common/utils/RoutingUtils';
+import Utils from '../../../common/utils/Utils';
+import Routes from '../../routes';
+import { ExperimentPageTabName } from '../../constants';
+import { useSearchRunsQuery } from '../../components/run-page/hooks/useSearchRunsQuery';
+import TestCasesTab from './regression-test-run/TestCasesTab';
+
+const RegressionTestRunPage = () => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+  const { experimentId, runUuid } = useParams<{ experimentId: string; runUuid: string }>();
+
+  const { data: runData } = useSearchRunsQuery({
+    experimentIds: experimentId ? [experimentId] : [],
+    filter: `attributes.run_id = "${runUuid}"`,
+    disabled: !experimentId || !runUuid,
+  });
+
+  const runDisplayName = Utils.getRunDisplayName(runData?.info, runUuid);
+  const runInfo = runData?.info;
+
+  const infoRows = useMemo(() => {
+    if (!runInfo) return null;
+    const rows: { label: string; value: string }[] = [];
+    if (runInfo.startTime) {
+      rows.push({
+        label: intl.formatMessage({
+          defaultMessage: 'Created at',
+          description: 'Regression test run info popover: created-at label',
+        }),
+        value: Utils.formatTimestamp(runInfo.startTime, intl),
+      });
+    }
+    if (runInfo.userId) {
+      rows.push({
+        label: intl.formatMessage({
+          defaultMessage: 'Created by',
+          description: 'Regression test run info popover: created-by label',
+        }),
+        value: runInfo.userId,
+      });
+    }
+    if (runInfo.experimentId) {
+      rows.push({
+        label: intl.formatMessage({
+          defaultMessage: 'Experiment ID',
+          description: 'Regression test run info popover: experiment-id label',
+        }),
+        value: runInfo.experimentId,
+      });
+    }
+    if (runInfo.status) {
+      rows.push({
+        label: intl.formatMessage({
+          defaultMessage: 'Status',
+          description: 'Regression test run info popover: status label',
+        }),
+        value: runInfo.status.charAt(0) + runInfo.status.slice(1).toLowerCase(),
+      });
+    }
+    if (runInfo.runUuid) {
+      rows.push({
+        label: intl.formatMessage({
+          defaultMessage: 'Run ID',
+          description: 'Regression test run info popover: run-id label',
+        }),
+        value: runInfo.runUuid,
+      });
+    }
+    if (runInfo.startTime && runInfo.endTime) {
+      rows.push({
+        label: intl.formatMessage({
+          defaultMessage: 'Duration',
+          description: 'Regression test run info popover: duration label',
+        }),
+        value: Utils.getDuration(runInfo.startTime, runInfo.endTime) ?? '',
+      });
+    }
+    return rows;
+  }, [runInfo, intl]);
+
+  return (
+    <div css={{ display: 'flex', flexDirection: 'column', padding: theme.spacing.lg, gap: theme.spacing.md }}>
+      <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm }}>
+        <Link
+          componentId="mlflow.regression-test-run.back-to-eval-runs"
+          to={Routes.getExperimentPageTabRoute(experimentId ?? '', ExperimentPageTabName.EvaluationRuns)}
+        >
+          <FormattedMessage
+            defaultMessage="&larr; Back to Evaluation runs"
+            description="Back link from the regression test run page to the evaluation runs list"
+          />
+        </Link>
+      </div>
+      <span css={{ display: 'inline-flex', alignItems: 'center', gap: theme.spacing.sm }}>
+        <div
+          css={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: theme.colors.backgroundSecondary,
+            padding: 6,
+            borderRadius: theme.spacing.lg,
+          }}
+        >
+          <BeakerIcon css={{ display: 'flex', color: theme.colors.textSecondary }} />
+        </div>
+        <span css={{ fontSize: 24, fontWeight: 600, lineHeight: '32px' }}>{runDisplayName}</span>
+        {infoRows && (
+          <InfoPopover iconTitle="Info">
+            <div
+              css={{
+                display: 'flex',
+                flexDirection: 'column',
+                gap: theme.spacing.xs,
+                flexWrap: 'nowrap',
+              }}
+            >
+              {infoRows.map(({ label, value }) => (
+                <div key={label} css={{ whiteSpace: 'nowrap' }}>
+                  {label}: {value}
+                </div>
+              ))}
+            </div>
+          </InfoPopover>
+        )}
+      </span>
+      <div css={{ marginTop: theme.spacing.md }}>
+        <TestCasesTab experimentId={experimentId} runUuid={runUuid} />
+      </div>
+    </div>
+  );
+};
+
+export default RegressionTestRunPage;

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/regression-test-run/TestCasesTab.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/regression-test-run/TestCasesTab.tsx
@@ -1,0 +1,34 @@
+/**
+ * Test cases tab for the regression-test run page.
+ *
+ * Reuses the polished GenAI traces table (the same component the run
+ * Evaluations tab renders), scoped to this regression-test run. Each test
+ * case is one trace produced by an ``assert_behavior`` call; its assertion
+ * results show up as the trace's assessment columns. We get input/output
+ * previews, latency, tokens, hover/expand, and per-assertion pass/fail for
+ * free instead of hand-rolling a table.
+ */
+import { Empty } from '@databricks/design-system';
+import { FormattedMessage } from 'react-intl';
+
+import { RegressionTestCasesTable } from '../../../components/evaluations/RegressionTestCasesTable';
+
+const TestCasesTab = ({ experimentId, runUuid }: { experimentId?: string; runUuid?: string }) => {
+  if (!experimentId || !runUuid) {
+    return (
+      <Empty
+        title={
+          <FormattedMessage
+            defaultMessage="No run selected"
+            description="Empty state when the regression-test run page has no run id"
+          />
+        }
+        description={null}
+      />
+    );
+  }
+
+  return <RegressionTestCasesTable experimentId={experimentId} runUuid={runUuid} runDisplayName={runUuid} />;
+};
+
+export default TestCasesTab;

--- a/mlflow/server/js/src/experiment-tracking/route-defs.ts
+++ b/mlflow/server/js/src/experiment-tracking/route-defs.ts
@@ -318,6 +318,18 @@ export const getRouteDefs = () => [
     } satisfies RouteHandle,
   },
   {
+    // Listed BEFORE runPageWithTab so the more-specific path
+    // /experiments/:experimentId/runs/:runUuid/regression-tests wins over
+    // the runPageWithTab wildcard /experiments/:experimentId/runs/:runUuid/*.
+    path: RoutePaths.regressionTestRunDetails,
+    element: createLazyRouteElement(() => import('./pages/experiment-evaluation-runs/RegressionTestRunPage')),
+    pageId: 'mlflow.regression-test-run-details',
+    handle: {
+      getPageTitle: (params) => `Regression Test Run ${params['runUuid']}`,
+      getAssistantPrompts: () => ['Summarize this regression test run.', 'Which tests failed and why?'],
+    } satisfies RouteHandle,
+  },
+  {
     path: RoutePaths.runPageWithTab,
     element: createLazyRouteElement(() => import('./components/run-page/RunPage')),
     pageId: PageId.runPageWithTab,

--- a/mlflow/server/js/src/experiment-tracking/routes.ts
+++ b/mlflow/server/js/src/experiment-tracking/routes.ts
@@ -83,6 +83,9 @@ export class RoutePaths {
   static get experimentPageTabIssueDetectionRunDetailsWithTab() {
     return createMLflowRoutePath('/experiments/:experimentId/evaluation-runs/:runUuid/*');
   }
+  static get regressionTestRunDetails() {
+    return createMLflowRoutePath('/experiments/:experimentId/runs/:runUuid/regression-tests');
+  }
   static get experimentPageTabDatasets() {
     return createMLflowRoutePath('/experiments/:experimentId/datasets');
   }
@@ -263,6 +266,10 @@ class Routes {
 
   static getIssueDetectionRunDetailsTabRoute(experimentId: string, runUuid: string, tabName: string) {
     return `${generatePath(RoutePaths.experimentPageTabIssueDetectionRunDetails, { experimentId, runUuid })}/${tabName}`;
+  }
+
+  static getRegressionTestRunDetailsRoute(experimentId: string, runUuid: string) {
+    return generatePath(RoutePaths.regressionTestRunDetails, { experimentId, runUuid });
   }
 
   /**

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -427,6 +427,10 @@
     "defaultMessage": "Y-axis:",
     "description": "Label text for y-axis in contour plot comparison in MLflow"
   },
+  "0H/Y71": {
+    "defaultMessage": "Test",
+    "description": "Type filter option in the evaluation runs table: show only regression-test runs"
+  },
   "0HIfuE": {
     "defaultMessage": "Outputs of the trace, derived from the root span's outputs",
     "description": "Tooltip description for the Response column in the traces table"
@@ -1103,6 +1107,10 @@
     "defaultMessage": "{fieldName} are empty",
     "description": "Default text in data table where items are empty in the model\n                  comparison page"
   },
+  "4AQBnK": {
+    "defaultMessage": "Collapse assertion text",
+    "description": "Aria label for the chevron that collapses a long assertion text"
+  },
   "4AkzyD": {
     "defaultMessage": "Confirm",
     "description": "Button label to confirm the inferred experiment kind"
@@ -1150,6 +1158,10 @@
   "4Jyn2b": {
     "defaultMessage": "Add/Edit alias for model version {version}",
     "description": "Model registry > model version alias editor > Title of the update alias modal"
+  },
+  "4M5Tow": {
+    "defaultMessage": "Run ID",
+    "description": "Regression test run info popover: run-id label"
   },
   "4NEPlV": {
     "defaultMessage": "Scatter Plot",
@@ -1282,6 +1294,10 @@
   "5LORfM": {
     "defaultMessage": "Key name cannot be changed. Create a new key if a different name is needed.",
     "description": "Tooltip explaining why key name field is disabled in drawer edit"
+  },
+  "5ML65B": {
+    "defaultMessage": "Duration",
+    "description": "Regression test run info popover: duration label"
   },
   "5Mzdx4": {
     "defaultMessage": "{count, plural, one {# resource} other {# resources}}",
@@ -1771,6 +1787,10 @@
     "defaultMessage": "Delete runs",
     "description": "Delete evaluation runs action"
   },
+  "7vws6u": {
+    "defaultMessage": "Trace",
+    "description": "Button to open the raw trace from the detail"
+  },
   "7x6xu8": {
     "defaultMessage": "Create prompt",
     "description": "Label for the create prompt button on the registered prompts page"
@@ -1830,6 +1850,10 @@
   "8ALhnh": {
     "defaultMessage": "Type a key",
     "description": "Key-value tag editor modal > Tag dropdown > Tag input placeholder"
+  },
+  "8DRg6t": {
+    "defaultMessage": "Status",
+    "description": "Regression test run info popover: status label"
   },
   "8DoNdT": {
     "defaultMessage": "Save",
@@ -2103,6 +2127,10 @@
     "defaultMessage": "Show change from baseline",
     "description": "Runs charts > components > config > RunsChartsConfigureDifferenceChart > Show change from baseline toggle"
   },
+  "9i4YFp": {
+    "defaultMessage": "No assertions recorded for this test.",
+    "description": "Empty assertions state in the regression-test detail"
+  },
   "9icYIV": {
     "defaultMessage": "Select Categories",
     "description": "Header for the category selection step in issue detection modal"
@@ -2134,6 +2162,10 @@
   "9tg3Dx": {
     "defaultMessage": "Description not updated",
     "description": "Partial save status message when experiment description update was not attempted"
+  },
+  "9tmTbe": {
+    "defaultMessage": "Experiment ID",
+    "description": "Regression test run info popover: experiment-id label"
   },
   "9ut1Fj": {
     "defaultMessage": "Create",
@@ -2202,6 +2234,10 @@
   "A7jptW": {
     "defaultMessage": "Edit tags",
     "description": "Edit tags action"
+  },
+  "A7npjN": {
+    "defaultMessage": "Failed",
+    "description": "Fail status pill in the regression-test detail"
   },
   "AAdQxU": {
     "defaultMessage": "Messages",
@@ -2583,6 +2619,10 @@
     "defaultMessage": "Evaluation",
     "description": "Label for the evaluation section in the MLflow experiment navbar"
   },
+  "C1y/A6": {
+    "defaultMessage": "Assertions",
+    "description": "Assertions column header"
+  },
   "C4y1fv": {
     "defaultMessage": "-∞",
     "description": "Label displaying negative infinity symbol displayed on a plot UI element"
@@ -2838,6 +2878,10 @@
   "DUnrWL": {
     "defaultMessage": "Run Name:",
     "description": "Row title for the run name on the experiment compare runs page"
+  },
+  "DVBFdl": {
+    "defaultMessage": "Expand assertion text",
+    "description": "Aria label for the chevron that expands a long assertion text"
   },
   "DXxTNn": {
     "defaultMessage": "Used for HMAC signature verification of incoming webhook requests.",
@@ -4747,6 +4791,10 @@
     "defaultMessage": "Classification",
     "description": "Label for experiments focused on classification modeling"
   },
+  "P037Va": {
+    "defaultMessage": "Passed",
+    "description": "Pass status pill in the regression-test detail"
+  },
   "P0Y/ks": {
     "defaultMessage": "Workspace Manager",
     "description": "Admin page title shown when the URL is scoped to a single workspace via ?workspace=…"
@@ -5363,6 +5411,10 @@
     "defaultMessage": "Create LLM judge",
     "description": "Title for new LLM judge modal"
   },
+  "SZQjTs": {
+    "defaultMessage": "Result",
+    "description": "Result column header"
+  },
   "Sb+wLa": {
     "defaultMessage": "Model configuration stores the LLM settings associated with this prompt.",
     "description": "Help text explaining model configuration purpose"
@@ -5550,6 +5602,10 @@
   "TcNbWT": {
     "defaultMessage": "View dataset metadata",
     "description": "Overflow-menu item that opens the V2 evaluation dataset metadata modal"
+  },
+  "TcXjUy": {
+    "defaultMessage": "Eval",
+    "description": "Type pill text for a regular evaluation run in the evaluation runs table"
   },
   "TeN9hs": {
     "defaultMessage": "Traces",
@@ -5986,6 +6042,10 @@
   "VwxvII": {
     "defaultMessage": "forecasting",
     "description": "A short label for experiments focused on time series forecasting"
+  },
+  "VziuiA": {
+    "defaultMessage": "Previous",
+    "description": "Previous test case"
   },
   "W+aLXo": {
     "defaultMessage": "Manage webhooks to receive HTTP notifications when events occur in MLflow.",
@@ -6911,6 +6971,10 @@
     "defaultMessage": "Tags",
     "description": "Title for the tags section on the run details page"
   },
+  "atJtoG": {
+    "defaultMessage": "Eval",
+    "description": "Type filter option in the evaluation runs table: show only evaluation runs"
+  },
   "atcZM5": {
     "defaultMessage": "Status",
     "description": "Header title for the status column in the logged model list table"
@@ -7158,6 +7222,10 @@
   "cB0/61": {
     "defaultMessage": "Z axis",
     "description": "Label for Z axis in Contour chart configurator in compare runs chart config modal"
+  },
+  "cB2EEJ": {
+    "defaultMessage": "Created at",
+    "description": "Regression test run info popover: created-at label"
   },
   "cBDYla": {
     "defaultMessage": "Actions",
@@ -8287,6 +8355,10 @@
     "defaultMessage": "No metrics match the search filter",
     "description": "Message displayed when no metrics match the search filter in the logged model details metrics table"
   },
+  "i+1bTL": {
+    "defaultMessage": "Test",
+    "description": "Type pill text for a regression-test run in the evaluation runs table"
+  },
   "i+RyPC": {
     "defaultMessage": "Your request could not be fulfilled. Please try again.",
     "description": "A message shown on the experiment page if the runs request fails"
@@ -8459,6 +8531,10 @@
     "defaultMessage": "Dark",
     "description": "Dark theme label"
   },
+  "iolCqR": {
+    "defaultMessage": "Latency",
+    "description": "Column label for agent latency in the regression-test table"
+  },
   "iq1aqV": {
     "defaultMessage": "Create dataset",
     "description": "Button label that opens the create-dataset modal on the v2 datasets list"
@@ -8534,6 +8610,10 @@
   "j8JWDD": {
     "defaultMessage": "Enter issue description",
     "description": "Placeholder text for issue description field"
+  },
+  "j8M7/w": {
+    "defaultMessage": "&larr; Back to Evaluation runs",
+    "description": "Back link from the regression test run page to the evaluation runs list"
   },
   "jClVwe": {
     "defaultMessage": "Point the OTLP exporter at this MLflow server by setting these environment variables. See the <a>OpenTelemetry export docs</a> for the full reference.",
@@ -9138,6 +9218,10 @@
   "mWl3Qv": {
     "defaultMessage": "{toolName} was called in {toolCallId}",
     "description": "A message that shows the tool call ID of a tool call chat message."
+  },
+  "mY3Q0W": {
+    "defaultMessage": "All",
+    "description": "Type filter option in the evaluation runs table: show every run"
   },
   "mY6f0y": {
     "defaultMessage": "Params",
@@ -9887,6 +9971,10 @@
     "defaultMessage": "Track and compare versions of your GenAI app",
     "description": "Empty state title displayed when no models are logged in the genai logged models list page"
   },
+  "qQazgD": {
+    "defaultMessage": "Type",
+    "description": "Column header for run type (Eval vs Test) in the evaluation runs table"
+  },
   "qR3llD": {
     "defaultMessage": "Max tokens",
     "description": "Experiment page > prompt lab > max tokens parameter label"
@@ -9902,6 +9990,10 @@
   "qVQYZH": {
     "defaultMessage": "Show less",
     "description": "Button to close alert description"
+  },
+  "qWUsTp": {
+    "defaultMessage": "No run selected",
+    "description": "Empty state when the regression-test run page has no run id"
   },
   "qZKsz+": {
     "defaultMessage": "Cancel",
@@ -10891,6 +10983,10 @@
     "defaultMessage": "Show first 10",
     "description": "Menu option for showing only 10 first runs in the experiment view runs compare mode"
   },
+  "w3S4C7": {
+    "defaultMessage": "Latency (ms)",
+    "description": "Column label for agent latency with the unit suffix"
+  },
   "w48V74": {
     "defaultMessage": "Trace breakdown",
     "description": "Header for the span tree within the MLflow trace UI"
@@ -11299,6 +11395,10 @@
     "defaultMessage": "Original logged model: {originalName}",
     "description": "Tooltip text showing the original logged model name"
   },
+  "yJV4aA": {
+    "defaultMessage": "Next",
+    "description": "Next test case"
+  },
   "yJpGwW": {
     "defaultMessage": "Deleted",
     "description": "Linked model dropdown option to show deleted experiment runs"
@@ -11374,6 +11474,10 @@
   "ysF5gb": {
     "defaultMessage": "Default",
     "description": "Label for the default render mode in the model trace explorer inputs/outputs tab"
+  },
+  "yuHd1B": {
+    "defaultMessage": "Test",
+    "description": "Column label for the test name in the regression-test table"
   },
   "yv5FMp": {
     "defaultMessage": "Add custom feedback to this session.",
@@ -11590,6 +11694,10 @@
   "zv4Ycc": {
     "defaultMessage": "View as table",
     "description": "Experiment tracking > Artifact view > View as table checkbox"
+  },
+  "zwIH4R": {
+    "defaultMessage": "Created by",
+    "description": "Regression test run info popover: created-by label"
   },
   "zwO8+l": {
     "defaultMessage": "20",

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/GenAITracesTable.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/GenAITracesTable.tsx
@@ -1,0 +1,734 @@
+import type { RowSelectionState } from '@tanstack/react-table';
+import { isNil } from 'lodash';
+import React, { useCallback, useMemo, useState } from 'react';
+
+import {
+  Button,
+  ChevronDownIcon,
+  Typography,
+  useDesignSystemTheme,
+  DialogCombobox,
+  DialogComboboxContent,
+  SegmentedControlGroup,
+  SegmentedControlButton,
+  DialogComboboxCustomButtonTriggerWrapper,
+  XCircleFillIcon,
+  TableFilterLayout,
+  LegacySkeleton,
+  FilterIcon,
+  Tooltip,
+  Spinner,
+  WarningIcon,
+} from '@databricks/design-system';
+import { FormattedMessage, useIntl } from '@databricks/i18n';
+import type { ModelTraceInfoV3 } from '../model-trace-explorer/ModelTrace.types';
+
+import { GenAITracesTableActions } from './GenAITracesTableActions';
+import { computeEvaluationsComparison } from './GenAiTracesTable.utils';
+import { GenAiTracesTableBody } from './GenAiTracesTableBody';
+import { GenAiTracesTableSearchInput } from './GenAiTracesTableSearchInput';
+import { EvaluationsOverviewColumnSelector } from './components/EvaluationsOverviewColumnSelector';
+import { EvaluationsOverviewSortDropdown } from './components/EvaluationsOverviewSortDropdown';
+import { GenAiEvaluationBadge } from './components/GenAiEvaluationBadge';
+import {
+  getAssessmentValueLabel,
+  KnownEvaluationResultAssessmentName,
+} from './components/GenAiEvaluationTracesReview.utils';
+import { useActiveEvaluation } from './hooks/useActiveEvaluation';
+import {
+  assessmentValueToSerializedString,
+  serializedStringToAssessmentValue,
+  useAssessmentFilters,
+} from './hooks/useAssessmentFilters';
+import { useEvaluationsSearchQuery } from './hooks/useEvaluationsSearchQuery';
+import { GenAITracesTableConfigProvider, type GenAITracesTableConfig } from './hooks/useGenAITracesTableConfig';
+import { useSelectedColumns } from './hooks/useGenAITracesUIState';
+import type { GetTraceFunction } from './hooks/useGetTrace';
+import { useTableColumns } from './hooks/useTableColumns';
+import { useTableSortURL } from './hooks/useTableSortURL';
+import type {
+  AssessmentFilter,
+  AssessmentInfo,
+  AssessmentValueType,
+  SaveAssessmentsQuery,
+  RunEvaluationTracesDataEntry,
+  TracesTableColumn,
+  TraceActions,
+  EvaluationsOverviewTableSort,
+} from './types';
+import { TracesTableColumnType } from './types';
+import { getAssessmentInfos, sortAssessmentInfos } from './utils/AggregationUtils';
+import { displayPercentage } from './utils/DisplayUtils';
+import { filterEvaluationResults } from './utils/EvaluationsFilterUtils';
+import { applyTraceInfoV3ToEvalEntry } from './utils/TraceUtils';
+
+function GenAiTracesTableImpl({
+  experimentId,
+  currentEvaluationResults: oldEvalResults,
+  compareToEvaluationResults: oldCompareToEvalResults,
+  currentRunDisplayName,
+  runUuid,
+  compareToRunUuid,
+  compareToRunDisplayName,
+  compareToRunLoading,
+  sampledInfo,
+  exportToEvalsInstanceEnabled = false,
+  getTrace,
+  saveAssessmentsQuery,
+  enableRunEvaluationWriteFeatures,
+  defaultSortOption,
+  disableAssessmentTooltips,
+  onTraceTagsEdit,
+  traceActions,
+  initialSelectedColumns,
+}: {
+  experimentId: string;
+  currentEvaluationResults: RunEvaluationTracesDataEntry[];
+  compareToEvaluationResults?: RunEvaluationTracesDataEntry[];
+  currentRunDisplayName?: string;
+  runUuid?: string;
+  compareToRunUuid?: string;
+  compareToRunDisplayName?: string;
+  compareToRunLoading?: boolean;
+  sampledInfo?: SampleInfo;
+  exportToEvalsInstanceEnabled?: boolean;
+  getTrace?: GetTraceFunction;
+  saveAssessmentsQuery?: SaveAssessmentsQuery;
+  enableRunEvaluationWriteFeatures?: boolean;
+  defaultSortOption?: EvaluationsOverviewTableSort;
+  // This is a temporary hack to disable assessment hovercards because
+  // we don't properly display long strings yet. We should eventually fix the hovercard
+  // to display long strings and remove this prop.
+  disableAssessmentTooltips?: boolean;
+  onTraceTagsEdit?: (trace: ModelTraceInfoV3) => void;
+  traceActions?: TraceActions;
+  initialSelectedColumns?: (allColumns: TracesTableColumn[]) => TracesTableColumn[];
+}) {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+
+  // Convert trace info v3 back to the old RunEvaluationTracesDataEntry format.
+  // We should gradually migrate this component to use trace info v3 directly and
+  // then we can remove this conversion.
+  const currentEvaluationResults = applyTraceInfoV3ToEvalEntry(oldEvalResults);
+  const compareToEvaluationResults = applyTraceInfoV3ToEvalEntry(oldCompareToEvalResults || []);
+
+  const enableTableRowSelection: boolean = Object.keys(traceActions ?? {}).length > 0;
+
+  const [selectedEvaluationId, setSelectedEvaluationId] = useActiveEvaluation();
+
+  // evaluationResults contains the merged evaluation results from the current and compare-to runs.
+  const evaluationResults = useMemo(
+    () => computeEvaluationsComparison(currentEvaluationResults, compareToEvaluationResults),
+    [currentEvaluationResults, compareToEvaluationResults],
+  );
+
+  const [searchQuery, setSearchQuery] = useEvaluationsSearchQuery();
+
+  const assessmentInfos = useMemo(() => {
+    return getAssessmentInfos(intl, currentEvaluationResults, compareToEvaluationResults);
+  }, [intl, currentEvaluationResults, compareToEvaluationResults]);
+
+  const allColumns: TracesTableColumn[] = useTableColumns(intl, currentEvaluationResults, assessmentInfos, runUuid);
+
+  const [assessmentFilters, setAssessmentFilters] = useAssessmentFilters(
+    // These are the subset of all assessment infos that are shown in the table
+    allColumns.map((col) => col.assessmentInfo).filter((info): info is AssessmentInfo => info !== undefined),
+  );
+
+  const displayEvaluationResults = useMemo(() => {
+    if (searchQuery === '' && assessmentFilters.length === 0) {
+      return evaluationResults;
+    }
+    return filterEvaluationResults(
+      evaluationResults,
+      assessmentFilters,
+      searchQuery,
+      currentRunDisplayName,
+      compareToRunDisplayName,
+    );
+  }, [evaluationResults, searchQuery, assessmentFilters, currentRunDisplayName, compareToRunDisplayName]);
+
+  const { selectedColumns, toggleColumns } = useSelectedColumns(
+    experimentId,
+    allColumns,
+    initialSelectedColumns,
+    runUuid,
+  );
+
+  const selectedAssessmentInfos = useMemo(() => {
+    const selectedAssessmentCols = selectedColumns.filter((col) => col.type === TracesTableColumnType.ASSESSMENT);
+    const selectedAssessments = selectedAssessmentCols.map((col) => col.assessmentInfo as AssessmentInfo);
+    const sortedSelectedAssessments = sortAssessmentInfos(selectedAssessments);
+    return sortedSelectedAssessments;
+  }, [selectedColumns]);
+
+  const overallAssessmentCol = allColumns.find(
+    (col) =>
+      col.type === TracesTableColumnType.ASSESSMENT &&
+      col.id === KnownEvaluationResultAssessmentName.OVERALL_ASSESSMENT,
+  );
+
+  const defaultSort = useMemo(
+    () =>
+      defaultSortOption ||
+      (overallAssessmentCol
+        ? { key: overallAssessmentCol.id, type: TracesTableColumnType.ASSESSMENT, asc: true }
+        : undefined),
+    [defaultSortOption, overallAssessmentCol],
+  );
+
+  const [urlTableSort, setUrlTableSort] = useTableSortURL();
+
+  const tableSort = useMemo(() => {
+    if (urlTableSort) {
+      const sortKeyExists = selectedColumns.some((col) => col.id === urlTableSort.key);
+      return sortKeyExists ? urlTableSort : defaultSort;
+    }
+    return defaultSort;
+  }, [urlTableSort, selectedColumns, defaultSort]);
+
+  const setTableSort = useCallback(
+    (sort: EvaluationsOverviewTableSort | undefined) => {
+      setUrlTableSort(sort, false);
+    },
+    [setUrlTableSort],
+  );
+
+  const getAssessmentFilter = useCallback(
+    (assessmentName: string, run: string): AssessmentFilter | undefined => {
+      return assessmentFilters.find((filter) => filter.assessmentName === assessmentName && filter.run === run);
+    },
+    [assessmentFilters],
+  );
+  const removeAssessmentFilter = useCallback(
+    (assessmentName: string, run: string) => {
+      setAssessmentFilters(
+        assessmentFilters.filter((filter) => filter.assessmentName !== assessmentName || filter.run !== run),
+      );
+    },
+    [assessmentFilters, setAssessmentFilters],
+  );
+
+  const updateAssessmentFilter = useCallback(
+    (
+      assessmentName: string,
+      filterValue: AssessmentValueType,
+      run: string,
+      filterType?: AssessmentFilter['filterType'],
+    ) => {
+      const filter = assessmentFilters.find((filter) => filter.assessmentName === assessmentName && filter.run === run);
+      if (filter === undefined) {
+        setAssessmentFilters([
+          ...assessmentFilters,
+          {
+            assessmentName,
+            filterValue,
+            filterType,
+            run,
+          },
+        ]);
+      } else {
+        setAssessmentFilters(
+          assessmentFilters.map((filter) => {
+            if (filter.assessmentName === assessmentName) {
+              return {
+                ...filter,
+                filterValue,
+                filterType,
+              };
+            }
+            return filter;
+          }),
+        );
+      }
+    },
+    [assessmentFilters, setAssessmentFilters],
+  );
+  const toggleAssessmentFilter = useCallback(
+    (
+      assessmentName: string,
+      filterValue: AssessmentValueType,
+      run: string,
+      filterType?: AssessmentFilter['filterType'],
+    ) => {
+      const filter = assessmentFilters.find((filter) => filter.assessmentName === assessmentName && filter.run === run);
+      if (filter === undefined) {
+        setAssessmentFilters([
+          ...assessmentFilters,
+          {
+            assessmentName,
+            filterValue,
+            filterType,
+            run,
+          },
+        ]);
+      } else if (filter.filterValue === filterValue && filter.filterType === filterType) {
+        // Remove the filter because it already exists.
+        setAssessmentFilters(
+          assessmentFilters.filter((filter) => filter.assessmentName !== assessmentName || filter.run !== run),
+        );
+      } else {
+        // Replace any filters with the same assessment name and run.
+        setAssessmentFilters(
+          assessmentFilters.map((filter) => {
+            if (filter.assessmentName === assessmentName && filter.run === run) {
+              return {
+                assessmentName,
+                filterValue,
+                filterType,
+                run,
+              };
+            }
+            return filter;
+          }),
+        );
+      }
+    },
+    [assessmentFilters, setAssessmentFilters],
+  );
+  const clearFilters = useCallback(() => {
+    setAssessmentFilters([]);
+  }, [setAssessmentFilters]);
+
+  const hasActiveFilters = assessmentFilters.length > 0;
+
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const selectedTraces: RunEvaluationTracesDataEntry[] = useMemo(() => {
+    const selectedEvaluationIds = Object.keys(rowSelection).filter((evaluationId) => rowSelection[evaluationId]);
+    return displayEvaluationResults
+      .filter(
+        (evaluation) =>
+          evaluation.currentRunValue && selectedEvaluationIds.includes(evaluation.currentRunValue.evaluationId),
+      )
+      .map((entry) => entry.currentRunValue)
+      .filter((entry) => entry !== undefined);
+  }, [rowSelection, displayEvaluationResults]);
+
+  const config: Partial<GenAITracesTableConfig> = {
+    enableRunEvaluationWriteFeatures: enableRunEvaluationWriteFeatures,
+  };
+
+  const totalEvaluationResults = currentEvaluationResults.length;
+
+  if (compareToRunLoading) {
+    return <LegacySkeleton />;
+  }
+
+  return (
+    <GenAITracesTableConfigProvider config={config}>
+      <div
+        css={{
+          display: 'flex',
+          flexDirection: 'row',
+          gap: theme.spacing.lg,
+          overflow: 'hidden',
+          height: '100%',
+        }}
+      >
+        <div
+          css={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: theme.spacing.xs,
+            overflow: 'hidden',
+            flexGrow: 1,
+          }}
+        >
+          <div
+            css={{
+              display: 'flex',
+              flex: 1,
+              flexDirection: 'column',
+              gap: theme.spacing.xs,
+              overflow: 'hidden',
+            }}
+          >
+            <div
+              css={{
+                display: 'flex',
+                width: '100%',
+                alignItems: 'flex-end',
+                justifyContent: 'space-between',
+                padding: `${theme.spacing.xs}px 0px`,
+              }}
+            >
+              <TableFilterLayout
+                css={{
+                  marginBottom: 0,
+                }}
+              >
+                <GenAiTracesTableSearchInput searchQuery={searchQuery} setSearchQuery={setSearchQuery} />
+                <DialogCombobox
+                  componentId="mlflow.genai_traces_table.filter_dropdown"
+                  label="Filters"
+                  value={Array.from(assessmentFilters).map((filter) => filter.assessmentName)}
+                  multiSelect
+                >
+                  <DialogComboboxCustomButtonTriggerWrapper>
+                    <Button
+                      endIcon={<ChevronDownIcon />}
+                      componentId="mlflow.evaluations_review.table_ui.filter_button"
+                      css={{
+                        border: hasActiveFilters ? `1px solid ${theme.colors.actionDefaultBorderFocus} !important` : '',
+                        backgroundColor: hasActiveFilters
+                          ? `${theme.colors.actionDefaultBackgroundHover} !important`
+                          : '',
+                      }}
+                    >
+                      <div
+                        css={{
+                          display: 'flex',
+                          gap: theme.spacing.sm,
+                          alignItems: 'center',
+                        }}
+                      >
+                        <FilterIcon />
+                        {intl.formatMessage(
+                          {
+                            defaultMessage: 'Filters{numFilters}',
+                            description: 'Evaluation review > evaluations list > filter dropdown button',
+                          },
+                          {
+                            numFilters: hasActiveFilters ? ` (${assessmentFilters.length})` : '',
+                          },
+                        )}
+                        {assessmentFilters.length > 0 && (
+                          <XCircleFillIcon
+                            css={{
+                              fontSize: 12,
+                              cursor: 'pointer',
+                              color: theme.colors.grey400,
+                              '&:hover': {
+                                color: theme.colors.grey600,
+                              },
+                            }}
+                            onClick={(e) => {
+                              clearFilters();
+                              e.stopPropagation();
+                              e.preventDefault();
+                            }}
+                          />
+                        )}
+                      </div>
+                    </Button>
+                  </DialogComboboxCustomButtonTriggerWrapper>
+                  <DialogComboboxContent>
+                    <div
+                      css={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        padding: `${theme.spacing.sm}px ${theme.spacing.sm}px`,
+                        gap: theme.spacing.md,
+                      }}
+                    >
+                      {selectedAssessmentInfos.map((assessmentInfo) => (
+                        <div
+                          css={{
+                            display: 'flex',
+                            flexDirection: 'column',
+                            gap: theme.spacing.sm,
+                          }}
+                          key={assessmentInfo.name}
+                        >
+                          <div
+                            css={{
+                              fontWeight: 500,
+                            }}
+                          >
+                            {assessmentInfo.displayName}
+                          </div>
+                          {currentRunDisplayName && (
+                            <AssessmentsFilterSelector
+                              assessmentLabel={assessmentInfo.displayName}
+                              assessmentName={assessmentInfo.name}
+                              assessmentInfo={assessmentInfo}
+                              assessmentFilter={getAssessmentFilter(assessmentInfo.name, currentRunDisplayName)}
+                              updateAssessmentFilter={updateAssessmentFilter}
+                              removeAssessmentFilter={removeAssessmentFilter}
+                              run={currentRunDisplayName}
+                            />
+                          )}
+                          {compareToRunUuid && compareToRunDisplayName && (
+                            <div
+                              css={{
+                                display: 'flex',
+                                flexDirection: 'column',
+                                gap: theme.spacing.xs,
+                              }}
+                            >
+                              <Typography.Hint>{compareToRunDisplayName}</Typography.Hint>
+                              <AssessmentsFilterSelector
+                                assessmentLabel={assessmentInfo.displayName}
+                                assessmentName={assessmentInfo.name}
+                                assessmentInfo={assessmentInfo}
+                                assessmentFilter={getAssessmentFilter(assessmentInfo.name, compareToRunDisplayName)}
+                                updateAssessmentFilter={updateAssessmentFilter}
+                                removeAssessmentFilter={removeAssessmentFilter}
+                                run={compareToRunDisplayName}
+                              />
+                            </div>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  </DialogComboboxContent>
+                </DialogCombobox>
+                <EvaluationsOverviewSortDropdown
+                  tableSort={tableSort}
+                  columns={allColumns}
+                  onChange={(sortOption, orderByAsc) => {
+                    setTableSort({ key: sortOption.key, type: sortOption.type, asc: orderByAsc });
+                  }}
+                />
+
+                {/* Column selector */}
+                <EvaluationsOverviewColumnSelector
+                  columns={allColumns}
+                  selectedColumns={selectedColumns}
+                  setSelectedColumnsWithHiddenColumns={toggleColumns}
+                />
+                <GenAITracesTableActions
+                  experimentId={experimentId}
+                  selectedTraces={selectedTraces}
+                  setRowSelection={setRowSelection}
+                  traceActions={traceActions}
+                  traceInfos={undefined}
+                />
+              </TableFilterLayout>
+              <div
+                css={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: theme.spacing.sm,
+                }}
+              >
+                <SampledInfoBadge totalRowCount={totalEvaluationResults} sampledInfo={sampledInfo} />
+                <Typography.Hint>
+                  {intl.formatMessage(
+                    {
+                      defaultMessage: '{numFilteredEvals} of {numEvals}',
+                      description:
+                        'Text displayed when showing a filtered subset evaluations in the evaluation review page',
+                    },
+                    {
+                      numEvals: evaluationResults.length,
+                      numFilteredEvals: displayEvaluationResults.length,
+                    },
+                  )}
+                </Typography.Hint>
+              </div>
+            </div>
+            <div
+              css={{
+                display: 'flex',
+                gap: theme.spacing.md,
+                width: '100%',
+                flex: 1,
+                overflowY: 'hidden',
+              }}
+            >
+              <div
+                css={{
+                  display: 'flex',
+                  flex: 1,
+                  overflowY: 'hidden',
+                  position: 'relative',
+                }}
+              >
+                <GenAiTracesTableBody
+                  experimentId={experimentId}
+                  selectedColumns={selectedColumns}
+                  allColumns={allColumns}
+                  evaluations={displayEvaluationResults}
+                  selectedEvaluationId={selectedEvaluationId}
+                  selectedAssessmentInfos={selectedAssessmentInfos}
+                  assessmentInfos={assessmentInfos}
+                  assessmentFilters={assessmentFilters}
+                  onChangeEvaluationId={setSelectedEvaluationId}
+                  tableSort={tableSort}
+                  runUuid={runUuid}
+                  compareToRunUuid={compareToRunUuid}
+                  runDisplayName={currentRunDisplayName}
+                  compareToRunDisplayName={compareToRunDisplayName}
+                  enableRowSelection={enableTableRowSelection}
+                  rowSelection={enableTableRowSelection ? rowSelection : undefined}
+                  setRowSelection={enableTableRowSelection ? setRowSelection : undefined}
+                  exportToEvalsInstanceEnabled={exportToEvalsInstanceEnabled}
+                  getTrace={getTrace}
+                  toggleAssessmentFilter={toggleAssessmentFilter}
+                  saveAssessmentsQuery={saveAssessmentsQuery}
+                  disableAssessmentTooltips={disableAssessmentTooltips}
+                  onTraceTagsEdit={onTraceTagsEdit}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </GenAITracesTableConfigProvider>
+  );
+}
+
+const SampledInfoBadge = (props: { totalRowCount: number; sampledInfo?: SampleInfo }) => {
+  const { totalRowCount, sampledInfo } = props;
+  const intl = useIntl();
+
+  if (!sampledInfo) {
+    return null;
+  }
+
+  // TODO: Remove this once table supports pagination
+  if (sampledInfo.maxAllowedCount) {
+    if (totalRowCount >= sampledInfo.maxAllowedCount) {
+      return (
+        <Tooltip
+          componentId="mlflow.experiment_list_view.max_traces.tooltip"
+          content={intl.formatMessage(
+            {
+              defaultMessage: 'Only the top {evalResultsCount} results are shown',
+              description: 'Evaluation review > evaluations list > sample info tooltip',
+            },
+            {
+              evalResultsCount: totalRowCount,
+            },
+          )}
+        >
+          <WarningIcon color="warning" />
+        </Tooltip>
+      );
+    }
+
+    return null;
+  }
+  if (sampledInfo.logCountLoading || isNil(sampledInfo.sampledCount) || isNil(sampledInfo.totalCount)) {
+    return <Spinner />;
+  }
+  return (
+    <GenAiEvaluationBadge>
+      <Tooltip
+        componentId="mlflow.experiment_list_view.sampled_badge.tooltip"
+        content={intl.formatMessage(
+          {
+            defaultMessage: 'Retrieved {sampledCount} out of {totalCount} total logs ({percentage}%)',
+            description: 'Evaluation review > evaluations list > sample info tooltip',
+          },
+          {
+            sampledCount: sampledInfo.sampledCount,
+            totalCount: sampledInfo.totalCount,
+            percentage: displayPercentage(sampledInfo.sampledCount / sampledInfo.totalCount),
+          },
+        )}
+      >
+        Sampled {displayPercentage(sampledInfo.sampledCount / sampledInfo.totalCount)}%
+      </Tooltip>
+    </GenAiEvaluationBadge>
+  );
+};
+
+const ANY_VALUE = '__any_value__';
+
+const AssessmentsFilterSelector = React.memo(
+  // eslint-disable-next-line react-component-name/react-component-name -- TODO(FEINF-4716)
+  ({
+    assessmentName,
+    assessmentInfo,
+    assessmentLabel,
+    assessmentFilter,
+    updateAssessmentFilter,
+    removeAssessmentFilter,
+    run,
+  }: {
+    assessmentName: string;
+    assessmentInfo: AssessmentInfo;
+    assessmentLabel: string;
+    assessmentFilter: AssessmentFilter | undefined;
+    updateAssessmentFilter: (assessmentName: string, filterValue: AssessmentValueType, run: string) => void;
+    removeAssessmentFilter: (assessmentName: string, run: string) => void;
+    run: string;
+  }) => {
+    const intl = useIntl();
+    const { theme } = useDesignSystemTheme();
+
+    const selectedValue = assessmentFilter
+      ? assessmentValueToSerializedString(assessmentFilter.filterValue)
+      : ANY_VALUE;
+
+    return (
+      <div
+        css={{
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        <SegmentedControlGroup
+          name="size-story"
+          value={selectedValue}
+          onChange={(event) => {
+            if (event.target.value === ANY_VALUE) {
+              removeAssessmentFilter(assessmentName, run);
+              return;
+            }
+            const value = serializedStringToAssessmentValue(assessmentInfo, event.target.value);
+            updateAssessmentFilter(assessmentName, value, run);
+          }}
+          size="middle"
+          componentId="mlflow.evaluations_review.table_ui.filter_control"
+        >
+          <SegmentedControlButton value={ANY_VALUE}>
+            <div
+              css={{
+                display: 'flex',
+                gap: theme.spacing.sm,
+                alignItems: 'center',
+                color: theme.colors.textPrimary,
+              }}
+            >
+              {intl.formatMessage({
+                defaultMessage: 'All',
+                description:
+                  'Evaluation review > sidebar list of evaluation results > filter control > option for filtering evaluation results with no filter',
+              })}
+            </div>
+          </SegmentedControlButton>
+          {Array.from(assessmentInfo.uniqueValues.values()).map((value) => {
+            const { content, icon } = getAssessmentValueLabel(intl, theme, assessmentInfo, value);
+            return (
+              <SegmentedControlButton
+                value={assessmentValueToSerializedString(value)}
+                key={assessmentValueToSerializedString(value)}
+              >
+                <div
+                  css={{
+                    display: 'flex',
+                    gap: theme.spacing.sm,
+                    alignItems: 'center',
+                    color: theme.colors.textPrimary,
+                  }}
+                >
+                  {content}
+                  {icon}
+                </div>
+              </SegmentedControlButton>
+            );
+          })}
+        </SegmentedControlGroup>
+      </div>
+    );
+  },
+);
+
+export interface SampleInfo {
+  sampledCount?: number;
+  totalCount?: number;
+  logCountLoading: boolean;
+  // Set this to the max number of logs that our system can fetch.
+  // If the evaluation result count hits this number, we will show a warning indicator to the user.
+  maxAllowedCount?: number;
+}
+
+/**
+ * @deprecated Use `GenAITracesTableBodyContainer` and `GenAITracesTableToolbar` instead for new use cases.
+ */
+// TODO: Add an error boundary to the OSS trace table
+export const GenAiTracesTableDeprecated = GenAiTracesTableImpl;

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/GenAITracesTableActions.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/GenAITracesTableActions.tsx
@@ -1,0 +1,360 @@
+import type { RowSelectionState } from '@tanstack/react-table';
+import { compact, isNil } from 'lodash';
+import { useCallback, useContext, useMemo, useState } from 'react';
+
+import { Button, Tooltip, DropdownMenu, ChevronDownIcon, useDesignSystemTheme } from '@databricks/design-system';
+import { useIntl } from '@databricks/i18n';
+
+import { GenAITracesTableContext } from './GenAITracesTableContext';
+import { GenAITraceComparisonModal } from './components/GenAITraceComparisonModal';
+import { GenAiDeleteTraceModal } from './components/GenAiDeleteTraceModal';
+import type { RunEvaluationTracesDataEntry, TraceActions } from './types';
+import { shouldEnableTagGrouping } from './utils/FeatureUtils';
+import { applyTraceInfoV3ToEvalEntry, getRowIdFromTrace } from './utils/TraceUtils';
+import { shouldUseUnifiedModelTraceComparisonUI } from '../model-trace-explorer/FeatureUtils';
+import { SESSION_ID_METADATA_KEY } from '../model-trace-explorer/constants';
+import type { ModelTraceInfoV3 } from '../model-trace-explorer/ModelTrace.types';
+
+interface GenAITracesTableActionsProps {
+  experimentId: string;
+  // @deprecated
+  selectedTraces?: RunEvaluationTracesDataEntry[];
+  // @deprecated
+  setRowSelection?: React.Dispatch<React.SetStateAction<RowSelectionState>>;
+  traceActions?: TraceActions;
+  traceInfos: ModelTraceInfoV3[] | undefined;
+  sqlWarehouseId?: string;
+}
+
+export const GenAITracesTableActions = (props: GenAITracesTableActionsProps) => {
+  const {
+    traceActions,
+    experimentId,
+    selectedTraces: selectedTracesFromProps,
+    traceInfos,
+    setRowSelection,
+    sqlWarehouseId,
+  } = props;
+
+  const { table, selectedRowIds, isGroupedBySession } = useContext(GenAITracesTableContext);
+
+  const selectedTracesFromContext: RunEvaluationTracesDataEntry[] | undefined = useMemo(
+    () =>
+      applyTraceInfoV3ToEvalEntry(
+        selectedRowIds
+          .map((rowId) => {
+            const traceInfo = traceInfos?.find((trace) => getRowIdFromTrace(trace) === rowId);
+            if (!traceInfo) {
+              return undefined;
+            }
+            return {
+              evaluationId: traceInfo.trace_id,
+              requestId: traceInfo.client_request_id || traceInfo.trace_id,
+              inputsId: traceInfo.trace_id,
+              inputs: {},
+              outputs: {},
+              targets: {},
+              overallAssessments: [],
+              responseAssessmentsByName: {},
+              metrics: {},
+              traceInfo,
+            };
+          })
+          .filter((trace) => !isNil(trace)),
+      ),
+    [selectedRowIds, traceInfos],
+  );
+
+  const selectedTraces: RunEvaluationTracesDataEntry[] = selectedTracesFromProps || selectedTracesFromContext;
+
+  return (
+    <TraceActionsDropdown
+      experimentId={experimentId}
+      selectedTraces={selectedTraces}
+      traceActions={traceActions}
+      setRowSelection={setRowSelection ?? table?.setRowSelection}
+      sqlWarehouseId={sqlWarehouseId}
+      isGroupedBySession={isGroupedBySession}
+    />
+  );
+};
+
+interface TraceActionsDropdownProps {
+  experimentId: string;
+  selectedTraces: RunEvaluationTracesDataEntry[];
+  traceActions?: TraceActions;
+  setRowSelection: React.Dispatch<React.SetStateAction<RowSelectionState>> | undefined;
+  sqlWarehouseId?: string;
+  isGroupedBySession: boolean;
+}
+
+const TraceActionsDropdown = (props: TraceActionsDropdownProps) => {
+  const { experimentId, selectedTraces, traceActions, setRowSelection, sqlWarehouseId, isGroupedBySession } = props;
+  const intl = useIntl();
+  const { theme } = useDesignSystemTheme();
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [showCompareModal, setShowCompareModal] = useState(false);
+  const isComparisonDrawerEnabled = shouldUseUnifiedModelTraceComparisonUI();
+  // prettier-ignore
+  const {
+    showAddToEvaluationDatasetModal,
+  } = useContext(GenAITracesTableContext);
+
+  const handleEditTags = useCallback(() => {
+    if (selectedTraces.length === 1 && selectedTraces[0].traceInfo && traceActions?.editTags) {
+      traceActions.editTags.showEditTagsModalForTrace(selectedTraces[0].traceInfo);
+    }
+  }, [selectedTraces, traceActions]);
+
+  const handleDeleteTraces = useCallback(() => {
+    setShowDeleteModal(true);
+  }, []);
+
+  const handleOpenCompare = useCallback(() => {
+    setShowCompareModal(true);
+  }, []);
+
+  const handleCloseCompare = useCallback(() => {
+    setShowCompareModal(false);
+  }, []);
+
+  const deleteTraces = useCallback(
+    async (experimentId: string, traceIds: string[]) => {
+      await traceActions?.deleteTracesAction?.deleteTraces?.(experimentId, traceIds);
+      setRowSelection?.({});
+    },
+    [setRowSelection, traceActions],
+  );
+
+  const hasExportAction = Boolean(traceActions?.exportToEvals);
+  const hasRunJudgesAction = Boolean(traceActions?.runJudgesAction);
+  const hasEditTagsAction = shouldEnableTagGrouping() && Boolean(traceActions?.editTags);
+  const hasDeleteAction = Boolean(traceActions?.deleteTracesAction);
+
+  const handleExportToDatasets = () => {
+    showAddToEvaluationDatasetModal?.(selectedTraces);
+  };
+
+  const handleRunJudges = useCallback(() => {
+    const traceIds = compact(selectedTraces.map((trace) => trace.traceInfo?.trace_id));
+    traceActions?.runJudgesAction?.showRunJudgesModal(traceIds);
+  }, [selectedTraces, traceActions]);
+
+  const selectedSessionCount = useMemo(() => {
+    if (!isGroupedBySession) {
+      return 0;
+    }
+    const sessionIds = new Set<string>();
+    selectedTraces.forEach((trace) => {
+      const sessionId = trace.traceInfo?.trace_metadata?.[SESSION_ID_METADATA_KEY];
+      if (sessionId) {
+        sessionIds.add(sessionId);
+      }
+    });
+    return sessionIds.size;
+  }, [isGroupedBySession, selectedTraces]);
+
+  const isEditTagsDisabled = selectedTraces.length > 1;
+  const noTracesSelected = selectedTraces.length === 0;
+  const noActionsAvailable = !hasExportAction && !hasRunJudgesAction && !hasEditTagsAction && !hasDeleteAction;
+  const canCompare = selectedTraces.length >= 2 && selectedTraces.length < 4;
+
+  const groupLabelStyles = {
+    color: theme.colors.textSecondary,
+  };
+
+  const groupItemStyles = {
+    paddingLeft: theme.spacing.lg,
+  };
+
+  if (noActionsAvailable) {
+    return null;
+  }
+
+  const ActionButton = (
+    <Button
+      componentId="mlflow.genai-traces-table.actions-dropdown"
+      disabled={noTracesSelected}
+      endIcon={<ChevronDownIcon />}
+    >
+      {isGroupedBySession
+        ? intl.formatMessage(
+            {
+              defaultMessage: 'Actions{count}',
+              description: 'Session actions dropdown button',
+            },
+            {
+              count: selectedSessionCount === 0 ? '' : ` (${selectedSessionCount})`,
+            },
+          )
+        : intl.formatMessage(
+            {
+              defaultMessage: 'Actions{count}',
+              description: 'Trace actions dropdown button',
+            },
+            {
+              count: noTracesSelected ? '' : ` (${selectedTraces.length})`,
+            },
+          )}
+    </Button>
+  );
+
+  return (
+    <>
+      <DropdownMenu.Root>
+        {noTracesSelected ? (
+          <Tooltip
+            componentId="mlflow.genai-traces-table.actions-disabled-tooltip"
+            content={
+              isGroupedBySession
+                ? intl.formatMessage({
+                    defaultMessage: 'Select one or more sessions to perform actions.',
+                    description: 'Tooltip shown when actions button is disabled due to no session selection',
+                  })
+                : intl.formatMessage({
+                    defaultMessage: 'Select one or more traces to add to an evaluation or edit the traces.',
+                    description: 'Tooltip shown when actions button is disabled due to no trace selection',
+                  })
+            }
+          >
+            <div>
+              <DropdownMenu.Trigger disabled asChild>
+                {ActionButton}
+              </DropdownMenu.Trigger>
+            </div>
+          </Tooltip>
+        ) : (
+          <DropdownMenu.Trigger asChild>{ActionButton}</DropdownMenu.Trigger>
+        )}
+        <DropdownMenu.Content>
+          {isGroupedBySession ? (
+            hasDeleteAction && (
+              <DropdownMenu.Item
+                componentId="mlflow.genai-traces-table.delete-session"
+                onClick={handleDeleteTraces}
+                disabled={traceActions?.deleteTracesAction?.isDisabled}
+                disabledReason={traceActions?.deleteTracesAction?.disabledReason}
+              >
+                {intl.formatMessage({
+                  defaultMessage: 'Delete sessions',
+                  description: 'Delete sessions and all their traces action',
+                })}
+              </DropdownMenu.Item>
+            )
+          ) : (
+            <>
+              {isComparisonDrawerEnabled && (
+                <>
+                  <DropdownMenu.Item
+                    componentId="mlflow.genai-traces-table.compare-traces"
+                    onClick={handleOpenCompare}
+                    disabled={!canCompare}
+                  >
+                    {intl.formatMessage({ defaultMessage: 'Compare', description: 'Compare traces button' })}
+                  </DropdownMenu.Item>
+                  <DropdownMenu.Separator />
+                </>
+              )}
+              {(hasExportAction || hasRunJudgesAction) && (
+                <>
+                  <DropdownMenu.Group>
+                    <DropdownMenu.Label css={groupLabelStyles}>
+                      {intl.formatMessage({
+                        defaultMessage: 'Use for evaluation',
+                        description: 'Trace actions dropdown group label',
+                      })}
+                    </DropdownMenu.Label>
+                    {hasRunJudgesAction && (
+                      <DropdownMenu.Item
+                        componentId="mlflow.genai-traces-table.run-judges"
+                        css={groupItemStyles}
+                        onClick={handleRunJudges}
+                      >
+                        {intl.formatMessage({
+                          defaultMessage: 'Run judges',
+                          description: 'Run judges on selected traces action',
+                        })}
+                      </DropdownMenu.Item>
+                    )}
+                    {hasExportAction && (
+                      <DropdownMenu.Item
+                        componentId="mlflow.genai-traces-table.export-to-datasets"
+                        css={groupItemStyles}
+                        onClick={handleExportToDatasets}
+                      >
+                        {intl.formatMessage({
+                          defaultMessage: 'Add to evaluation dataset',
+                          description: 'Add traces to evaluation dataset action',
+                        })}
+                      </DropdownMenu.Item>
+                    )}
+                  </DropdownMenu.Group>
+                </>
+              )}
+              {(hasEditTagsAction || hasDeleteAction) && (
+                <>
+                  {(hasExportAction || hasRunJudgesAction) && <DropdownMenu.Separator />}
+                  <DropdownMenu.Group>
+                    <DropdownMenu.Label css={groupLabelStyles}>
+                      {intl.formatMessage({
+                        defaultMessage: 'Edit',
+                        description: 'Trace actions dropdown group label',
+                      })}
+                    </DropdownMenu.Label>
+                    {hasEditTagsAction && (
+                      <DropdownMenu.Item
+                        componentId="mlflow.genai-traces-table.edit-tags"
+                        css={groupItemStyles}
+                        onClick={handleEditTags}
+                        disabled={isEditTagsDisabled}
+                      >
+                        {intl.formatMessage({
+                          defaultMessage: 'Edit tags',
+                          description: 'Edit tags action',
+                        })}
+                      </DropdownMenu.Item>
+                    )}
+                    {hasDeleteAction && (
+                      <DropdownMenu.Item
+                        componentId="mlflow.genai-traces-table.delete-traces"
+                        css={groupItemStyles}
+                        onClick={handleDeleteTraces}
+                        disabled={traceActions?.deleteTracesAction?.isDisabled}
+                        disabledReason={traceActions?.deleteTracesAction?.disabledReason}
+                      >
+                        {intl.formatMessage({
+                          defaultMessage: 'Delete traces',
+                          description: 'Delete traces action',
+                        })}
+                      </DropdownMenu.Item>
+                    )}
+                  </DropdownMenu.Group>
+                </>
+              )}
+            </>
+          )}
+        </DropdownMenu.Content>
+      </DropdownMenu.Root>
+
+      {traceActions?.editTags?.EditTagsModal}
+      {traceActions?.runJudgesAction?.RunJudgesModal}
+
+      {showDeleteModal && traceActions?.deleteTracesAction && (
+        <GenAiDeleteTraceModal
+          experimentIds={[experimentId]}
+          visible={showDeleteModal}
+          selectedTraces={selectedTraces}
+          handleClose={() => setShowDeleteModal(false)}
+          deleteTraces={deleteTraces}
+        />
+      )}
+      {showCompareModal && (
+        <GenAITraceComparisonModal
+          traceIds={compact(selectedTraces.map((trace) => trace.fullTraceId ?? trace.traceInfo?.trace_id))}
+          onClose={handleCloseCompare}
+          // prettier-ignore
+        />
+      )}
+    </>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/GenAITracesTableBodyContainer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/GenAITracesTableBodyContainer.tsx
@@ -1,0 +1,296 @@
+import React, { useMemo, useCallback } from 'react';
+
+import { useDesignSystemTheme } from '@databricks/design-system';
+import { FormattedMessage } from '@databricks/i18n';
+import type { Assessment, ModelTraceInfoV3 } from '../model-trace-explorer/ModelTrace.types';
+import { AssessmentSchemaContextProvider } from '../model-trace-explorer/contexts/AssessmentSchemaContext';
+
+import { computeEvaluationsComparison } from './GenAiTracesTable.utils';
+import { GenAiTracesTableBody } from './GenAiTracesTableBody';
+import { useActiveEvaluation } from './hooks/useActiveEvaluation';
+import { useGenAiTraceTableRowSelection } from './hooks/useGenAiTraceTableRowSelection';
+import type { GetTraceFunction } from './hooks/useGetTrace';
+import type {
+  AssessmentFilter,
+  AssessmentCountMetrics,
+  AssessmentInfo,
+  TracesTableColumn,
+  EvaluationsOverviewTableSort,
+  TableFilter,
+} from './types';
+import { FilterOperator, TracesTableColumnGroup, TracesTableColumnType } from './types';
+import { sortAssessmentInfos } from './utils/AggregationUtils';
+import { shouldEnableTagGrouping } from './utils/FeatureUtils';
+import { applyTraceInfoV3ToEvalEntry, DEFAULT_RUN_PLACEHOLDER_NAME } from './utils/TraceUtils';
+
+interface GenAITracesTableBodyContainerProps {
+  // Experiment metadata
+  experimentId?: string;
+  currentRunDisplayName?: string;
+  runUuid?: string;
+  compareToRunUuid?: string;
+  compareToRunDisplayName?: string;
+  getRunColor?: (runUuid: string) => string;
+
+  // Table metadata
+  assessmentInfos: AssessmentInfo[];
+
+  // Table data
+  currentTraceInfoV3: ModelTraceInfoV3[];
+  compareToTraceInfoV3?: ModelTraceInfoV3[];
+  getTrace: GetTraceFunction;
+
+  // Table state
+  selectedColumns: TracesTableColumn[];
+  allColumns: TracesTableColumn[];
+  tableSort: EvaluationsOverviewTableSort | undefined;
+  filters: TableFilter[];
+  setFilters: (filters: TableFilter[]) => void;
+
+  // TODO: Remove this in favor of unified tagging modal apis
+  onTraceTagsEdit?: (trace: ModelTraceInfoV3) => void;
+
+  // Configuration
+  enableRowSelection?: boolean;
+
+  /**
+   * Whether to display a loading overlay over the table
+   */
+  isTableLoading?: boolean;
+
+  /**
+   * Whether to group traces by session
+   */
+  isGroupedBySession: boolean;
+
+  /**
+   * Current search query; when set, matching text in the Request column is highlighted.
+   */
+  searchQuery?: string;
+
+  // Infinite scroll props (active when shouldUseInfinitePaginatedTraces is true)
+  fetchNextPage?: () => void;
+  hasNextPage?: boolean;
+  isFetchingNextPage?: boolean;
+
+  // Server-side assessment count data (active when shouldUseInfinitePaginatedTraces is true)
+  assessmentCountMetrics?: AssessmentCountMetrics;
+  compareAssessmentCountMetrics?: AssessmentCountMetrics;
+
+  fitToContainer?: boolean;
+}
+
+const GenAITracesTableBodyContainerImpl: React.FC<React.PropsWithChildren<GenAITracesTableBodyContainerProps>> =
+  // eslint-disable-next-line react-component-name/react-component-name -- TODO(FEINF-4716)
+  React.memo((props: GenAITracesTableBodyContainerProps) => {
+    const {
+      experimentId,
+      currentTraceInfoV3,
+      compareToTraceInfoV3,
+      currentRunDisplayName,
+      runUuid,
+      compareToRunUuid,
+      compareToRunDisplayName,
+      setFilters,
+      filters,
+      selectedColumns,
+      tableSort,
+      assessmentInfos,
+      getTrace,
+      onTraceTagsEdit,
+      allColumns,
+      getRunColor,
+      enableRowSelection = true,
+      isTableLoading = false,
+      isGroupedBySession,
+      searchQuery,
+      fetchNextPage,
+      hasNextPage,
+      isFetchingNextPage,
+      assessmentCountMetrics,
+      compareAssessmentCountMetrics,
+      fitToContainer,
+    } = props;
+    const { theme } = useDesignSystemTheme();
+
+    // Convert trace info v3 to the format expected by GenAITracesTableBody
+    const currentEvaluationResults = useMemo(
+      () =>
+        applyTraceInfoV3ToEvalEntry(
+          currentTraceInfoV3.map((traceInfo) => ({
+            evaluationId: traceInfo.trace_id,
+            requestId: traceInfo.client_request_id || traceInfo.trace_id,
+            inputsId: traceInfo.trace_id,
+            inputs: {},
+            outputs: {},
+            targets: {},
+            overallAssessments: [],
+            responseAssessmentsByName: {},
+            metrics: {},
+            traceInfo,
+          })),
+        ),
+      [currentTraceInfoV3],
+    );
+    const compareToEvaluationResults = useMemo(
+      () =>
+        applyTraceInfoV3ToEvalEntry(
+          (compareToTraceInfoV3 || []).map((traceInfo) => ({
+            evaluationId: traceInfo.trace_id,
+            requestId: traceInfo.client_request_id || traceInfo.trace_id,
+            inputsId: traceInfo.trace_id,
+            inputs: {},
+            outputs: {},
+            targets: {},
+            overallAssessments: [],
+            responseAssessmentsByName: {},
+            metrics: {},
+            traceInfo,
+          })),
+        ),
+      [compareToTraceInfoV3],
+    );
+
+    const { rowSelection, setRowSelection } = useGenAiTraceTableRowSelection();
+
+    // Handle assessment filter toggle
+    const handleAssessmentFilterToggle = useCallback(
+      (assessmentName: string, filterValue: any, run: string) => {
+        const filter = filters.find(
+          (filter) => filter.column === TracesTableColumnGroup.ASSESSMENT && filter.key === assessmentName,
+        );
+        if (filter === undefined) {
+          setFilters([
+            ...filters,
+            {
+              column: TracesTableColumnGroup.ASSESSMENT,
+              key: assessmentName,
+              operator: FilterOperator.EQUALS,
+              value: filterValue,
+            },
+          ]);
+        } else if (filter.value === filterValue) {
+          // Remove the filter because it already exists.
+          setFilters(
+            filters.filter(
+              (filter) => !(filter.column === TracesTableColumnGroup.ASSESSMENT && filter.key === assessmentName),
+            ),
+          );
+        } else {
+          // Replace any filters with the same assessment name and run.
+          setFilters(
+            filters.map((filter) => {
+              if (filter.column === TracesTableColumnGroup.ASSESSMENT && filter.key === assessmentName) {
+                return {
+                  column: TracesTableColumnGroup.ASSESSMENT,
+                  key: assessmentName,
+                  operator: FilterOperator.EQUALS,
+                  value: filterValue,
+                };
+              }
+              return filter;
+            }),
+          );
+        }
+      },
+      [filters, setFilters],
+    );
+
+    const assessmentFilters: AssessmentFilter[] = useMemo(() => {
+      return filters
+        .filter((filter) => filter.column === TracesTableColumnGroup.ASSESSMENT)
+        .map((filter) => ({
+          assessmentName: filter.key || '',
+          filterValue: filter.value,
+          run: currentRunDisplayName || DEFAULT_RUN_PLACEHOLDER_NAME,
+        }));
+    }, [filters, currentRunDisplayName]);
+
+    const [selectedEvaluationId, setSelectedEvaluationId] = useActiveEvaluation();
+
+    // Get selected assessment infos
+    const selectedAssessmentInfos = useMemo(() => {
+      const selectedAssessmentCols = selectedColumns.filter((col) => col.type === TracesTableColumnType.ASSESSMENT);
+      const selectedAssessments = selectedAssessmentCols.map((col) => col.assessmentInfo as AssessmentInfo);
+      return sortAssessmentInfos(selectedAssessments);
+    }, [selectedColumns]);
+
+    // Compute evaluations comparison
+    const evaluationResults = useMemo(
+      () => computeEvaluationsComparison(currentEvaluationResults, compareToEvaluationResults),
+      [currentEvaluationResults, compareToEvaluationResults],
+    );
+
+    const assessments = useMemo(() => {
+      return currentEvaluationResults.flatMap((evalResult) => evalResult?.traceInfo?.assessments ?? []) as Assessment[];
+    }, [currentEvaluationResults]);
+
+    return (
+      <div
+        css={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: theme.spacing.xs,
+          overflow: 'hidden',
+          flexGrow: 1,
+        }}
+      >
+        <div
+          css={{
+            display: 'flex',
+            gap: theme.spacing.md,
+            width: '100%',
+            flex: 1,
+            overflow: 'hidden',
+          }}
+        >
+          <div
+            css={{
+              flex: 1,
+              overflow: 'hidden',
+              position: 'relative',
+            }}
+          >
+            <AssessmentSchemaContextProvider assessments={assessments}>
+              <GenAiTracesTableBody
+                experimentId={experimentId}
+                selectedColumns={selectedColumns}
+                allColumns={allColumns}
+                evaluations={evaluationResults}
+                selectedEvaluationId={selectedEvaluationId}
+                selectedAssessmentInfos={selectedAssessmentInfos}
+                assessmentInfos={assessmentInfos}
+                assessmentFilters={assessmentFilters}
+                onChangeEvaluationId={setSelectedEvaluationId}
+                getRunColor={getRunColor}
+                runUuid={runUuid}
+                compareToRunUuid={compareToRunUuid}
+                runDisplayName={currentRunDisplayName}
+                compareToRunDisplayName={compareToRunDisplayName}
+                enableRowSelection={enableRowSelection}
+                rowSelection={rowSelection}
+                setRowSelection={setRowSelection}
+                toggleAssessmentFilter={handleAssessmentFilterToggle}
+                tableSort={tableSort}
+                getTrace={getTrace}
+                onTraceTagsEdit={onTraceTagsEdit}
+                enableGrouping={false}
+                isTableLoading={isTableLoading}
+                isGroupedBySession={isGroupedBySession}
+                searchQuery={searchQuery}
+                fetchNextPage={fetchNextPage}
+                hasNextPage={hasNextPage}
+                isFetchingNextPage={isFetchingNextPage}
+                assessmentCountMetrics={assessmentCountMetrics}
+                compareAssessmentCountMetrics={compareAssessmentCountMetrics}
+                fitToContainer={fitToContainer}
+              />
+            </AssessmentSchemaContextProvider>
+          </div>
+        </div>
+      </div>
+    );
+  });
+
+// TODO: Add an error boundary to the OSS trace table
+export const GenAITracesTableBodyContainer = GenAITracesTableBodyContainerImpl;

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/GenAITracesTableBodySkeleton.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/GenAITracesTableBodySkeleton.tsx
@@ -1,0 +1,34 @@
+import type { Table } from '@tanstack/react-table';
+
+import { ParagraphSkeleton, TableSkeletonRows, useDesignSystemTheme } from '@databricks/design-system';
+
+import type { EvalTraceComparisonEntry } from './types';
+
+export const GenAITracesTableBodySkeleton = ({
+  className,
+  table,
+}: {
+  className?: string;
+  table?: Table<EvalTraceComparisonEntry>;
+}) => {
+  const { theme } = useDesignSystemTheme();
+  return (
+    <div
+      css={{
+        display: 'flex',
+        flexDirection: 'column',
+        width: '100%',
+        gap: theme.spacing.sm,
+        padding: theme.spacing.md,
+        backgroundColor: theme.colors.backgroundPrimary,
+      }}
+      className={className}
+    >
+      {table ? (
+        <TableSkeletonRows label="Loading..." numRows={3} table={table} />
+      ) : (
+        [...Array(10).keys()].map((i) => <ParagraphSkeleton label="Loading..." key={i} seed={`s-${i}`} />)
+      )}
+    </div>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/GenAITracesTableContext.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/GenAITracesTableContext.tsx
@@ -1,0 +1,115 @@
+import { Drawer } from '@databricks/design-system';
+import type { Table } from '@tanstack/react-table';
+import { compact, isUndefined } from 'lodash';
+import React, { createContext, useCallback, useMemo, useState } from 'react';
+
+import type { EvalTraceComparisonEntry, RunEvaluationTracesDataEntry } from './types';
+import { ModelTraceExplorerPreferencesProvider } from '../model-trace-explorer/ModelTraceExplorerPreferencesContext';
+import {
+  useModelTraceExplorerContext,
+  type DrawerComponentType,
+} from '../model-trace-explorer/ModelTraceExplorerContext';
+import type { GetTraceFunction } from './hooks/useGetTrace';
+import { getExperimentIdFromTraceLocation } from './utils/TraceUtils';
+
+type TraceRow = EvalTraceComparisonEntry & { multiline?: boolean };
+
+export interface GenAITracesTableContextValue<T> {
+  /** TanStack table instance (may be undefined until grandchild mounts) */
+  table: Table<T> | undefined;
+  /** Grandchild calls this once when it builds the table */
+  setTable: (tbl: Table<T> | undefined) => void;
+
+  selectedRowIds: string[];
+  /** Grandchild updates this on every selection change */
+  setSelectedRowIds: (rowIds: string[]) => void;
+
+  /** Whether traces are grouped by session */
+  isGroupedBySession: boolean;
+
+  /**
+   * Drawer component to use when rendering the trace UI & comparison views.
+   * In OSS, we pass in the AssistantAwareDrawer component, but otherwise it
+   * defaults to the standard Design System Drawer component.
+   */
+  DrawerComponent: DrawerComponentType;
+
+  /**
+   * Function to show the "Add to Evaluation Dataset" modal.
+   * Provide traces to be added to the dataset. If `undefined` is passed, the modal is closed.
+   */
+  showAddToEvaluationDatasetModal?: (traces?: RunEvaluationTracesDataEntry[]) => void;
+}
+export const GenAITracesTableContext = createContext<GenAITracesTableContextValue<TraceRow>>({
+  table: undefined,
+  setTable: () => {},
+  selectedRowIds: [],
+  isGroupedBySession: false,
+  setSelectedRowIds: () => {},
+  DrawerComponent: Drawer,
+});
+
+interface GenAITracesTableProviderProps {
+  children: React.ReactNode;
+  experimentId?: string;
+  getTrace?: GetTraceFunction;
+  isGroupedBySession: boolean;
+  DrawerComponent?: DrawerComponentType;
+}
+
+export const GenAITracesTableProvider: React.FC<React.PropsWithChildren<GenAITracesTableProviderProps>> = ({
+  children,
+  experimentId,
+  getTrace,
+  isGroupedBySession,
+  DrawerComponent = Drawer,
+}) => {
+  const [table, setTable] = useState<Table<TraceRow> | undefined>();
+  const [selectedRowIds, setSelectedRowIds] = useState<string[]>([]);
+  const [showDatasetModal, setShowDatasetModal] = useState(false);
+  const [selectedTraces, setSelectedTraces] = useState<RunEvaluationTracesDataEntry[] | undefined>(undefined);
+
+  const { renderExportTracesToDatasetsModal } = useModelTraceExplorerContext();
+
+  const showAddToEvaluationDatasetModal = useCallback((traces?: RunEvaluationTracesDataEntry[]) => {
+    setSelectedTraces(traces);
+    setShowDatasetModal(!isUndefined(traces));
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      table,
+      setTable,
+      getTrace,
+      selectedRowIds,
+      setSelectedRowIds,
+      isGroupedBySession,
+      showAddToEvaluationDatasetModal,
+      DrawerComponent,
+    }),
+    // prettier-ignore
+    [
+      table,
+      getTrace,
+      selectedRowIds,
+      isGroupedBySession,
+      showAddToEvaluationDatasetModal,
+      DrawerComponent,
+    ],
+  );
+
+  return (
+    <ModelTraceExplorerPreferencesProvider>
+      <GenAITracesTableContext.Provider value={value}>
+        {children}
+        {renderExportTracesToDatasetsModal?.({
+          selectedTraceInfos: selectedTraces ? compact(selectedTraces.map((trace) => trace.traceInfo)) : [],
+          experimentId:
+            getExperimentIdFromTraceLocation(selectedTraces?.[0]?.traceInfo?.trace_location) ?? experimentId ?? '',
+          visible: showDatasetModal,
+          setVisible: setShowDatasetModal,
+        })}
+      </GenAITracesTableContext.Provider>
+    </ModelTraceExplorerPreferencesProvider>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/GenAITracesTableToolbar.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/GenAITracesTableToolbar.tsx
@@ -1,0 +1,317 @@
+import { isNil } from 'lodash';
+import React, { useCallback } from 'react';
+
+import {
+  Typography,
+  useDesignSystemTheme,
+  TableFilterLayout,
+  Tooltip,
+  Spinner,
+  WarningIcon,
+  Button,
+  RefreshIcon,
+  ToggleButton,
+} from '@databricks/design-system';
+import { FormattedMessage, useIntl } from '@databricks/i18n';
+
+import { GenAITracesTableActions } from './GenAITracesTableActions';
+import { GenAiTracesTableFilter } from './GenAiTracesTableFilter';
+import { GenAiTracesTableSearchInput } from './GenAiTracesTableSearchInput';
+import { EvaluationsOverviewColumnSelectorGrouped } from './components/EvaluationsOverviewColumnSelectorGrouped';
+import { EvaluationsOverviewSortDropdown } from './components/EvaluationsOverviewSortDropdown';
+import { DetectIssuesButton } from './components/DetectIssuesButton';
+import type {
+  EvaluationsOverviewTableSort,
+  TraceActions,
+  AssessmentInfo,
+  TracesTableColumn,
+  TableFilter,
+  TableFilterOptions,
+  TraceTablePageSource,
+} from './types';
+import { shouldEnableSessionGrouping, shouldEnableTagGrouping } from './utils/FeatureUtils';
+import { shouldEnableIssueDetection } from '../../../common/utils/FeatureUtils';
+import type { ModelTraceInfoV3 } from '../model-trace-explorer/ModelTrace.types';
+
+interface CountInfo {
+  currentCount?: number;
+  totalCount: number;
+  maxAllowedCount: number;
+  logCountLoading: boolean;
+}
+
+interface GenAITracesTableToolbarProps {
+  // Component for detect issues button
+  pageSource?: TraceTablePageSource;
+
+  // Experiment metadata
+  experimentId?: string;
+
+  // Table metadata
+  allColumns: TracesTableColumn[];
+  assessmentInfos: AssessmentInfo[];
+
+  // Table data
+  traceInfos: ModelTraceInfoV3[] | undefined;
+
+  // Filters
+  searchQuery: string;
+  setSearchQuery: (query: string) => void;
+  filters: TableFilter[];
+  setFilters: (newFilters: TableFilter[] | undefined, replace?: boolean) => void;
+  tableSort: EvaluationsOverviewTableSort | undefined;
+  setTableSort: (sort: EvaluationsOverviewTableSort | undefined) => void;
+  selectedColumns: TracesTableColumn[];
+  toggleColumns: (newColumns: TracesTableColumn[]) => void;
+  setSelectedColumns: (nextSelected: TracesTableColumn[]) => void;
+
+  // Actions
+  traceActions?: TraceActions;
+
+  // Stats
+  countInfo: CountInfo;
+
+  // Table filter options
+  tableFilterOptions: TableFilterOptions;
+
+  // Loading state
+  isMetadataLoading?: boolean;
+
+  // Error state
+  metadataError?: Error | null;
+
+  // whether or not the toolbar show show additional search options only
+  // available in the new APIs. this param is somewhat confusingly named
+  // in OSS, since the "new APIs" still use the v3 prefixes
+  usesV4APIs?: boolean;
+  onRefresh?: () => void;
+  isRefreshing?: boolean;
+
+  // Session grouping
+  isGroupedBySession?: boolean;
+  forceGroupBySession?: boolean;
+  onToggleSessionGrouping?: () => void;
+
+  // Issue detection
+  onDetectIssues?: () => void;
+
+  // Additional elements to render in the toolbar
+  addons?: React.ReactNode;
+}
+
+export const GenAITracesTableToolbar: React.FC<React.PropsWithChildren<GenAITracesTableToolbarProps>> = React.memo(
+  // eslint-disable-next-line react-component-name/react-component-name -- TODO(FEINF-4716)
+  (props: GenAITracesTableToolbarProps) => {
+    const {
+      pageSource = 'experiment-traces',
+      searchQuery,
+      setSearchQuery,
+      filters,
+      setFilters,
+      tableSort,
+      setTableSort,
+      selectedColumns,
+      toggleColumns,
+      setSelectedColumns,
+      assessmentInfos,
+      experimentId,
+      traceInfos,
+      tableFilterOptions,
+      traceActions,
+      allColumns,
+      countInfo,
+      isMetadataLoading,
+      usesV4APIs,
+      metadataError,
+      onRefresh,
+      isRefreshing,
+      isGroupedBySession,
+      forceGroupBySession,
+      onToggleSessionGrouping,
+      onDetectIssues,
+      addons,
+    } = props;
+    const { theme } = useDesignSystemTheme();
+    const intl = useIntl();
+
+    const onSortChange = useCallback(
+      (sortOption, orderByAsc) => {
+        setTableSort({ key: sortOption.key, type: sortOption.type, asc: orderByAsc });
+      },
+      [setTableSort],
+    );
+
+    // When using V4 APIs, we want users to be able to change filters while the traces are being loaded or there is an error
+    const shouldDisplayErrorState = Boolean(metadataError && !usesV4APIs);
+    const shouldDisplayLoadingState = isMetadataLoading && !usesV4APIs;
+
+    return (
+      <div
+        css={{
+          display: 'flex',
+          width: '100%',
+          alignItems: 'flex-end',
+          gap: theme.spacing.sm,
+          paddingBottom: `${theme.spacing.xs}px`,
+        }}
+      >
+        <TableFilterLayout
+          css={{
+            marginBottom: 0,
+            flex: 1,
+          }}
+        >
+          <GenAiTracesTableSearchInput searchQuery={searchQuery} setSearchQuery={setSearchQuery} />
+          <GenAiTracesTableFilter
+            filters={filters}
+            setFilters={setFilters}
+            assessmentInfos={assessmentInfos}
+            experimentId={experimentId}
+            tableFilterOptions={tableFilterOptions}
+            allColumns={allColumns}
+            isLoading={shouldDisplayLoadingState}
+            isError={shouldDisplayErrorState}
+            usesV4APIs={usesV4APIs}
+          />
+          <EvaluationsOverviewSortDropdown
+            tableSort={tableSort}
+            columns={selectedColumns}
+            onChange={onSortChange}
+            enableGrouping={shouldEnableTagGrouping()}
+            isLoading={shouldDisplayLoadingState}
+            isError={shouldDisplayErrorState}
+          />
+
+          <EvaluationsOverviewColumnSelectorGrouped
+            columns={allColumns}
+            selectedColumns={selectedColumns}
+            toggleColumns={toggleColumns}
+            setSelectedColumns={setSelectedColumns}
+            isLoading={shouldDisplayLoadingState}
+            isError={shouldDisplayErrorState}
+          />
+          {traceActions && experimentId && (
+            <GenAITracesTableActions
+              experimentId={experimentId}
+              traceActions={traceActions}
+              traceInfos={traceInfos}
+              // prettier-ignore
+            />
+          )}
+          {shouldEnableSessionGrouping() && onToggleSessionGrouping && !forceGroupBySession && (
+            <Tooltip
+              componentId="mlflow.traces-table.group-by-session-button.tooltip"
+              content={intl.formatMessage({
+                defaultMessage: 'Toggle session grouping',
+                description: 'Tooltip for the group by session button in the traces table toolbar',
+              })}
+            >
+              <ToggleButton
+                componentId="mlflow.traces-table.group-by-session-button"
+                onPressedChange={onToggleSessionGrouping}
+                pressed={isGroupedBySession}
+                aria-label={intl.formatMessage({
+                  defaultMessage: 'Toggle session grouping',
+                  description: 'Aria label for the group by session button in the traces table toolbar',
+                })}
+              >
+                <FormattedMessage
+                  defaultMessage="Group by session"
+                  description="Label for the group by session button in the traces table toolbar"
+                />
+              </ToggleButton>
+            </Tooltip>
+          )}
+          {shouldEnableIssueDetection() && onDetectIssues && (
+            <DetectIssuesButton
+              componentId={
+                pageSource === 'experiment-traces'
+                  ? 'mlflow.traces-table.detect-issues-button'
+                  : pageSource === 'chat-sessions'
+                    ? 'mlflow.chat-sessions.detect-issues-button'
+                    : 'mlflow.run-view-traces.detect-issues-button'
+              }
+              onClick={onDetectIssues}
+            />
+          )}
+          {onRefresh && (
+            <Tooltip
+              componentId="mlflow.traces-table.refresh-button.tooltip"
+              content={intl.formatMessage({
+                defaultMessage: 'Refresh traces',
+                description: 'Tooltip for the refresh traces button in the traces table toolbar',
+              })}
+            >
+              <Button
+                componentId="mlflow.traces-table.refresh-button"
+                icon={<RefreshIcon />}
+                onClick={onRefresh}
+                loading={isRefreshing}
+                aria-label={intl.formatMessage({
+                  defaultMessage: 'Refresh traces',
+                  description: 'Aria label for the refresh traces button in the traces table toolbar',
+                })}
+              />
+            </Tooltip>
+          )}
+          {addons}
+        </TableFilterLayout>
+        <SampledInfoBadge countInfo={countInfo} />
+      </div>
+    );
+  },
+);
+
+const SampledInfoBadge = (props: { countInfo: CountInfo }) => {
+  const { countInfo } = props;
+  const intl = useIntl();
+  const { theme } = useDesignSystemTheme();
+
+  if (countInfo.logCountLoading || isNil(countInfo.currentCount)) {
+    return <Spinner size="small" />;
+  }
+
+  return (
+    <div
+      css={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: theme.spacing.sm,
+      }}
+    >
+      {countInfo.currentCount >= countInfo.maxAllowedCount && (
+        <Tooltip
+          componentId="mlflow.experiment_list_view.max_traces.tooltip"
+          content={intl.formatMessage(
+            {
+              defaultMessage: 'Only the top {evalResultsCount} results are shown',
+              description: 'Evaluation review > evaluations list > sample info tooltip',
+            },
+            {
+              evalResultsCount: countInfo.maxAllowedCount,
+            },
+          )}
+        >
+          <WarningIcon color="warning" />
+        </Tooltip>
+      )}
+      <Typography.Hint>
+        {intl.formatMessage(
+          {
+            defaultMessage: '{numFilteredEvals} of {numEvals}',
+            description: 'Text displayed when showing a filtered subset evaluations in the evaluation review page',
+          },
+          {
+            // Sometimes the api returns more than the max allowed count. To avoid confusion, we show the max allowed count.
+            numFilteredEvals:
+              countInfo.currentCount >= countInfo.maxAllowedCount ? countInfo.maxAllowedCount : countInfo.currentCount,
+            numEvals:
+              countInfo.totalCount >= countInfo.maxAllowedCount
+                ? `${countInfo.maxAllowedCount}+`
+                : countInfo.totalCount,
+          },
+        )}
+      </Typography.Hint>
+    </div>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/GenAiTracesTable.utils.ts
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/GenAiTracesTable.utils.ts
@@ -1,0 +1,302 @@
+import type { ColumnDef } from '@tanstack/react-table';
+import { isNil } from 'lodash';
+
+import { KnownEvaluationResultAssessmentName } from './enum';
+import {
+  REQUEST_TIME_COLUMN_ID,
+  STATE_COLUMN_ID,
+  SOURCE_COLUMN_ID,
+  TAGS_COLUMN_ID,
+  EXECUTION_DURATION_COLUMN_ID,
+  TRACE_NAME_COLUMN_ID,
+  SORTABLE_INFO_COLUMNS,
+  TRACE_ID_COLUMN_ID,
+  SESSION_COLUMN_ID,
+  INPUTS_COLUMN_ID,
+  RESPONSE_COLUMN_ID,
+  USER_COLUMN_ID,
+  LOGGED_MODEL_COLUMN_ID,
+  TOKENS_COLUMN_ID,
+  SIMULATION_GOAL_COLUMN_ID,
+  SIMULATION_PERSONA_COLUMN_ID,
+  LINKED_PROMPTS_COLUMN_ID,
+  ISSUES_COLUMN_ID,
+  GIT_BRANCH_COLUMN_ID,
+  GIT_COMMIT_COLUMN_ID,
+} from './hooks/useTableColumns';
+import type { TracesTableColumn, EvalTraceComparisonEntry, RunEvaluationTracesDataEntry } from './types';
+import { TracesTableColumnGroup, TracesTableColumnType } from './types';
+import { getTraceInfoInputs, shouldUseTraceInfoV3 } from './utils/TraceUtils';
+import { SIMULATION_GOAL_KEY, SIMULATION_PERSONA_KEY } from './utils/SessionGroupingUtils';
+import type { ModelTraceInfoV3 } from '../model-trace-explorer/ModelTrace.types';
+
+const GROUP_PRIORITY = [
+  TracesTableColumnGroup.INFO,
+  TracesTableColumnGroup.ASSESSMENT,
+  TracesTableColumnGroup.EXPECTATION,
+  TracesTableColumnGroup.TAG,
+] as const;
+
+/** Preferred order *within* the INFO group by column ID */
+const INFO_COLUMN_PRIORITY = [
+  TRACE_ID_COLUMN_ID,
+  INPUTS_COLUMN_ID,
+  RESPONSE_COLUMN_ID,
+  SESSION_COLUMN_ID,
+  USER_COLUMN_ID,
+  TRACE_NAME_COLUMN_ID,
+  LOGGED_MODEL_COLUMN_ID,
+  TOKENS_COLUMN_ID,
+] as const;
+
+/** Columns that should always appear at the end of the INFO group */
+const INFO_COLUMN_LAST = [ISSUES_COLUMN_ID] as const;
+
+/** Preferred order *within* the ASSESSMENT group by column ID */
+const ASSESSMENT_COLUMN_PRIORITY = [KnownEvaluationResultAssessmentName.OVERALL_ASSESSMENT] as const;
+
+const groupRank: Record<TracesTableColumnGroup, number> = Object.fromEntries(
+  GROUP_PRIORITY.map((grp, idx) => [grp, idx]),
+) as any;
+
+const infoColumnRank: Record<string, number> = Object.fromEntries(INFO_COLUMN_PRIORITY.map((id, idx) => [id, idx]));
+
+const assessmentColumnRank: Record<string, number> = Object.fromEntries(
+  ASSESSMENT_COLUMN_PRIORITY.map((id, idx) => [id, idx]),
+);
+
+export function sortGroupedColumns(
+  columns: TracesTableColumn[],
+  isComparing?: boolean,
+  isGroupedBySession?: boolean,
+): TracesTableColumn[] {
+  return [...columns].sort((colA, colB) => {
+    // If grouped by session, always put session column first
+    if (isGroupedBySession) {
+      if (colA.id === SESSION_COLUMN_ID) return -1;
+      if (colB.id === SESSION_COLUMN_ID) return 1;
+    }
+
+    // If grouped by session, put goal and persona columns near the front (after session)
+    if (isGroupedBySession) {
+      const isGoalOrPersonaA = colA.id === SIMULATION_GOAL_COLUMN_ID || colA.id === SIMULATION_PERSONA_COLUMN_ID;
+      const isGoalOrPersonaB = colB.id === SIMULATION_GOAL_COLUMN_ID || colB.id === SIMULATION_PERSONA_COLUMN_ID;
+      if (isGoalOrPersonaA && !isGoalOrPersonaB) return -1;
+      if (!isGoalOrPersonaA && isGoalOrPersonaB) return 1;
+      // Between goal and persona, put goal first
+      if (colA.id === SIMULATION_GOAL_COLUMN_ID && colB.id === SIMULATION_PERSONA_COLUMN_ID) return -1;
+      if (colA.id === SIMULATION_PERSONA_COLUMN_ID && colB.id === SIMULATION_GOAL_COLUMN_ID) return 1;
+    }
+
+    // If comparing, always put request time column first
+    if (isComparing) {
+      if (colA.id === INPUTS_COLUMN_ID) return -1;
+      if (colB.id === INPUTS_COLUMN_ID) return 1;
+    }
+
+    // 1) Compare their groups by precomputed rank
+    const groupA = colA.group ?? TracesTableColumnGroup.INFO;
+    const groupB = colB.group ?? TracesTableColumnGroup.INFO;
+    const groupComparison = groupRank[groupA] - groupRank[groupB];
+    if (groupComparison !== 0) return groupComparison;
+
+    // 2) Same group: INFO
+    if (groupA === TracesTableColumnGroup.INFO) {
+      // Columns in INFO_COLUMN_LAST should always appear at the end
+      const isLastA = INFO_COLUMN_LAST.includes(colA.id as (typeof INFO_COLUMN_LAST)[number]);
+      const isLastB = INFO_COLUMN_LAST.includes(colB.id as (typeof INFO_COLUMN_LAST)[number]);
+      if (isLastA && !isLastB) return 1;
+      if (!isLastA && isLastB) return -1;
+
+      const rankA = infoColumnRank[colA.id] ?? Infinity;
+      const rankB = infoColumnRank[colB.id] ?? Infinity;
+      if (rankA !== rankB) return rankA - rankB;
+      return colA.label.localeCompare(colB.label);
+    }
+
+    // 3) Same group: ASSESSMENT
+    if (groupA === TracesTableColumnGroup.ASSESSMENT) {
+      const rankA = assessmentColumnRank[colA.id] ?? Infinity;
+      const rankB = assessmentColumnRank[colB.id] ?? Infinity;
+      if (rankA !== rankB) return rankA - rankB;
+      return colA.label.localeCompare(colB.label);
+    }
+
+    // 4) Same group: EXPECTATION
+    if (groupA === TracesTableColumnGroup.EXPECTATION) {
+      return colA.label.localeCompare(colB.label);
+    }
+
+    // 5) Same group: TAG (or any other fallback)
+    return colA.label.localeCompare(colB.label);
+  });
+}
+
+export const sortColumns = (columns: ColumnDef<EvalTraceComparisonEntry>[], selectedColumns: TracesTableColumn[]) => {
+  return columns.sort((a, b) => {
+    const getPriority = (col: typeof a) => {
+      const colType = selectedColumns.find((c) => c.id === col.id)?.type;
+
+      // Regression-test view: the Test (trace id) column leads.
+      if (col.id === TRACE_ID_COLUMN_ID) return 0;
+      if (colType === TracesTableColumnType.INPUT) return 1;
+      if (col.id === TRACE_NAME_COLUMN_ID) return 2;
+      if (colType === TracesTableColumnType.TRACE_INFO) return 3;
+      if (colType === TracesTableColumnType.INTERNAL_MONITOR_REQUEST_TIME) return 4;
+      if (colType === TracesTableColumnType.ASSESSMENT) return 5;
+      return 999; // keep any other columns after the known ones
+    };
+
+    // primary sort key: our priority number
+    const diff = getPriority(a) - getPriority(b);
+    if (diff !== 0) return diff;
+
+    // secondary key: for assessment columns, prioritize 'Overall' and then sort alphabetically by label
+    const aCol = selectedColumns.find((c) => c.id === a.id);
+    const bCol = selectedColumns.find((c) => c.id === b.id);
+    if (aCol?.type === TracesTableColumnType.ASSESSMENT && bCol?.type === TracesTableColumnType.ASSESSMENT) {
+      if (aCol.id === KnownEvaluationResultAssessmentName.OVERALL_ASSESSMENT) return -1;
+      if (bCol.id === KnownEvaluationResultAssessmentName.OVERALL_ASSESSMENT) return 1;
+      return (aCol.label || '').localeCompare(bCol.label || '');
+    }
+
+    // tertiary key: original array order (stable sort fallback)
+    return 0;
+  });
+};
+
+export const traceInfoSortingFn = (
+  traceInfoA: ModelTraceInfoV3 | undefined,
+  traceInfoB: ModelTraceInfoV3 | undefined,
+  colId: string,
+) => {
+  // only support sorting by request time for now
+  if (!SORTABLE_INFO_COLUMNS.includes(colId)) {
+    return 0;
+  }
+
+  const aVal = String(getTraceInfoValueWithColId(traceInfoA as ModelTraceInfoV3, colId) ?? '');
+  const bVal = String(getTraceInfoValueWithColId(traceInfoB as ModelTraceInfoV3, colId) ?? '');
+
+  return aVal.localeCompare(bVal, undefined, { numeric: true });
+};
+
+export const getTraceInfoValueWithColId = (traceInfo: ModelTraceInfoV3, colId: string) => {
+  switch (colId) {
+    case REQUEST_TIME_COLUMN_ID:
+    case EXECUTION_DURATION_COLUMN_ID:
+    case TAGS_COLUMN_ID:
+    case STATE_COLUMN_ID:
+      return traceInfo[colId];
+    case SOURCE_COLUMN_ID:
+      return traceInfo.tags;
+    case TRACE_ID_COLUMN_ID:
+      return traceInfo.trace_id;
+    case SESSION_COLUMN_ID:
+      return traceInfo.tags?.['mlflow.trace.session'];
+    case SIMULATION_GOAL_COLUMN_ID:
+      return traceInfo.trace_metadata?.['mlflow.simulation.goal'];
+    case SIMULATION_PERSONA_COLUMN_ID:
+      return traceInfo.trace_metadata?.['mlflow.simulation.persona'];
+    case LINKED_PROMPTS_COLUMN_ID:
+      return traceInfo.tags?.['mlflow.linkedPrompts'];
+    case GIT_BRANCH_COLUMN_ID:
+      return traceInfo.trace_metadata?.['mlflow.source.git.branch'];
+    case GIT_COMMIT_COLUMN_ID:
+      return traceInfo.trace_metadata?.['mlflow.source.git.commit'];
+    default:
+      // Return null for unknown column IDs to avoid breaking the UI
+      return null;
+  }
+};
+
+function getUniqueInputRequests(
+  evaluationResults: RunEvaluationTracesDataEntry[],
+): Map<string, RunEvaluationTracesDataEntry> {
+  const resultMap = new Map<string, RunEvaluationTracesDataEntry>();
+  // If there are duplicate input ids, we need to append a count to the key to ensure uniqueness.
+  const duplicateIndexMap = new Map<string, number>();
+
+  evaluationResults?.forEach((entry) => {
+    let key = shouldUseTraceInfoV3([entry]) ? getTraceInfoInputs(entry.traceInfo as ModelTraceInfoV3) : entry.inputsId;
+    if (resultMap.has(key)) {
+      const currentCount = duplicateIndexMap.get(entry.inputsId) || 0;
+      const newCount = currentCount + 1;
+      duplicateIndexMap.set(entry.inputsId, newCount);
+      key = `${entry.inputsId}_${newCount}`;
+    }
+    resultMap.set(key, entry);
+  });
+  return resultMap;
+}
+
+export function computeEvaluationsComparison(
+  currentRunEvalResults: RunEvaluationTracesDataEntry[],
+  otherRunEvalResults?: RunEvaluationTracesDataEntry[],
+): EvalTraceComparisonEntry[] {
+  if (isNil(otherRunEvalResults)) {
+    return currentRunEvalResults.map((entry) => ({ currentRunValue: entry }));
+  }
+
+  // TODO(nsthorat): This logic does not work when a single eval run contains the same input ids, e.g. there is multiple evals with the same
+  // input id. This is a bug in the current implementation.
+
+  // Merge the two eval results by joining on inputsId. There may be results that are only present in one of the two.
+  const otherRunEvalResultsMap = getUniqueInputRequests(otherRunEvalResults);
+
+  const currentRunEvalResultsMap = getUniqueInputRequests(currentRunEvalResults);
+  const allRequestIds = new Set([...currentRunEvalResultsMap.keys(), ...otherRunEvalResultsMap.keys()]);
+
+  return Array.from(allRequestIds).map((inputsId) => {
+    return {
+      currentRunValue: currentRunEvalResultsMap.get(inputsId),
+      otherRunValue: otherRunEvalResultsMap.get(inputsId),
+    };
+  });
+}
+
+/**
+ * Returns simulation columns (goal/persona) that should be auto-selected based on trace metadata.
+ * Only returns columns that exist in allColumns and are not already in selectedColumns.
+ */
+export function getSimulationColumnsToAdd(
+  traces: ModelTraceInfoV3[],
+  allColumns: TracesTableColumn[],
+  selectedColumns: TracesTableColumn[],
+): TracesTableColumn[] {
+  if (traces.length === 0) {
+    return [];
+  }
+
+  let hasGoalMetadata = false;
+  let hasPersonaMetadata = false;
+
+  for (const trace of traces) {
+    if (!hasGoalMetadata && trace.trace_metadata?.[SIMULATION_GOAL_KEY]) {
+      hasGoalMetadata = true;
+    }
+    if (!hasPersonaMetadata && trace.trace_metadata?.[SIMULATION_PERSONA_KEY]) {
+      hasPersonaMetadata = true;
+    }
+    if (hasGoalMetadata && hasPersonaMetadata) {
+      break;
+    }
+  }
+
+  if (!hasGoalMetadata && !hasPersonaMetadata) {
+    return [];
+  }
+
+  const columnsToAdd: TracesTableColumn[] = [];
+  const goalColumn = allColumns.find((col) => col.id === SIMULATION_GOAL_COLUMN_ID);
+  const personaColumn = allColumns.find((col) => col.id === SIMULATION_PERSONA_COLUMN_ID);
+
+  if (hasGoalMetadata && goalColumn && !selectedColumns.some((col) => col.id === SIMULATION_GOAL_COLUMN_ID)) {
+    columnsToAdd.push(goalColumn);
+  }
+  if (hasPersonaMetadata && personaColumn && !selectedColumns.some((col) => col.id === SIMULATION_PERSONA_COLUMN_ID)) {
+    columnsToAdd.push(personaColumn);
+  }
+
+  return columnsToAdd;
+}

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/GenAiTracesTableBody.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/GenAiTracesTableBody.tsx
@@ -1,0 +1,712 @@
+import type { RowSelectionState, OnChangeFn, ColumnDef, Row } from '@tanstack/react-table';
+import { getCoreRowModel, getSortedRowModel } from '@tanstack/react-table';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import { isNil } from 'lodash';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { Empty, SearchIcon, Table, TableSkeletonRows, useDesignSystemTheme } from '@databricks/design-system';
+import { useIntl } from '@databricks/i18n';
+import { isV4TraceId } from '../model-trace-explorer/ModelTraceExplorer.utils';
+import { shouldUseUnifiedModelTraceComparisonUI } from '../model-trace-explorer/FeatureUtils';
+import type { ModelTraceInfoV3 } from '../model-trace-explorer/ModelTrace.types';
+import { useReactTable_unverifiedWithReact18 as useReactTable } from '../react-table/useReactTable';
+
+import { GenAITracesTableBodySkeleton } from './GenAITracesTableBodySkeleton';
+import { GenAITracesTableContext } from './GenAITracesTableContext';
+import { sortColumns, sortGroupedColumns } from './GenAiTracesTable.utils';
+import { getColumnConfig } from './GenAiTracesTableBody.utils';
+import { MemoizedGenAiTracesTableBodyRows } from './GenAiTracesTableBodyRows';
+import { MemoizedGenAiTracesTableSessionGroupedRows } from './GenAiTracesTableSessionGroupedRows';
+import { GenAiTracesTableHeader } from './GenAiTracesTableHeader';
+import { groupTracesBySessionForTable } from './utils/SessionGroupingUtils';
+import { HeaderCellRenderer } from './cellRenderers/HeaderCellRenderer';
+import type { GetTraceFunction } from './hooks/useGetTrace';
+import { REQUEST_TIME_COLUMN_ID, SESSION_COLUMN_ID, SERVER_SORTABLE_INFO_COLUMNS } from './hooks/useTableColumns';
+import {
+  type RunEvaluationTracesDataEntry,
+  type EvaluationsOverviewTableSort,
+  TracesTableColumnType,
+  type AssessmentAggregates,
+  type AssessmentCountMetrics,
+  type AssessmentFilter,
+  type AssessmentInfo,
+  type AssessmentValueType,
+  type EvalTraceComparisonEntry,
+  type SaveAssessmentsQuery,
+  type TracesTableColumn,
+  TracesTableColumnGroup,
+} from './types';
+import { getAssessmentAggregates, buildAggregatesFromCountMetrics } from './utils/AggregationUtils';
+import { escapeCssSpecialCharacters } from './utils/DisplayUtils';
+import { getExperimentIdFromTraceLocation, getRowIdFromEvaluation } from './utils/TraceUtils';
+
+const GenAITraceComparisonModal = React.lazy(() =>
+  import('./components/GenAITraceComparisonModal').then((m) => ({ default: m.GenAITraceComparisonModal })),
+);
+import { TestCaseDetail } from './TestCaseDetail';
+
+const GenAiEvaluationTracesReviewModal = React.lazy(() =>
+  import('./components/GenAiEvaluationTracesReviewModal').then((m) => ({
+    default: m.GenAiEvaluationTracesReviewModal,
+  })),
+);
+
+export const GenAiTracesTableBody = React.memo(
+  // eslint-disable-next-line react-component-name/react-component-name -- TODO(FEINF-4716)
+  ({
+    experimentId,
+    selectedColumns,
+    evaluations,
+    selectedEvaluationId,
+    selectedAssessmentInfos,
+    assessmentInfos,
+    assessmentFilters,
+    tableSort,
+    onChangeEvaluationId,
+    getRunColor,
+    runUuid,
+    runDisplayName,
+    compareToRunUuid,
+    compareToRunDisplayName,
+    rowSelection,
+    setRowSelection,
+    exportToEvalsInstanceEnabled = false,
+    getTrace,
+    toggleAssessmentFilter,
+    saveAssessmentsQuery,
+    disableAssessmentTooltips,
+    onTraceTagsEdit,
+    enableRowSelection,
+    enableGrouping = false,
+    allColumns,
+    isTableLoading,
+    isGroupedBySession,
+    searchQuery,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    assessmentCountMetrics,
+    compareAssessmentCountMetrics,
+    fitToContainer = false,
+  }: {
+    experimentId?: string;
+    selectedColumns: TracesTableColumn[];
+    evaluations: EvalTraceComparisonEntry[];
+    selectedEvaluationId: string | undefined;
+    selectedAssessmentInfos: AssessmentInfo[];
+    assessmentInfos: AssessmentInfo[];
+    assessmentFilters: AssessmentFilter[];
+    tableSort: EvaluationsOverviewTableSort | undefined;
+    onChangeEvaluationId: (evaluationId: string | undefined, traceInfo?: ModelTraceInfoV3) => void;
+    getRunColor?: (runUuid: string) => string;
+    // Current run
+    runUuid?: string;
+    runDisplayName?: string;
+    // Other run
+    compareToRunUuid?: string;
+    compareToRunDisplayName?: string;
+    rowSelection?: RowSelectionState;
+    setRowSelection?: OnChangeFn<RowSelectionState>;
+    exportToEvalsInstanceEnabled?: boolean;
+    getTrace?: GetTraceFunction;
+    toggleAssessmentFilter: (
+      assessmentName: string,
+      filterValue: AssessmentValueType,
+      run: string,
+      filterType?: AssessmentFilter['filterType'],
+    ) => void;
+    saveAssessmentsQuery?: SaveAssessmentsQuery;
+    disableAssessmentTooltips?: boolean;
+    onTraceTagsEdit?: (trace: ModelTraceInfoV3) => void;
+    enableRowSelection?: boolean;
+    enableGrouping?: boolean;
+    allColumns: TracesTableColumn[];
+    isTableLoading?: boolean;
+    isGroupedBySession?: boolean;
+    /** When set, matching text in the Request column is highlighted. */
+    searchQuery?: string;
+    // Infinite scroll props (active when shouldUseInfinitePaginatedTraces is true)
+    fetchNextPage?: () => void;
+    hasNextPage?: boolean;
+    isFetchingNextPage?: boolean;
+    // Server-side assessment count data (active when shouldUseInfinitePaginatedTraces is true)
+    assessmentCountMetrics?: AssessmentCountMetrics;
+    compareAssessmentCountMetrics?: AssessmentCountMetrics;
+    fitToContainer?: boolean;
+  }) => {
+    const intl = useIntl();
+    const { theme } = useDesignSystemTheme();
+    const [collapsedHeader, setCollapsedHeader] = useState(false);
+    const lastSelectedRowIdRef = useRef<string | null>(null);
+    const lastSelectedSessionIdRef = useRef<string | null>(null);
+    // Track which sessions are expanded (collapsed by default)
+    const [expandedSessions, setExpandedSessions] = useState<Set<string>>(new Set());
+
+    const toggleSessionExpanded = React.useCallback((sessionId: string) => {
+      setExpandedSessions((prev) => {
+        const next = new Set(prev);
+        if (next.has(sessionId)) {
+          next.delete(sessionId);
+        } else {
+          next.add(sessionId);
+        }
+        return next;
+      });
+    }, []);
+
+    const isComparing = !isNil(compareToRunUuid);
+
+    const evaluationInputs = useMemo(
+      () => selectedColumns.filter((col) => col.type === TracesTableColumnType.INPUT),
+      [selectedColumns],
+    );
+
+    const sortedGroupedColumns = useMemo(
+      () => sortGroupedColumns(selectedColumns, isComparing, isGroupedBySession),
+      [selectedColumns, isComparing, isGroupedBySession],
+    );
+
+    const { columns } = useMemo(() => {
+      if (!enableGrouping) {
+        // Return flat columns without grouping
+        const columnsList = selectedColumns.map((col) =>
+          getColumnConfig(col, {
+            evaluationInputs,
+            isComparing,
+            theme,
+            intl,
+            experimentId,
+            onChangeEvaluationId,
+            onTraceTagsEdit,
+          }),
+        );
+
+        return { columns: sortColumns(columnsList, selectedColumns) };
+      }
+
+      // Create a map of group IDs to their column arrays
+      const groupColumns = new Map<TracesTableColumnGroup, ColumnDef<EvalTraceComparisonEntry>[]>();
+
+      sortedGroupedColumns.forEach((col) => {
+        // Get the group for this column, defaulting to 'Info' if not specified
+        const groupId = col.group || TracesTableColumnGroup.INFO;
+
+        // Initialize the group's columns array if it doesn't exist
+        if (!groupColumns.has(groupId)) {
+          groupColumns.set(groupId, []);
+        }
+
+        // or branch of this should never get hit
+        (groupColumns.get(groupId) || []).push(
+          getColumnConfig(col, {
+            evaluationInputs,
+            isComparing,
+            theme,
+            intl,
+            experimentId,
+            onChangeEvaluationId,
+            onTraceTagsEdit,
+          }),
+        );
+      });
+
+      // Convert the map to an array of column groups and sort columns within each group
+      const topLevelColumns: ColumnDef<EvalTraceComparisonEntry>[] = Array.from(groupColumns.entries()).map(
+        ([groupId, columns]) => ({
+          header: HeaderCellRenderer,
+          meta: {
+            groupId,
+            visibleCount: columns.length,
+            totalCount: allColumns.filter((col) => col.group === groupId).length,
+            enableGrouping,
+          },
+          id: `${groupId}-group`,
+          columns,
+        }),
+      );
+
+      return { columns: topLevelColumns };
+    }, [
+      sortedGroupedColumns,
+      selectedColumns,
+      evaluationInputs,
+      isComparing,
+      onChangeEvaluationId,
+      theme,
+      intl,
+      experimentId,
+      onTraceTagsEdit,
+      enableGrouping,
+      allColumns,
+    ]);
+
+    const { setTable, setSelectedRowIds } = React.useContext(GenAITracesTableContext);
+
+    // Compute grouped rows when session grouping is enabled
+    const { groupedRows, traceIdToTurnMap } = useMemo(
+      () =>
+        isGroupedBySession
+          ? groupTracesBySessionForTable(evaluations, expandedSessions, isComparing)
+          : { groupedRows: [], traceIdToTurnMap: {} },
+      [isGroupedBySession, evaluations, expandedSessions, isComparing],
+    );
+
+    const table = useReactTable<EvalTraceComparisonEntry & { multiline?: boolean }>(
+      'js/packages/web-shared/src/genai-traces-table/GenAiTracesTableBody.tsx',
+      {
+        data: evaluations,
+        columns,
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        enableColumnResizing: true,
+        columnResizeMode: 'onChange',
+        enableRowSelection,
+        enableMultiSort: true,
+        state: {
+          rowSelection,
+        },
+        meta: {
+          getRunColor,
+          traceIdToTurnMap,
+          searchQuery,
+        },
+        onRowSelectionChange: setRowSelection,
+        getRowId: (row) => getRowIdFromEvaluation(row.currentRunValue),
+      },
+    );
+
+    const rowSelectionChangeHandler = useCallback(
+      (row: Row<EvalTraceComparisonEntry>, event: unknown) => {
+        const defaultHandler = row.getToggleSelectedHandler();
+        const eventWithShiftKey = event as KeyboardEvent & MouseEvent;
+        const isShiftPressed = Boolean(eventWithShiftKey?.shiftKey);
+        const currentSelectionState = table.getState().rowSelection ?? {};
+        const isDeselecting = row.getIsSelected();
+        const isOnlySelectedRow =
+          isDeselecting && Object.keys(currentSelectionState).length === 1 && currentSelectionState[row.id];
+
+        if (!isShiftPressed || !lastSelectedRowIdRef.current) {
+          defaultHandler(event);
+          lastSelectedRowIdRef.current = isOnlySelectedRow ? null : row.id;
+          return;
+        }
+
+        const allRows = table.getRowModel().rows;
+        const anchorIndex = allRows.findIndex((tableRow) => tableRow.id === lastSelectedRowIdRef.current);
+        const currentIndex = allRows.findIndex((tableRow) => tableRow.id === row.id);
+
+        if (anchorIndex === -1 || currentIndex === -1) {
+          defaultHandler(event);
+          lastSelectedRowIdRef.current = isOnlySelectedRow ? null : row.id;
+          return;
+        }
+
+        const [start, end] = anchorIndex <= currentIndex ? [anchorIndex, currentIndex] : [currentIndex, anchorIndex];
+        const updatedSelection: RowSelectionState = { ...currentSelectionState };
+
+        for (let index = start; index <= end; index += 1) {
+          const targetRow = allRows[index];
+
+          if (!targetRow.getCanSelect()) {
+            continue;
+          }
+
+          if (isDeselecting) {
+            delete updatedSelection[targetRow.id];
+          } else {
+            updatedSelection[targetRow.id] = true;
+          }
+        }
+
+        table.setRowSelection(updatedSelection);
+        lastSelectedRowIdRef.current = Object.keys(updatedSelection).length === 0 ? null : row.id;
+      },
+      [table],
+    );
+
+    const onToggleSessionSelection = useCallback(
+      (sessionId: string, traces: ModelTraceInfoV3[], event: unknown) => {
+        const traceIds = traces.map((t) => t.trace_id);
+        const currentSelection = table.getState().rowSelection ?? {};
+        const isDeselecting = traceIds.every((id) => currentSelection[id]);
+
+        // Support shift+click to select a range of sessions
+        const eventWithShiftKey = event as KeyboardEvent & MouseEvent;
+        const isShiftPressed = Boolean(eventWithShiftKey?.shiftKey);
+
+        if (isShiftPressed && lastSelectedSessionIdRef.current) {
+          // Find session headers in groupedRows for range selection
+          const sessionHeaders = groupedRows.filter(
+            (r): r is (typeof groupedRows)[number] & { type: 'sessionHeader' } => r.type === 'sessionHeader',
+          );
+          const anchorIndex = sessionHeaders.findIndex((h) => h.sessionId === lastSelectedSessionIdRef.current);
+          const currentIndex = sessionHeaders.findIndex((h) => h.sessionId === sessionId);
+
+          if (anchorIndex !== -1 && currentIndex !== -1) {
+            const [start, end] =
+              anchorIndex <= currentIndex ? [anchorIndex, currentIndex] : [currentIndex, anchorIndex];
+            const updatedSelection: RowSelectionState = { ...currentSelection };
+
+            for (let index = start; index <= end; index += 1) {
+              const header = sessionHeaders[index];
+              header.traces.forEach((t) => {
+                if (isDeselecting) {
+                  delete updatedSelection[t.trace_id];
+                } else {
+                  updatedSelection[t.trace_id] = true;
+                }
+              });
+            }
+
+            table.setRowSelection(updatedSelection);
+            lastSelectedSessionIdRef.current = Object.keys(updatedSelection).length === 0 ? null : sessionId;
+            return;
+          }
+        }
+
+        // Default: toggle single session
+        const updatedSelection: RowSelectionState = { ...currentSelection };
+        traceIds.forEach((id) => {
+          if (isDeselecting) {
+            delete updatedSelection[id];
+          } else {
+            updatedSelection[id] = true;
+          }
+        });
+
+        table.setRowSelection(updatedSelection);
+
+        // Update anchor: clear if nothing is selected after deselecting
+        const hasSelectionAfter = Object.keys(updatedSelection).length > 0;
+        lastSelectedSessionIdRef.current = hasSelectionAfter ? sessionId : null;
+      },
+      [table, groupedRows],
+    );
+
+    // Need to check if rowSelection is undefined, otherwise getIsAllRowsSelected throws an error
+    const allRowSelected = rowSelection !== undefined && table.getIsAllRowsSelected();
+    const someRowSelected = table.getIsSomeRowsSelected();
+
+    useEffect(() => {
+      setTable(table);
+
+      return () => setTable(undefined);
+    }, [table, setTable]);
+
+    useEffect(() => {
+      if (enableRowSelection) {
+        setSelectedRowIds(table.getSelectedRowModel().rows.map((r) => r.id));
+      }
+    }, [table, rowSelection, setSelectedRowIds, enableRowSelection]);
+
+    useEffect(() => {
+      if (!enableRowSelection) {
+        lastSelectedRowIdRef.current = null;
+        lastSelectedSessionIdRef.current = null;
+        return;
+      }
+
+      if (!rowSelection || Object.keys(rowSelection).length === 0) {
+        lastSelectedRowIdRef.current = null;
+        lastSelectedSessionIdRef.current = null;
+      }
+    }, [rowSelection, enableRowSelection]);
+
+    // When the table is empty.
+    const emptyDescription = intl.formatMessage({
+      defaultMessage: ' No traces found. Try clearing your active filters to see more traces.',
+      description: 'Text displayed when no traces are found in the trace review page',
+    });
+
+    const emptyComponent = <Empty description={emptyDescription} image={<SearchIcon />} />;
+    const isEmpty = (): boolean => table.getRowModel().rows.length === 0;
+
+    // Updating sorting when the prop changes.
+    useEffect(() => {
+      // Only do client-side sorting for columns that are not supported by the server.
+      if (!tableSort || SERVER_SORTABLE_INFO_COLUMNS.includes(tableSort.key)) {
+        table.setSorting([]);
+        return;
+      }
+
+      if (tableSort.key === SESSION_COLUMN_ID) {
+        table.setSorting([
+          {
+            id: tableSort.key,
+            desc: !tableSort.asc,
+          },
+          {
+            id: REQUEST_TIME_COLUMN_ID,
+            desc: false,
+          },
+        ]);
+      } else {
+        table.setSorting([
+          {
+            id: tableSort.key,
+            desc: !tableSort.asc,
+          },
+        ]);
+      }
+    }, [tableSort, table]);
+
+    const { rows } = table.getRowModel();
+
+    // The virtualizer needs to know the scrollable container element
+    const tableContainerRef = React.useRef<HTMLDivElement>(null);
+
+    // Use grouped rows count when session grouping is enabled, otherwise use regular rows
+    const virtualizerRowCount = isGroupedBySession ? groupedRows.length : rows.length;
+
+    const rowVirtualizer = useVirtualizer({
+      count: virtualizerRowCount,
+      estimateSize: () => 120, // estimate row height for accurate scrollbar dragging
+      getScrollElement: () => tableContainerRef.current,
+      measureElement:
+        typeof window !== 'undefined' && navigator.userAgent.indexOf('Firefox') === -1
+          ? (element) => element?.getBoundingClientRect().height
+          : undefined,
+      overscan: 10,
+    });
+
+    const virtualItems = rowVirtualizer.getVirtualItems();
+    const virtualizerTotalSize = rowVirtualizer.getTotalSize();
+    const tableHeaderGroups = table.getHeaderGroups();
+    const columnSizingInfo = table.getState().columnSizingInfo;
+
+    const columnSizeInfo = table.getState().columnSizingInfo;
+
+    /**
+     * Instead of calling `column.getSize()` on every render for every header
+     * and especially every data cell (very expensive),
+     * we will calculate all column sizes at once at the root table level in a useMemo
+     * and pass the column sizes down as CSS variables to the <table> element.
+     */
+    const { columnSizeVars, tableWidth } = useMemo(() => {
+      const colSizes: { [key: string]: string } = {};
+      tableHeaderGroups.forEach((headerGroup) => {
+        headerGroup.headers.forEach((header) => {
+          colSizes[`--header-${escapeCssSpecialCharacters(header.column.id)}-size`] = header.getSize() + 'px';
+        });
+      });
+
+      // Calculate the total width of the table by adding up the width of all columns.
+      let tableWidth = 0;
+      if (rows.length > 0) {
+        const row = rows[0] as Row<EvalTraceComparisonEntry>;
+        const cells = row.getVisibleCells();
+        cells.forEach((cell) => {
+          colSizes[`--col-${escapeCssSpecialCharacters(cell.column.id)}-size`] = cell.column.getSize() + 'px';
+          tableWidth += cell.column.getSize();
+        });
+      }
+
+      return { columnSizeVars: colSizes, tableWidth: tableWidth + 'px' };
+      // columnSizingInfo is not directly referenced but is needed to trigger recalculation
+      // when columns are resized, since getSize() reads from this state internally.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [tableHeaderGroups, rows, columnSizingInfo]);
+
+    // Compute assessment aggregates.
+    // When server-side assessment count metrics are available (infinite pagination),
+    // use them for categorical assessments to get accurate counts across all traces.
+    const assessmentNameToAggregates = useMemo(() => {
+      const result: Record<string, AssessmentAggregates> = {};
+      const currentData = !assessmentCountMetrics?.isLoading ? assessmentCountMetrics?.data : undefined;
+      const otherData = !compareAssessmentCountMetrics?.isLoading ? compareAssessmentCountMetrics?.data : undefined;
+      for (const assessmentInfo of selectedAssessmentInfos) {
+        // The synthetic "Result" assessment exists only on the traces (no
+        // server-side count metric), so always aggregate it from the loaded
+        // traces; metric-based counts would be empty (0%).
+        if (currentData && assessmentInfo.dtype !== 'unknown' && assessmentInfo.name !== 'Result') {
+          result[assessmentInfo.name] = buildAggregatesFromCountMetrics(
+            assessmentInfo,
+            currentData,
+            assessmentFilters,
+            otherData,
+          );
+        } else {
+          result[assessmentInfo.name] = getAssessmentAggregates(assessmentInfo, evaluations, assessmentFilters);
+        }
+      }
+      return result;
+    }, [
+      selectedAssessmentInfos,
+      evaluations,
+      assessmentFilters,
+      assessmentCountMetrics,
+      compareAssessmentCountMetrics,
+    ]);
+
+    const evalEntryMatchesEvaluationId = useCallback((evaluationId: string, entry?: RunEvaluationTracesDataEntry) => {
+      if (isV4TraceId(evaluationId) && entry?.fullTraceId === evaluationId) {
+        return true;
+      }
+      return entry?.evaluationId === evaluationId;
+    }, []);
+
+    // Find the selected evaluation entry to derive experimentId and comparison trace IDs.
+    const selectedEvaluation = useMemo(() => {
+      if (!selectedEvaluationId) {
+        return undefined;
+      }
+      return evaluations.find(
+        (entry) =>
+          evalEntryMatchesEvaluationId(selectedEvaluationId, entry.currentRunValue) ||
+          evalEntryMatchesEvaluationId(selectedEvaluationId, entry.otherRunValue),
+      );
+    }, [selectedEvaluationId, evaluations, evalEntryMatchesEvaluationId]);
+
+    // Derive experimentId from the selected evaluation's trace_location, falling back to the prop
+    const selectedEvaluationExperimentId = useMemo(
+      () =>
+        getExperimentIdFromTraceLocation(selectedEvaluation?.currentRunValue?.traceInfo?.trace_location) ??
+        getExperimentIdFromTraceLocation(selectedEvaluation?.otherRunValue?.traceInfo?.trace_location) ??
+        experimentId,
+      [selectedEvaluation, experimentId],
+    );
+
+    // Get the trace IDs for the comparison modal.
+    // TODO: after the new comparison modal is rolled out, we can remove the comparison capabilities from <GenAiEvaluationTracesReviewModal>
+    const comparedTraceIds = useMemo(() => {
+      if (!shouldUseUnifiedModelTraceComparisonUI()) {
+        return null;
+      }
+
+      if (selectedEvaluation?.otherRunValue?.fullTraceId && selectedEvaluation?.currentRunValue?.fullTraceId) {
+        return [selectedEvaluation.currentRunValue.fullTraceId, selectedEvaluation.otherRunValue.fullTraceId];
+      }
+      return null;
+    }, [selectedEvaluation]);
+
+    const handleScrollForInfiniteFetch = useCallback(
+      (e: React.UIEvent<HTMLDivElement>) => {
+        if (!fetchNextPage || !hasNextPage || isFetchingNextPage) return;
+        const { scrollHeight, scrollTop, clientHeight } = e.currentTarget;
+        if (scrollHeight - scrollTop - clientHeight < 200) {
+          fetchNextPage();
+        }
+      },
+      [fetchNextPage, hasNextPage, isFetchingNextPage],
+    );
+
+    // Auto-fetch next page while the container isn't tall enough to scroll
+    useEffect(() => {
+      const container = tableContainerRef.current;
+      if (!container || !fetchNextPage || !hasNextPage || isFetchingNextPage) return;
+      if (container.scrollHeight <= container.clientHeight) {
+        fetchNextPage();
+      }
+    }, [fetchNextPage, hasNextPage, isFetchingNextPage, virtualizerTotalSize]);
+
+    return (
+      <>
+        <div
+          className="container"
+          ref={tableContainerRef}
+          onScroll={handleScrollForInfiniteFetch}
+          css={{
+            height: '100%',
+            position: 'relative',
+            overflowY: 'auto',
+            overflowX: 'auto',
+          }}
+        >
+          <Table
+            css={{
+              width: fitToContainer ? '100%' : tableWidth,
+              minWidth: '100%',
+              ...columnSizeVars, // Define column sizes on the <table> element
+            }}
+            empty={isEmpty() && !isTableLoading ? emptyComponent : undefined}
+            someRowsSelected={enableRowSelection ? someRowSelected || allRowSelected : undefined}
+          >
+            <GenAiTracesTableHeader
+              headerGroups={table.getHeaderGroups()}
+              enableRowSelection={enableRowSelection}
+              enableGrouping={enableGrouping}
+              selectedAssessmentInfos={selectedAssessmentInfos}
+              assessmentNameToAggregates={assessmentNameToAggregates}
+              assessmentFilters={assessmentFilters}
+              toggleAssessmentFilter={toggleAssessmentFilter}
+              runDisplayName={runDisplayName}
+              compareToRunUuid={compareToRunUuid}
+              compareToRunDisplayName={compareToRunDisplayName}
+              disableAssessmentTooltips={disableAssessmentTooltips}
+              collapsedHeader={collapsedHeader}
+              setCollapsedHeader={setCollapsedHeader}
+              isComparing={isComparing}
+              allRowSelected={allRowSelected}
+              someRowSelected={someRowSelected}
+              toggleAllRowsSelectedHandler={table.getToggleAllRowsSelectedHandler}
+            />
+            {isTableLoading ? (
+              <GenAITracesTableBodySkeleton table={table} />
+            ) : isGroupedBySession ? (
+              <MemoizedGenAiTracesTableSessionGroupedRows
+                rows={rows}
+                groupedRows={groupedRows}
+                isComparing={isComparing}
+                enableRowSelection={enableRowSelection}
+                virtualItems={virtualItems}
+                virtualizerTotalSize={virtualizerTotalSize}
+                virtualizerMeasureElement={rowVirtualizer.measureElement}
+                rowSelectionState={rowSelection}
+                selectedColumns={sortedGroupedColumns}
+                expandedSessions={expandedSessions}
+                toggleSessionExpanded={toggleSessionExpanded}
+                onToggleSessionSelection={onToggleSessionSelection}
+                experimentId={experimentId}
+                getRunColor={getRunColor}
+                runUuid={runUuid}
+                compareToRunUuid={compareToRunUuid}
+                rowSelectionChangeHandler={rowSelectionChangeHandler}
+                searchQuery={searchQuery}
+              />
+            ) : (
+              <MemoizedGenAiTracesTableBodyRows
+                rows={rows}
+                isComparing={isComparing}
+                enableRowSelection={enableRowSelection}
+                virtualItems={virtualItems}
+                virtualizerTotalSize={virtualizerTotalSize}
+                virtualizerMeasureElement={rowVirtualizer.measureElement}
+                rowSelectionState={rowSelection}
+                selectedColumns={selectedColumns}
+                rowSelectionChangeHandler={rowSelectionChangeHandler}
+              />
+            )}
+            {isFetchingNextPage && <TableSkeletonRows table={table} />}
+          </Table>
+        </div>
+        <React.Suspense fallback={null}>
+          {comparedTraceIds && shouldUseUnifiedModelTraceComparisonUI() ? (
+            <GenAITraceComparisonModal
+              traceIds={comparedTraceIds}
+              onClose={() => onChangeEvaluationId(undefined)}
+              // prettier-ignore
+            />
+          ) : (
+            selectedEvaluationId &&
+            selectedEvaluation &&
+            (() => {
+              const curId = selectedEvaluation.currentRunValue?.evaluationId;
+              const idx = rows.findIndex((row) => row.original?.currentRunValue?.evaluationId === curId);
+              const evalIdAt = (j: number) => rows[j]?.original?.currentRunValue?.evaluationId;
+              return (
+                <TestCaseDetail
+                  evaluation={selectedEvaluation}
+                  experimentId={selectedEvaluationExperimentId ?? experimentId}
+                  assessmentInfos={assessmentInfos}
+                  onClose={() => onChangeEvaluationId(undefined)}
+                  onPrev={idx > 0 ? () => onChangeEvaluationId(evalIdAt(idx - 1)) : undefined}
+                  onNext={idx >= 0 && idx < rows.length - 1 ? () => onChangeEvaluationId(evalIdAt(idx + 1)) : undefined}
+                />
+              );
+            })()
+          )}
+        </React.Suspense>
+      </>
+    );
+  },
+);

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/GenAiTracesTableBody.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/GenAiTracesTableBody.utils.tsx
@@ -1,0 +1,418 @@
+import type { ColumnDef } from '@tanstack/react-table';
+import { isNil } from 'lodash';
+
+import type { ThemeType } from '@databricks/design-system';
+import { Tooltip } from '@databricks/design-system';
+import type { IntlShape } from '@databricks/i18n';
+
+import { traceInfoSortingFn } from './GenAiTracesTable.utils';
+import {
+  AssessmentCell,
+  expectationCellRenderer,
+  inputColumnCellRenderer,
+  traceInfoCellRenderer,
+} from './cellRenderers/rendererFunctions';
+import {
+  getEvaluationResultAssessmentValue,
+  KnownEvaluationResultAssessmentStringValue,
+  stringifyValue,
+} from './components/GenAiEvaluationTracesReview.utils';
+import { RESPONSE_COLUMN_ID, TRACE_ID_COLUMN_ID } from './hooks/useTableColumns';
+import type {
+  AssessmentValueType,
+  EvalTraceComparisonEntry,
+  TracesTableColumn,
+  AssessmentInfo,
+  RunEvaluationResultAssessment,
+} from './types';
+import { TracesTableColumnType } from './types';
+import { timeSinceStr } from './utils/DisplayUtils';
+import type { ModelTraceInfoV3 } from '../model-trace-explorer/ModelTrace.types';
+
+const DEFAULT_ASSESSMENT_CELL_WIDTH_PX = 120;
+const DEFAULT_ASSESSMENTS_CELL_WIDTH_COMPARE_PX = 120;
+const MAX_ASSESSMENT_COLUMN_SIZE = 200;
+const DEFAULT_INPUT_COLUMNS_TOTAL_WIDTH_PX = 300;
+
+export function compareAssessmentValues(
+  assessmentInfo: AssessmentInfo,
+  a: AssessmentValueType,
+  b: AssessmentValueType,
+): 'greater' | 'less' | 'equal' {
+  if (assessmentInfo.dtype === 'pass-fail') {
+    if (a === b) {
+      return 'equal';
+    }
+    if (a === KnownEvaluationResultAssessmentStringValue.YES) {
+      return 'greater';
+    } else if (a === KnownEvaluationResultAssessmentStringValue.NO) {
+      return 'less';
+    } else {
+      return !isNil(b) ? 'less' : 'equal';
+    }
+  } else if (assessmentInfo.dtype === 'boolean') {
+    if (a === b) {
+      return 'equal';
+    }
+    if (a === true) {
+      return 'greater';
+    } else if (a === false) {
+      return 'less';
+    } else {
+      return !isNil(b) ? 'less' : 'equal';
+    }
+  } else if (assessmentInfo.dtype === 'string') {
+    // Compare the strings in alphabetical sort order.
+    if (a === b) {
+      return 'equal';
+    }
+    if (a === null) {
+      return 'less';
+    }
+    if (b === null) {
+      return 'greater';
+    }
+    const aString = a as string | undefined;
+    const bString = b as string | undefined;
+    if (isNil(aString)) {
+      return 'less';
+    } else if (isNil(bString)) {
+      return 'greater';
+    }
+    return aString.toString().localeCompare(bString.toString()) === 1 ? 'greater' : 'less';
+  } else if (assessmentInfo.dtype === 'numeric') {
+    if (a === b) {
+      return 'equal';
+    }
+    if (a === null) {
+      return 'less';
+    }
+    if (b === null) {
+      return 'greater';
+    }
+    const aNumber = a as number;
+    const bNumber = b as number;
+    return aNumber > bNumber ? 'greater' : 'less';
+  }
+
+  return 'equal';
+}
+
+export const formatResponseTitle = (outputs: string) => {
+  let outputsTitle = outputs;
+
+  try {
+    const parsedOutputs = JSON.parse(outputs);
+
+    // Try to parse OpenAI messages
+    const choices = parsedOutputs['response']['choices'];
+    if (Array.isArray(choices) && !isNil(choices[0]?.message?.content)) {
+      outputsTitle = choices[0]?.message?.content;
+    } else {
+      outputsTitle = stringifyValue(outputs);
+    }
+  } catch {
+    outputsTitle = stringifyValue(outputs);
+  }
+
+  return outputsTitle;
+};
+
+export const getColumnConfig = (
+  col: TracesTableColumn,
+  {
+    evaluationInputs,
+    isComparing,
+    theme,
+    intl,
+    experimentId,
+    onChangeEvaluationId,
+    onTraceTagsEdit,
+  }: {
+    evaluationInputs: TracesTableColumn[];
+    isComparing: boolean;
+    theme: ThemeType;
+    intl: IntlShape;
+    experimentId?: string;
+    onChangeEvaluationId: (evaluationId: string | undefined, traceInfo?: ModelTraceInfoV3) => void;
+    onTraceTagsEdit?: (trace: ModelTraceInfoV3) => void;
+  },
+): ColumnDef<EvalTraceComparisonEntry> => {
+  const baseColConfig: ColumnDef<EvalTraceComparisonEntry> = {
+    header: col.label,
+    id: col.id,
+    accessorFn: (originalRow) => originalRow,
+  };
+
+  switch (col.type) {
+    case TracesTableColumnType.INPUT:
+      return {
+        ...baseColConfig,
+        sortingFn: (a, b) => {
+          const aValue = a.getValue(col.id) as EvalTraceComparisonEntry;
+          const bValue = b.getValue(col.id) as EvalTraceComparisonEntry;
+          const aSortValue = {
+            request: aValue.currentRunValue?.inputs[col.id] || aValue.otherRunValue?.inputs[col.id] || '',
+            evalId: aValue.currentRunValue?.evaluationId || aValue.otherRunValue?.evaluationId || '',
+          };
+          const bSortValue = {
+            request: bValue.currentRunValue?.inputs[col.id] || bValue.otherRunValue?.inputs[col.id] || '',
+            evalId: bValue.currentRunValue?.evaluationId || bValue.otherRunValue?.evaluationId || '',
+          };
+
+          return JSON.stringify(aSortValue).localeCompare(JSON.stringify(bSortValue));
+        },
+        size: DEFAULT_INPUT_COLUMNS_TOTAL_WIDTH_PX / evaluationInputs.length,
+        minSize: 120,
+        cell: (cell) =>
+          inputColumnCellRenderer(
+            onChangeEvaluationId,
+            cell,
+            isComparing,
+            theme,
+            col.id,
+            (cell?.table?.options?.meta as any)?.getRunColor,
+          ),
+      };
+    case TracesTableColumnType.ASSESSMENT:
+      return {
+        ...baseColConfig,
+        accessorFn: (originalRow) => {
+          return { isComparing, assessmentInfo: col.assessmentInfo, comparisonEntry: originalRow };
+        },
+        sortingFn: (a, b) => {
+          const { comparisonEntry: aValue } = a.getValue(col.id) as {
+            comparisonEntry: EvalTraceComparisonEntry;
+          };
+          const { comparisonEntry: bValue } = b.getValue(col.id) as {
+            comparisonEntry: EvalTraceComparisonEntry;
+          };
+          if (col.assessmentInfo) {
+            const aAssessment = {
+              currentValue: aValue.currentRunValue?.responseAssessmentsByName[col.assessmentInfo.name]?.[0],
+              otherValue: aValue.otherRunValue?.responseAssessmentsByName[col.assessmentInfo.name]?.[0],
+            };
+            const bAssessment = {
+              currentValue: bValue.currentRunValue?.responseAssessmentsByName[col.assessmentInfo.name]?.[0],
+              otherValue: bValue.otherRunValue?.responseAssessmentsByName[col.assessmentInfo.name]?.[0],
+            };
+            return sortCompareAssessments(col.assessmentInfo, aAssessment, bAssessment);
+          }
+          return 0;
+        },
+        maxSize: MAX_ASSESSMENT_COLUMN_SIZE,
+        size: isComparing ? DEFAULT_ASSESSMENTS_CELL_WIDTH_COMPARE_PX : DEFAULT_ASSESSMENT_CELL_WIDTH_PX,
+        minSize: isComparing ? DEFAULT_ASSESSMENTS_CELL_WIDTH_COMPARE_PX : DEFAULT_ASSESSMENT_CELL_WIDTH_PX,
+        cell: (cell) => {
+          const { isComparing, assessmentInfo, comparisonEntry } = cell.getValue() as {
+            isComparing: boolean;
+            assessmentInfo: AssessmentInfo;
+            comparisonEntry: EvalTraceComparisonEntry;
+          };
+          return (
+            <AssessmentCell
+              isComparing={isComparing}
+              assessmentInfo={assessmentInfo}
+              comparisonEntry={comparisonEntry}
+            />
+          );
+        },
+      };
+    case TracesTableColumnType.EXPECTATION:
+      return {
+        ...baseColConfig,
+        accessorFn: (originalRow) => {
+          return { isComparing, expectationName: col.expectationName, comparisonEntry: originalRow };
+        },
+        maxSize: MAX_ASSESSMENT_COLUMN_SIZE,
+        size: isComparing ? DEFAULT_ASSESSMENTS_CELL_WIDTH_COMPARE_PX : DEFAULT_ASSESSMENT_CELL_WIDTH_PX,
+        minSize: isComparing ? DEFAULT_ASSESSMENTS_CELL_WIDTH_COMPARE_PX : DEFAULT_ASSESSMENT_CELL_WIDTH_PX,
+        cell: (cell) => {
+          const { isComparing, expectationName, comparisonEntry } = cell.getValue() as {
+            isComparing: boolean;
+            expectationName: string;
+            comparisonEntry: EvalTraceComparisonEntry;
+          };
+          return expectationCellRenderer(theme, intl, isComparing, expectationName, comparisonEntry);
+        },
+      };
+    case TracesTableColumnType.TRACE_INFO:
+      return {
+        ...baseColConfig,
+        accessorFn: (originalRow) => {
+          return { isComparing, comparisonEntry: originalRow };
+        },
+        sortingFn: (a, b) => {
+          const { comparisonEntry: aValue } = a.getValue(col.id) as {
+            comparisonEntry: EvalTraceComparisonEntry;
+          };
+          const { comparisonEntry: bValue } = b.getValue(col.id) as {
+            comparisonEntry: EvalTraceComparisonEntry;
+          };
+
+          return traceInfoSortingFn(aValue?.currentRunValue?.traceInfo, bValue?.currentRunValue?.traceInfo, col.id);
+        },
+        size: col.id === RESPONSE_COLUMN_ID ? 300 : col.id === TRACE_ID_COLUMN_ID ? 260 : 100,
+        minSize: col.id === RESPONSE_COLUMN_ID ? 120 : col.id === TRACE_ID_COLUMN_ID ? 200 : 100,
+        cell: (cell) => {
+          const { isComparing, comparisonEntry } = cell.getValue() as {
+            isComparing: boolean;
+            comparisonEntry: EvalTraceComparisonEntry;
+          };
+
+          const { traceIdToTurnMap, searchQuery } = (cell.table?.options?.meta as any) ?? {};
+
+          return traceInfoCellRenderer(
+            isComparing,
+            col.id,
+            comparisonEntry,
+            onChangeEvaluationId,
+            intl,
+            theme,
+            experimentId,
+            onTraceTagsEdit,
+            traceIdToTurnMap,
+            searchQuery,
+          );
+        },
+      };
+    case TracesTableColumnType.INTERNAL_MONITOR_REQUEST_TIME:
+      return {
+        ...baseColConfig,
+        accessorFn: (originalRow) => originalRow.currentRunValue?.requestTime,
+        sortingFn: (a, b) => {
+          const aValue = a.getValue(col.id);
+          const bValue = b.getValue(col.id);
+          return JSON.stringify(aValue).localeCompare(JSON.stringify(bValue));
+        },
+        size: 100,
+        minSize: 100,
+        cell: (cell) => {
+          const requestTime = cell.getValue() as string | undefined;
+          if (!requestTime) {
+            return null;
+          }
+          const date = new Date(requestTime);
+          return (
+            <Tooltip
+              componentId="mlflow.experiment-evaluation-monitoring.trace-info-hover-request-time"
+              content={date.toLocaleString(navigator.language, { timeZoneName: 'short' })}
+            >
+              <span>{timeSinceStr(date)}</span>
+            </Tooltip>
+          );
+        },
+      };
+    default:
+      return baseColConfig;
+  }
+};
+
+export function sortCompareAssessments(
+  assessmentInfo: AssessmentInfo,
+  a: {
+    currentValue?: RunEvaluationResultAssessment;
+    otherValue?: RunEvaluationResultAssessment;
+  },
+  b: {
+    currentValue?: RunEvaluationResultAssessment;
+    otherValue?: RunEvaluationResultAssessment;
+  },
+) {
+  const aCurrentValue = a.currentValue ? getEvaluationResultAssessmentValue(a.currentValue) : undefined;
+  const bCurrentValue = b.currentValue ? getEvaluationResultAssessmentValue(b.currentValue) : undefined;
+  const aOtherValue = a.otherValue ? getEvaluationResultAssessmentValue(a.otherValue) : undefined;
+  const bOtherValue = b.otherValue ? getEvaluationResultAssessmentValue(b.otherValue) : undefined;
+
+  if (assessmentInfo.dtype === 'pass-fail') {
+    // Priorities:
+    // Pass => Fail
+    // Fail
+    // Fail => Pass
+    // Pass
+    const aIsPassToFail =
+      aOtherValue === KnownEvaluationResultAssessmentStringValue.YES &&
+      aCurrentValue === KnownEvaluationResultAssessmentStringValue.NO;
+    const bIsPassToFail =
+      bOtherValue === KnownEvaluationResultAssessmentStringValue.YES &&
+      bCurrentValue === KnownEvaluationResultAssessmentStringValue.NO;
+    const aIsFailToPass =
+      aOtherValue === KnownEvaluationResultAssessmentStringValue.NO &&
+      aCurrentValue === KnownEvaluationResultAssessmentStringValue.YES;
+    const bIsFailToPass =
+      bOtherValue === KnownEvaluationResultAssessmentStringValue.NO &&
+      bCurrentValue === KnownEvaluationResultAssessmentStringValue.YES;
+    const aIsFailToFail =
+      aOtherValue === KnownEvaluationResultAssessmentStringValue.NO &&
+      aCurrentValue === KnownEvaluationResultAssessmentStringValue.NO;
+    const bIsFailToFail =
+      bOtherValue === KnownEvaluationResultAssessmentStringValue.NO &&
+      bCurrentValue === KnownEvaluationResultAssessmentStringValue.NO;
+    const aIsPassToPass =
+      aOtherValue === KnownEvaluationResultAssessmentStringValue.YES &&
+      aCurrentValue === KnownEvaluationResultAssessmentStringValue.YES;
+    const bIsPassToPass =
+      bOtherValue === KnownEvaluationResultAssessmentStringValue.YES &&
+      bCurrentValue === KnownEvaluationResultAssessmentStringValue.YES;
+
+    // Sort according to priority
+    if (aIsPassToFail && !bIsPassToFail) return -1;
+    if (!aIsPassToFail && bIsPassToFail) return 1;
+
+    if (aIsFailToFail && !bIsFailToFail) return -1;
+    if (!aIsFailToFail && bIsFailToFail) return 1;
+
+    if (aIsFailToPass && !bIsFailToPass) return -1;
+    if (!aIsFailToPass && bIsFailToPass) return 1;
+
+    if (aIsPassToPass && !bIsPassToPass) return -1;
+    if (!aIsPassToPass && bIsPassToPass) return 1;
+
+    return sortPassFailAssessments(a.currentValue, b.currentValue);
+  } else {
+    if (aCurrentValue === bCurrentValue) {
+      return 0;
+    }
+    if (!isNil(aCurrentValue) && !isNil(bCurrentValue)) {
+      return aCurrentValue > bCurrentValue ? 1 : -1;
+    } else {
+      return isNil(aCurrentValue) ? -1 : 1;
+    }
+  }
+}
+
+function sortPassFailAssessments(a?: RunEvaluationResultAssessment, b?: RunEvaluationResultAssessment) {
+  if (!a && b) {
+    return 1;
+  } else if (a && !b) {
+    return -1;
+  }
+  if (!a || !b) {
+    return 0;
+  }
+
+  const aIsPassing =
+    a.stringValue === KnownEvaluationResultAssessmentStringValue.YES
+      ? true
+      : a.stringValue === KnownEvaluationResultAssessmentStringValue.NO
+        ? false
+        : undefined;
+  const bIsPassing =
+    b.stringValue === KnownEvaluationResultAssessmentStringValue.YES
+      ? true
+      : b.stringValue === KnownEvaluationResultAssessmentStringValue.NO
+        ? false
+        : undefined;
+
+  if (aIsPassing === bIsPassing) {
+    return 0;
+  }
+  // Null values get sorted last.
+  if (aIsPassing === undefined) {
+    return 1;
+  }
+  if (bIsPassing === undefined) {
+    return -1;
+  }
+  return aIsPassing ? 1 : -1;
+}

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/GenAiTracesTableBodyRows.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/GenAiTracesTableBodyRows.tsx
@@ -1,0 +1,183 @@
+import type { Cell, Row, RowSelectionState } from '@tanstack/react-table';
+import { flexRender } from '@tanstack/react-table';
+import type { VirtualItem } from '@tanstack/react-virtual';
+import React from 'react';
+
+import { TableCell, TableRow, TableRowSelectCell, Tooltip, useDesignSystemTheme } from '@databricks/design-system';
+import { useIntl } from '@databricks/i18n';
+
+import type { TracesTableColumn, EvalTraceComparisonEntry } from './types';
+import { escapeCssSpecialCharacters } from './utils/DisplayUtils';
+
+interface GenAiTracesTableBodyRowsProps {
+  rows: Row<EvalTraceComparisonEntry>[];
+  isComparing: boolean;
+  enableRowSelection?: boolean;
+  virtualItems: VirtualItem<Element>[];
+  virtualizerTotalSize: number;
+  virtualizerMeasureElement: (node: HTMLDivElement | null) => void;
+  // eslint-disable-next-line react/no-unused-prop-types
+  rowSelectionState: RowSelectionState | undefined;
+  selectedColumns: TracesTableColumn[];
+  rowSelectionChangeHandler?: (row: Row<EvalTraceComparisonEntry>, event: unknown) => void;
+}
+
+export const GenAiTracesTableBodyRows = React.memo(
+  // eslint-disable-next-line react-component-name/react-component-name -- TODO(FEINF-4716)
+  ({
+    rows,
+    isComparing,
+    enableRowSelection,
+    virtualItems,
+    virtualizerTotalSize,
+    virtualizerMeasureElement,
+    selectedColumns,
+    rowSelectionChangeHandler,
+  }: GenAiTracesTableBodyRowsProps) => {
+    return (
+      <div
+        style={{
+          height: `${virtualizerTotalSize}px`, // tells scrollbar how big the table is
+          position: 'relative', // needed for absolute positioning of rows
+          display: 'grid',
+        }}
+      >
+        {virtualItems.map((virtualRow) => {
+          const row = rows[virtualRow.index] as Row<EvalTraceComparisonEntry>;
+          const exportableTrace = row.original.currentRunValue && !isComparing;
+          return (
+            <div
+              key={virtualRow.key}
+              data-index={virtualRow.index}
+              ref={(node) => virtualizerMeasureElement(node)}
+              style={{
+                position: 'absolute',
+                transform: `translate3d(0, ${virtualRow.start}px, 0)`,
+                willChange: 'transform',
+                width: '100%',
+              }}
+            >
+              <GenAiTracesTableBodyRow
+                row={row}
+                exportableTrace={exportableTrace}
+                enableRowSelection={enableRowSelection}
+                isSelected={enableRowSelection ? row.getIsSelected() : undefined}
+                isComparing={isComparing}
+                selectedColumns={selectedColumns}
+                rowSelectionChangeHandler={rowSelectionChangeHandler}
+              />
+            </div>
+          );
+        })}
+      </div>
+    );
+  },
+);
+
+// Memoized wrapper for the body rows which is used during column resizing
+export const MemoizedGenAiTracesTableBodyRows = React.memo(GenAiTracesTableBodyRows) as typeof GenAiTracesTableBodyRows;
+
+export const GenAiTracesTableBodyRow = React.memo(
+  // eslint-disable-next-line react-component-name/react-component-name -- TODO(FEINF-4716)
+  ({
+    row,
+    exportableTrace,
+    enableRowSelection,
+    isComparing,
+    isSelected,
+    selectedColumns, // Prop needed to force row re-rending when selectedColumns change
+    rowSelectionChangeHandler,
+    displayCheckbox = true,
+  }: {
+    row: Row<EvalTraceComparisonEntry>;
+    exportableTrace?: boolean;
+    enableRowSelection?: boolean;
+    isComparing: boolean;
+    isSelected?: boolean;
+    selectedColumns: TracesTableColumn[];
+    rowSelectionChangeHandler?: (row: Row<EvalTraceComparisonEntry>, event: unknown) => void;
+    /** When false, renders a spacer instead of a checkbox in the select cell area */
+    displayCheckbox?: boolean;
+  }) => {
+    const cells = row.getVisibleCells();
+    const intl = useIntl();
+    const { theme } = useDesignSystemTheme();
+    const rowSelectHandler = rowSelectionChangeHandler
+      ? (event: unknown) => rowSelectionChangeHandler(row, event)
+      : row.getToggleSelectedHandler();
+    return (
+      <>
+        <TableRow>
+          <div
+            css={{ display: 'flex', overflow: 'hidden', flexShrink: 0, gap: !displayCheckbox ? theme.spacing.xs : 0 }}
+          >
+            {enableRowSelection &&
+              (!displayCheckbox ? (
+                <>
+                  <TableRowSelectCell
+                    componentId="mlflow.experiment-evaluation-monitoring.evals-logs-table-cell.spacer"
+                    noCheckbox
+                  />
+                  {/* Spacer matching the chevron button width in the session header */}
+                  <div css={{ width: theme.general.heightSm, flexShrink: 0 }} />
+                </>
+              ) : (
+                <Tooltip
+                  componentId="mlflow.experiment-evaluation-monitoring.evals-logs-table-cell-tooltip"
+                  content={
+                    isComparing
+                      ? intl.formatMessage({
+                          defaultMessage: 'You cannot select rows when comparing runs',
+                          description: 'Tooltip message for the select button when comparing runs',
+                        })
+                      : !exportableTrace
+                        ? intl.formatMessage({
+                            defaultMessage:
+                              'This trace is not exportable because it either contains an error or the response is not a ChatCompletionResponse.',
+                            description: 'Tooltip message for the export button when the trace is not exportable',
+                          })
+                        : null
+                  }
+                >
+                  <TableRowSelectCell
+                    componentId="mlflow.experiment-evaluation-monitoring.evals-logs-table-cell"
+                    checked={isSelected && exportableTrace}
+                    onChange={rowSelectHandler}
+                    isDisabled={isComparing || !exportableTrace}
+                  />
+                </Tooltip>
+              ))}
+          </div>
+          {cells.map((cell) => (
+            <GenAiTracesTableBodyRowCell cell={cell} key={cell.id} />
+          ))}
+        </TableRow>
+      </>
+    );
+  },
+);
+
+// eslint-disable-next-line react-component-name/react-component-name -- TODO(FEINF-4716)
+export const GenAiTracesTableBodyRowCell = React.memo(({ cell }: { cell: Cell<EvalTraceComparisonEntry, unknown> }) => {
+  const { theme } = useDesignSystemTheme();
+  return (
+    <TableCell
+      key={cell.id}
+      style={{
+        flex: `1 1 var(--col-${escapeCssSpecialCharacters(cell.column.id)}-size)`,
+      }}
+      css={{
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        // First span, make it width full.
+        '> span:first-of-type': {
+          padding: `${theme.spacing.xs}px 0px`,
+          width: '100%',
+        },
+      }}
+    >
+      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+    </TableCell>
+  );
+});

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/GenAiTracesTableFilter.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/GenAiTracesTableFilter.tsx
@@ -1,0 +1,262 @@
+import { useCallback } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+
+import {
+  Button,
+  ChevronDownIcon,
+  useDesignSystemTheme,
+  FilterIcon,
+  Popover,
+  PlusIcon,
+  XCircleFillIcon,
+  Spinner,
+  DangerIcon,
+} from '@databricks/design-system';
+import { FormattedMessage, useIntl } from '@databricks/i18n';
+
+import { TableFilterItem } from './components/filters/TableFilterItem';
+import type { AssessmentInfo, TableFilterFormState, TableFilter, TableFilterOptions, TracesTableColumn } from './types';
+import { FilterOperator } from './types';
+
+export const GenAiTracesTableFilter = ({
+  filters,
+  setFilters,
+  assessmentInfos,
+  experimentId,
+  tableFilterOptions,
+  allColumns,
+  isLoading,
+  isError,
+  usesV4APIs,
+}: {
+  filters: TableFilter[];
+  setFilters: (filters: TableFilter[]) => void;
+  assessmentInfos: AssessmentInfo[];
+  experimentId?: string;
+  tableFilterOptions: TableFilterOptions;
+  allColumns: TracesTableColumn[];
+  isLoading?: boolean;
+  isError?: boolean;
+  usesV4APIs?: boolean;
+}) => {
+  const intl = useIntl();
+  const { theme } = useDesignSystemTheme();
+
+  const hasActiveFilters = filters.length > 0;
+
+  const clearFilters = useCallback(() => {
+    setFilters([]);
+  }, [setFilters]);
+
+  return (
+    <Popover.Root componentId="mlflow.genai_traces_table_filter.filter_dropdown">
+      <Popover.Trigger asChild>
+        <Button
+          endIcon={<ChevronDownIcon />}
+          componentId="mlflow.evaluations_review.table_ui.filter_button"
+          css={{
+            border: hasActiveFilters ? `1px solid ${theme.colors.actionDefaultBorderFocus} !important` : '',
+            backgroundColor: hasActiveFilters ? `${theme.colors.actionDefaultBackgroundHover} !important` : '',
+          }}
+        >
+          <div
+            css={{
+              display: 'flex',
+              gap: theme.spacing.sm,
+              alignItems: 'center',
+            }}
+          >
+            <FilterIcon />
+            {intl.formatMessage(
+              {
+                defaultMessage: 'Filters{numFilters}',
+                description: 'Evaluation review > evaluations list > filter dropdown button',
+              },
+              {
+                numFilters: hasActiveFilters ? ` (${filters.length})` : '',
+              },
+            )}
+            {hasActiveFilters && (
+              <XCircleFillIcon
+                css={{
+                  fontSize: 12,
+                  cursor: 'pointer',
+                  color: theme.colors.grey400,
+                  '&:hover': {
+                    color: theme.colors.grey600,
+                  },
+                }}
+                onClick={() => {
+                  clearFilters();
+                }}
+              />
+            )}
+          </div>
+        </Button>
+      </Popover.Trigger>
+      <Popover.Content align="start" css={{ padding: theme.spacing.md }}>
+        {isError ? (
+          <div
+            css={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: theme.spacing.xs,
+              padding: `${theme.spacing.md}px`,
+              color: theme.colors.textValidationDanger,
+            }}
+            data-testid="filter-dropdown-error"
+          >
+            <DangerIcon />
+            <FormattedMessage
+              defaultMessage="Fetching traces failed"
+              description="Error message for fetching traces failed"
+            />
+          </div>
+        ) : isLoading ? (
+          <div
+            css={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: theme.spacing.xs,
+              padding: `${theme.spacing.md}px`,
+              color: theme.colors.textSecondary,
+            }}
+            data-testid="filter-dropdown-loading"
+          >
+            <Spinner size="small" />
+          </div>
+        ) : (
+          <FilterForm
+            filters={filters}
+            assessmentInfos={assessmentInfos}
+            setFilters={setFilters}
+            experimentId={experimentId}
+            tableFilterOptions={tableFilterOptions}
+            allColumns={allColumns}
+            usesV4APIs={usesV4APIs}
+          />
+        )}
+      </Popover.Content>
+    </Popover.Root>
+  );
+};
+
+const useFilterForm = (filters: TableFilter[]) => {
+  const form = useForm<TableFilterFormState>({
+    defaultValues: {
+      filters: filters.length > 0 ? filters : [{ column: '', operator: FilterOperator.EQUALS, value: '' }],
+    },
+  });
+
+  return form;
+};
+
+const FilterForm = ({
+  filters,
+  assessmentInfos,
+  setFilters,
+  experimentId,
+  tableFilterOptions,
+  allColumns,
+  usesV4APIs,
+}: {
+  filters: TableFilter[];
+  assessmentInfos: AssessmentInfo[];
+  setFilters: (filters: TableFilter[]) => void;
+  experimentId?: string;
+  tableFilterOptions: TableFilterOptions;
+  allColumns: TracesTableColumn[];
+  usesV4APIs?: boolean;
+}) => {
+  const { theme } = useDesignSystemTheme();
+
+  const filterForm = useFilterForm(filters);
+
+  const { setValue, watch } = filterForm;
+
+  const localFilters = watch('filters');
+
+  return (
+    <FormProvider {...filterForm}>
+      <div
+        css={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: theme.spacing.lg,
+          overflow: 'auto',
+        }}
+      >
+        <div
+          css={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: theme.spacing.sm,
+          }}
+        >
+          {localFilters.map((filter, index) => (
+            <TableFilterItem
+              key={filter.column + filter.operator + filter.value + index}
+              tableFilter={filter}
+              index={index}
+              onChange={(newFilter) => {
+                localFilters[index] = newFilter;
+                setValue('filters', localFilters);
+              }}
+              onDelete={() => {
+                const newFilters = [...localFilters];
+                newFilters.splice(index, 1);
+                // If there are no filters, add an initial filter
+                if (newFilters.length === 0) {
+                  newFilters.push({ column: '', operator: FilterOperator.EQUALS, value: '' });
+                }
+                setValue('filters', newFilters);
+              }}
+              assessmentInfos={assessmentInfos}
+              experimentId={experimentId}
+              tableFilterOptions={tableFilterOptions}
+              allColumns={allColumns}
+              usesV4APIs={usesV4APIs}
+            />
+          ))}
+        </div>
+        <div>
+          <Button
+            componentId="mlflow.evaluations_review.table_ui.add_filter_button"
+            icon={<PlusIcon />}
+            onClick={() => {
+              setValue('filters', [...localFilters, { column: '', operator: FilterOperator.EQUALS, value: '' }]);
+            }}
+          >
+            <FormattedMessage
+              defaultMessage="Add filter"
+              description="Button label for adding a filter in the GenAI Traces Table filter form"
+            />
+          </Button>
+        </div>
+        <div
+          css={{
+            display: 'flex',
+            justifyContent: 'flex-end',
+          }}
+        >
+          <Button
+            componentId="mlflow.evaluations_review.table_ui.apply_filters_button"
+            type="primary"
+            onClick={() => setFilters(localFilters)}
+            css={{
+              display: 'flex',
+              justifyContent: 'flex-end',
+            }}
+          >
+            <FormattedMessage
+              defaultMessage="Apply filters"
+              description="Button label for applying the filters in the GenAI Traces Table"
+            />
+          </Button>
+        </div>
+      </div>
+    </FormProvider>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/GenAiTracesTableHeader.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/GenAiTracesTableHeader.tsx
@@ -1,0 +1,476 @@
+import type { HeaderGroup } from '@tanstack/react-table';
+import { flexRender } from '@tanstack/react-table';
+import { isNil } from 'lodash';
+import React, { useState } from 'react';
+
+import {
+  HoverCard,
+  TableHeader,
+  TableRow,
+  TableRowSelectCell,
+  Tooltip,
+  useDesignSystemTheme,
+  ChevronDownIcon,
+} from '@databricks/design-system';
+import { defineMessage, useIntl, type MessageDescriptor } from '@databricks/i18n';
+
+import { EvaluationsAssessmentHoverCard } from './components/EvaluationsAssessmentHoverCard';
+import { AssessmentColumnSummary } from './components/charts/AssessmentColumnSummary';
+import {
+  createAssessmentColumnId,
+  TRACE_ID_COLUMN_ID,
+  INPUTS_COLUMN_ID,
+  RESPONSE_COLUMN_ID,
+  SESSION_COLUMN_ID,
+  USER_COLUMN_ID,
+  TRACE_NAME_COLUMN_ID,
+  TOKENS_COLUMN_ID,
+  EXECUTION_DURATION_COLUMN_ID,
+  REQUEST_TIME_COLUMN_ID,
+  STATE_COLUMN_ID,
+  SOURCE_COLUMN_ID,
+  LOGGED_MODEL_COLUMN_ID,
+  LINKED_PROMPTS_COLUMN_ID,
+  RUN_NAME_COLUMN_ID,
+  TAGS_COLUMN_ID,
+  ISSUES_COLUMN_ID,
+} from './hooks/useTableColumns';
+import {
+  TracesTableColumnGroup,
+  type AssessmentAggregates,
+  type AssessmentFilter,
+  type AssessmentInfo,
+  type AssessmentValueType,
+  type EvalTraceComparisonEntry,
+} from './types';
+import { escapeCssSpecialCharacters } from './utils/DisplayUtils';
+import { getDocsLink } from './utils/DocUtils';
+
+const COLUMN_TOOLTIPS = {
+  [TRACE_ID_COLUMN_ID]: {
+    description: defineMessage({
+      defaultMessage: 'Unique identifier for the trace',
+      description: 'Tooltip description for the Trace ID column in the traces table',
+    }),
+  },
+  [INPUTS_COLUMN_ID]: {
+    description: defineMessage({
+      defaultMessage: "Inputs of the trace, derived from the root span's inputs",
+      description: 'Tooltip description for the Inputs column in the traces table',
+    }),
+  },
+  [RESPONSE_COLUMN_ID]: {
+    description: defineMessage({
+      defaultMessage: "Outputs of the trace, derived from the root span's outputs",
+      description: 'Tooltip description for the Response column in the traces table',
+    }),
+  },
+  [SESSION_COLUMN_ID]: {
+    description: defineMessage({
+      defaultMessage: 'A unique identifier for the session or conversation for grouping traces',
+      description: 'Tooltip description for the Session column in the traces table',
+    }),
+    docsUrl: getDocsLink('/genai/tracing/track-users-sessions/'),
+  },
+  [USER_COLUMN_ID]: {
+    description: defineMessage({
+      defaultMessage: 'Application user who triggered the trace',
+      description: 'Tooltip description for the User column in the traces table',
+    }),
+    docsUrl: getDocsLink('/genai/tracing/track-users-sessions/'),
+  },
+  [TRACE_NAME_COLUMN_ID]: {
+    description: defineMessage({
+      defaultMessage: "Name of the trace, derived from the root span's name",
+      description: 'Tooltip description for the Trace Name column in the traces table',
+    }),
+  },
+  [TOKENS_COLUMN_ID]: {
+    description: defineMessage({
+      defaultMessage: 'Aggregated input/output/total token usage across all spans in the trace',
+      description: 'Tooltip description for the Tokens column in the traces table',
+    }),
+    docsUrl: getDocsLink('/genai/tracing/token-usage-cost'),
+  },
+  [EXECUTION_DURATION_COLUMN_ID]: {
+    description: defineMessage({
+      defaultMessage: 'Total trace duration',
+      description: 'Tooltip description for the Execution Duration column in the traces table',
+    }),
+  },
+  [REQUEST_TIME_COLUMN_ID]: {
+    description: defineMessage({
+      defaultMessage: 'When the trace was created',
+      description: 'Tooltip description for the Request Time column in the traces table',
+    }),
+  },
+  [STATE_COLUMN_ID]: {
+    description: defineMessage({
+      defaultMessage: 'Trace status: OK, ERROR, or IN_PROGRESS',
+      description: 'Tooltip description for the State column in the traces table',
+    }),
+  },
+  [SOURCE_COLUMN_ID]: {
+    description: defineMessage({
+      defaultMessage: 'Entry point or script that generated the trace',
+      description: 'Tooltip description for the Source column in the traces table',
+    }),
+    docsUrl: getDocsLink('/genai/tracing/track-environments-context'),
+  },
+  [LOGGED_MODEL_COLUMN_ID]: {
+    description: defineMessage({
+      defaultMessage: 'Associated model version',
+      description: 'Tooltip description for the Logged Model column in the traces table',
+    }),
+  },
+  [LINKED_PROMPTS_COLUMN_ID]: {
+    description: defineMessage({
+      defaultMessage: 'Linked prompt versions from Prompt Registry',
+      description: 'Tooltip description for the Linked Prompts column in the traces table',
+    }),
+    docsUrl: getDocsLink('/genai/prompt-registry/use-prompts-in-apps#linking-with-trace'),
+  },
+  [RUN_NAME_COLUMN_ID]: {
+    description: defineMessage({
+      defaultMessage: 'Associated MLflow Run if the trace was generated within an MLflow run context',
+      description: 'Tooltip description for the Run Name column in the traces table',
+    }),
+  },
+  [TAGS_COLUMN_ID]: {
+    description: defineMessage({
+      defaultMessage: 'User-defined key-value pairs',
+      description: 'Tooltip description for the Tags column in the traces table',
+    }),
+    docsUrl: getDocsLink('/genai/tracing/attach-tags'),
+  },
+  [ISSUES_COLUMN_ID]: {
+    description: defineMessage({
+      defaultMessage: 'Issues detected on the trace by automatic issue detection',
+      description: 'Tooltip description for the Issues column in the traces table',
+    }),
+    docsUrl: getDocsLink('/genai/eval-monitor/ai-insights/detect-issues'),
+  },
+  [`${TracesTableColumnGroup.ASSESSMENT}-group`]: {
+    description: defineMessage({
+      defaultMessage: 'Feedback scores logged to the trace',
+      description: 'Tooltip description for the Assessment column group in the traces table',
+    }),
+    docsUrl: getDocsLink('/genai/eval-monitor'),
+  },
+  [`${TracesTableColumnGroup.EXPECTATION}-group`]: {
+    description: defineMessage({
+      defaultMessage: 'Ground truth values annotated to the trace',
+      description: 'Tooltip description for the Expectation column group in the traces table',
+    }),
+    docsUrl: getDocsLink('/genai/assessments/expectations'),
+  },
+} satisfies Record<string, { description: MessageDescriptor; docsUrl?: string }>;
+
+interface GenAiTracesTableHeaderProps {
+  enableRowSelection?: boolean;
+  enableGrouping?: boolean;
+  selectedAssessmentInfos: AssessmentInfo[];
+  assessmentNameToAggregates: Record<string, AssessmentAggregates>;
+  assessmentFilters: AssessmentFilter[];
+  toggleAssessmentFilter: (
+    assessmentName: string,
+    filterValue: AssessmentValueType,
+    run: string,
+    filterType?: AssessmentFilter['filterType'],
+  ) => void;
+  runDisplayName?: string;
+  compareToRunUuid?: string;
+  compareToRunDisplayName?: string;
+  disableAssessmentTooltips?: boolean;
+  collapsedHeader: boolean;
+  setCollapsedHeader: (collapsed: boolean) => void;
+  isComparing: boolean;
+  headerGroups: HeaderGroup<EvalTraceComparisonEntry>[];
+  allRowSelected: boolean;
+  someRowSelected: boolean;
+  toggleAllRowsSelectedHandler: () => (event: unknown) => void;
+}
+
+export const GenAiTracesTableHeader = React.memo(
+  // eslint-disable-next-line react-component-name/react-component-name -- TODO(FEINF-4716)
+  ({
+    enableRowSelection,
+    enableGrouping,
+    selectedAssessmentInfos,
+    assessmentNameToAggregates,
+    assessmentFilters,
+    toggleAssessmentFilter,
+    runDisplayName,
+    compareToRunUuid,
+    compareToRunDisplayName,
+    disableAssessmentTooltips,
+    collapsedHeader,
+    setCollapsedHeader,
+    isComparing,
+    headerGroups,
+    allRowSelected,
+    someRowSelected,
+    toggleAllRowsSelectedHandler,
+  }: GenAiTracesTableHeaderProps) => {
+    const { theme } = useDesignSystemTheme();
+    const intl = useIntl();
+    const [isChevronHovered, setIsChevronHovered] = useState(false);
+
+    // super hacky way to get the border to show between the header and the row
+    const borderCss = enableGrouping
+      ? {
+          position: 'relative' as const,
+          '&::before': {
+            content: '""',
+            position: 'absolute' as const,
+            top: '32px',
+            left: 0,
+            right: 0,
+            borderTop: `1px solid ${theme.colors.border}`,
+          },
+        }
+      : {};
+
+    return (
+      <>
+        {headerGroups.map((headerGroup, depth) => (
+          <TableRow
+            isHeader
+            key={headerGroup.id}
+            css={{
+              position: 'sticky',
+              top: depth * 40,
+              zIndex: 100,
+              // hack to hide the bottom border of the first row
+              ...(enableGrouping && {
+                '& > *': {
+                  borderBottom: depth === 0 ? 'none' : undefined,
+                },
+              }),
+              ...(depth === headerGroups.length - 1 && {
+                borderBottom: `1px solid ${isChevronHovered ? theme.colors.blue500 : theme.colors.border}`,
+                transition: 'border-color 0.2s',
+                // Remove default cell borders in the last header row
+                '& > *': {
+                  borderBottom: 'none',
+                },
+              }),
+            }}
+          >
+            {enableRowSelection && (
+              <div css={selectedAssessmentInfos.length === 0 && depth === 1 ? {} : borderCss}>
+                <TableRowSelectCell
+                  componentId="mlflow.experiment-evaluation-monitoring.evals-logs-table-header-select-cell"
+                  checked={allRowSelected}
+                  indeterminate={someRowSelected}
+                  onChange={toggleAllRowsSelectedHandler()}
+                  checkboxLabel={intl.formatMessage({
+                    defaultMessage: 'Select all',
+                    description: 'Description for button to select all rows in table',
+                  })}
+                  noCheckbox={depth === 0}
+                  isDisabled={isComparing}
+                />
+              </div>
+            )}
+            {headerGroup.headers.map((header) => {
+              if (header.isPlaceholder) return null; // skip spacer cells
+
+              const assessmentInfo = selectedAssessmentInfos.find(
+                (info) => createAssessmentColumnId(info.name) === header.id,
+              );
+
+              const title = header.isPlaceholder ? null : (
+                <div
+                  css={{
+                    display: 'inline-block',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    wordBreak: 'normal',
+                    overflowWrap: 'normal',
+                  }}
+                  title={String(flexRender(header.column.columnDef.header, header.getContext()))}
+                >
+                  {flexRender(header.column.columnDef.header, header.getContext())}
+                </div>
+              );
+              const tooltipInfo = COLUMN_TOOLTIPS[header.column.id as keyof typeof COLUMN_TOOLTIPS];
+              const titleElement =
+                assessmentInfo && !disableAssessmentTooltips ? (
+                  <HoverCard
+                    key={header.id}
+                    content={
+                      <>
+                        <EvaluationsAssessmentHoverCard
+                          assessmentInfo={assessmentInfo}
+                          assessmentNameToAggregates={assessmentNameToAggregates}
+                          allAssessmentFilters={assessmentFilters}
+                          toggleAssessmentFilter={toggleAssessmentFilter}
+                          runUuid={runDisplayName}
+                          compareToRunUuid={compareToRunUuid ? compareToRunDisplayName : undefined}
+                        />
+                      </>
+                    }
+                    trigger={title}
+                  />
+                ) : !isNil(title) && tooltipInfo ? (
+                  <Tooltip
+                    componentId="mlflow.traces-table.column-header-tooltip"
+                    content={
+                      <span>
+                        {intl.formatMessage(tooltipInfo.description)}.
+                        {'docsUrl' in tooltipInfo && tooltipInfo.docsUrl && (
+                          <>
+                            {' '}
+                            <a
+                              href={tooltipInfo.docsUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              css={{ color: theme.colors.blue400 }}
+                            >
+                              {intl.formatMessage({
+                                defaultMessage: 'Learn more',
+                                description: 'Link text in column header tooltip that opens documentation in a new tab',
+                              })}
+                            </a>
+                          </>
+                        )}
+                      </span>
+                    }
+                  >
+                    {title}
+                  </Tooltip>
+                ) : !isNil(title) ? (
+                  title
+                ) : null;
+
+              return (
+                <TableHeader
+                  key={header.column.id}
+                  componentId="codegen_mlflow_app_src_experiment-tracking_components_evaluations_evaluationsoverview.tsx_576"
+                  css={{
+                    '> span:first-of-type': {
+                      width: '100%',
+                      height: '100%',
+                      marginTop: 'auto',
+                      marginBottom: 'auto',
+                    },
+                    ...(selectedAssessmentInfos.length === 0 && depth === 1 ? {} : borderCss),
+                  }}
+                  style={{
+                    flex: `${header.colSpan} 1 var(--header-${escapeCssSpecialCharacters(header?.column.id)}-size)`,
+                  }}
+                  header={header}
+                  column={header.column}
+                >
+                  <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+                    {titleElement}
+                    <div
+                      css={{
+                        borderTop:
+                          !enableGrouping && selectedAssessmentInfos.length > 0
+                            ? `1px solid ${theme.colors.border}`
+                            : '',
+                        width: '100%',
+                      }}
+                    >
+                      {assessmentInfo && (
+                        <AssessmentColumnSummary
+                          theme={theme}
+                          intl={intl}
+                          assessmentInfo={assessmentInfo}
+                          assessmentAggregates={assessmentNameToAggregates[assessmentInfo.name]}
+                          allAssessmentFilters={assessmentFilters}
+                          toggleAssessmentFilter={toggleAssessmentFilter}
+                          currentRunDisplayName={runDisplayName}
+                          compareToRunDisplayName={compareToRunUuid ? compareToRunDisplayName : undefined}
+                          collapsedHeader={collapsedHeader}
+                        />
+                      )}
+                    </div>
+                  </div>
+                </TableHeader>
+              );
+            })}
+            {depth === headerGroups.length - 1 && (
+              <div
+                css={{
+                  paddingTop: '0px !important',
+                  position: 'absolute',
+                  left: 0,
+                  right: 0,
+                  bottom: 0,
+                  zIndex: 101,
+                  padding: 0,
+                  pointerEvents: 'none',
+                }}
+              >
+                {/* Mask the border under the chevron */}
+                <div
+                  css={{
+                    position: 'absolute',
+                    left: '50%',
+                    top: '100%',
+                    width: '24px',
+                    height: '12px',
+                    background: theme.colors.backgroundPrimary,
+                    transform: 'translate(-50%, -50%)',
+                    zIndex: 101,
+                  }}
+                />
+                {/* Chevron circle, pointer events enabled */}
+                <div
+                  css={{
+                    position: 'absolute',
+                    left: '50%',
+                    top: '100%',
+                    transform: 'translate(-50%, -50%)',
+                    zIndex: 102,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    width: '22px',
+                    height: '22px',
+                    pointerEvents: 'auto',
+                    cursor: 'pointer',
+                  }}
+                  onClick={() => setCollapsedHeader(!collapsedHeader)}
+                  onMouseEnter={() => setIsChevronHovered(true)}
+                  onMouseLeave={() => setIsChevronHovered(false)}
+                >
+                  <div
+                    css={{
+                      width: '22px',
+                      height: '22px',
+                      borderRadius: '50%',
+                      background: theme.colors.backgroundPrimary,
+                      border: `2px solid ${theme.colors.border}`,
+                      boxShadow: '0 2px 8px 0 rgba(0,0,0,0.10)',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      transition: 'border-color 0.2s, box-shadow 0.2s',
+                      ':hover': {
+                        borderColor: theme.colors.blue500,
+                        boxShadow: '0 2px 12px 0 rgba(0,0,0,0.18)',
+                      },
+                      opacity: isChevronHovered ? 1 : 0.5,
+                    }}
+                  >
+                    <ChevronDownIcon
+                      css={{
+                        transform: !collapsedHeader ? 'rotate(180deg)' : 'none',
+                        transition: 'transform 0.2s, opacity 0.2s',
+                        color: theme.colors.textSecondary,
+                      }}
+                    />
+                  </div>
+                </div>
+              </div>
+            )}
+          </TableRow>
+        ))}
+      </>
+    );
+  },
+);

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/GenAiTracesTableSearchInput.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/GenAiTracesTableSearchInput.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+
+import { TableFilterInput } from '@databricks/design-system';
+import { useIntl } from '@databricks/i18n';
+
+const SEARCH_QUERY_FILTER_DEBOUNCE_MS = 400;
+
+export function GenAiTracesTableSearchInput({
+  searchQuery,
+  setSearchQuery,
+  placeholder,
+}: {
+  searchQuery: string;
+  setSearchQuery: (query: string) => void;
+  placeholder?: string;
+}) {
+  const intl = useIntl();
+
+  const [pendingUserQuery, setPendingUserQuery] = useState(searchQuery);
+  // When the search query changes, update the pending user query.
+  useEffect(() => {
+    setPendingUserQuery(searchQuery);
+  }, [searchQuery]);
+
+  // Debounce adding the filter search query to the URL so we don't over push to the URL.
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      setSearchQuery(pendingUserQuery);
+    }, SEARCH_QUERY_FILTER_DEBOUNCE_MS);
+    return () => clearTimeout(timeout);
+  }, [pendingUserQuery, setSearchQuery]);
+
+  return (
+    <TableFilterInput
+      componentId="mlflow.evaluations_review.table_ui.filter_input"
+      placeholder={
+        placeholder ??
+        intl.formatMessage({
+          defaultMessage: 'Search traces by id, request, or response',
+          description: 'Placeholder text for the search input in the trace results table',
+        })
+      }
+      value={pendingUserQuery}
+      onChange={(e) => setPendingUserQuery(e.target.value)}
+    />
+  );
+}

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/GenAiTracesTableSessionGroupedRows.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/GenAiTracesTableSessionGroupedRows.tsx
@@ -1,0 +1,306 @@
+import type { Row, RowSelectionState } from '@tanstack/react-table';
+import type { VirtualItem } from '@tanstack/react-virtual';
+import React, { useCallback, useMemo } from 'react';
+
+import {
+  Button,
+  ChevronDownIcon,
+  ChevronRightIcon,
+  TableRow,
+  TableRowSelectCell,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
+import type { ModelTraceInfoV3 } from '../model-trace-explorer/ModelTrace.types';
+
+import { SessionHeaderCell } from './cellRenderers/SessionHeaderCellRenderers';
+import { GenAiTracesTableBodyRow } from './GenAiTracesTableBodyRows';
+import type { TracesTableColumn, EvalTraceComparisonEntry } from './types';
+import type { GroupedTraceTableRowData } from './utils/SessionGroupingUtils';
+
+interface GenAiTracesTableSessionGroupedRowsProps {
+  rows: Row<EvalTraceComparisonEntry>[];
+  groupedRows: GroupedTraceTableRowData[];
+  isComparing: boolean;
+  enableRowSelection?: boolean;
+  // eslint-disable-next-line react/no-unused-prop-types
+  rowSelectionState: RowSelectionState | undefined;
+  virtualItems: VirtualItem<Element>[];
+  virtualizerTotalSize: number;
+  virtualizerMeasureElement: (node: HTMLDivElement | null) => void;
+  selectedColumns: TracesTableColumn[];
+  expandedSessions: Set<string>;
+  toggleSessionExpanded: (sessionId: string) => void;
+  onToggleSessionSelection?: (sessionId: string, traces: ModelTraceInfoV3[], event: unknown) => void;
+  experimentId?: string;
+  getRunColor?: (runUuid: string) => string;
+  runUuid?: string;
+  compareToRunUuid?: string;
+  rowSelectionChangeHandler?: (row: Row<EvalTraceComparisonEntry>, event: unknown) => void;
+  /** When set, matching text in the Request column is highlighted. */
+  searchQuery?: string;
+}
+
+interface SessionHeaderRowProps {
+  sessionId: string;
+  otherSessionId?: string;
+  // eslint-disable-next-line react/no-unused-prop-types
+  traceCount: number;
+  traces: ModelTraceInfoV3[];
+  otherTraces?: ModelTraceInfoV3[];
+  goal?: string;
+  persona?: string;
+  selectedColumns: TracesTableColumn[];
+  experimentId?: string;
+  isExpanded: boolean;
+  isComparing: boolean;
+  enableRowSelection?: boolean;
+  isSessionSelected?: boolean;
+  isSessionIndeterminate?: boolean;
+  onToggleSessionSelection?: (sessionId: string, traces: ModelTraceInfoV3[], event: unknown) => void;
+  toggleSessionExpanded: (sessionId: string) => void;
+  getRunColor?: (runUuid: string) => string;
+  runUuid?: string;
+  compareToRunUuid?: string;
+  searchQuery?: string;
+}
+
+export const GenAiTracesTableSessionGroupedRows = React.memo(function GenAiTracesTableSessionGroupedRows({
+  rows,
+  groupedRows,
+  isComparing,
+  enableRowSelection,
+  virtualItems,
+  virtualizerTotalSize,
+  virtualizerMeasureElement,
+  rowSelectionState,
+  selectedColumns,
+  expandedSessions,
+  toggleSessionExpanded,
+  onToggleSessionSelection,
+  experimentId,
+  getRunColor,
+  runUuid,
+  compareToRunUuid,
+  rowSelectionChangeHandler,
+  searchQuery,
+}: GenAiTracesTableSessionGroupedRowsProps) {
+  // Create a map from eval data (contained in `groupedRows`) to the
+  // actual table row from the tanstack data model. When grouping by
+  // sessions, the rows shuffle around so we need to make sure that things
+  // like selection state are updated correctly.
+  const evaluationToRowMap = useMemo(() => {
+    const map = new Map<EvalTraceComparisonEntry, Row<EvalTraceComparisonEntry>>();
+    rows.forEach((row) => {
+      map.set(row.original, row);
+    });
+    return map;
+  }, [rows]);
+
+  const getSessionSelectionState = useCallback(
+    (traces: ModelTraceInfoV3[]) => {
+      if (!rowSelectionState || traces.length === 0) {
+        return { allSelected: false, someSelected: false };
+      }
+      const traceIds = traces.map((t) => t.trace_id);
+      const selectedCount = traceIds.filter((id) => rowSelectionState[id]).length;
+      return {
+        allSelected: selectedCount === traceIds.length,
+        someSelected: selectedCount > 0 && selectedCount < traceIds.length,
+      };
+    },
+    [rowSelectionState],
+  );
+
+  return (
+    <div
+      style={{
+        height: `${virtualizerTotalSize}px`,
+        position: 'relative',
+        display: 'grid',
+      }}
+    >
+      {virtualItems.map((virtualRow) => {
+        const groupedRow = groupedRows[virtualRow.index];
+
+        if (!groupedRow) {
+          return null;
+        }
+
+        // Render header using a custom renderer for session data
+        if (groupedRow.type === 'sessionHeader') {
+          const { allSelected, someSelected } = getSessionSelectionState(groupedRow.traces);
+          return (
+            <div
+              key={`session-header-${groupedRow.sessionId}-${virtualRow.index}`}
+              data-index={virtualRow.index}
+              ref={(node) => virtualizerMeasureElement(node)}
+              style={{
+                position: 'absolute',
+                transform: `translate3d(0, ${virtualRow.start}px, 0)`,
+                willChange: 'transform',
+                width: '100%',
+              }}
+            >
+              <SessionHeaderRow
+                sessionId={groupedRow.sessionId}
+                otherSessionId={groupedRow.otherSessionId}
+                traceCount={groupedRow.traces.length}
+                traces={groupedRow.traces}
+                otherTraces={groupedRow.otherTraces}
+                goal={groupedRow.goal}
+                persona={groupedRow.persona}
+                selectedColumns={selectedColumns}
+                experimentId={experimentId}
+                isExpanded={expandedSessions.has(groupedRow.sessionId)}
+                isComparing={isComparing}
+                enableRowSelection={enableRowSelection}
+                isSessionSelected={allSelected}
+                isSessionIndeterminate={someSelected}
+                onToggleSessionSelection={onToggleSessionSelection}
+                toggleSessionExpanded={toggleSessionExpanded}
+                searchQuery={searchQuery}
+                getRunColor={getRunColor}
+                runUuid={runUuid}
+                compareToRunUuid={compareToRunUuid}
+              />
+            </div>
+          );
+        }
+
+        // Render trace row using the existing renderer, providing it
+        // with a reference to the actual tanstack table row.
+        let row = evaluationToRowMap.get(groupedRow.data);
+        if (!row) {
+          // Bug in React 18: for some reason, `evaluationToRowMap` loses the row reference when the table is re-rendered.
+          // This is a workaround to find the row by matching the trace IDs.
+          row = rows.find(
+            ({ original }) =>
+              original.currentRunValue?.traceInfo?.trace_id === groupedRow.data.currentRunValue?.traceInfo?.trace_id &&
+              original.otherRunValue?.traceInfo?.trace_id === groupedRow.data.otherRunValue?.traceInfo?.trace_id,
+          );
+          if (!row) {
+            return null;
+          }
+        }
+
+        const exportableTrace = row.original.currentRunValue && !isComparing;
+        // For traces within a session, show a spacer instead of a checkbox to maintain alignment
+        const isSessionTrace = Boolean(groupedRow.sessionId);
+
+        return (
+          <div
+            key={virtualRow.key}
+            data-index={virtualRow.index}
+            ref={(node) => virtualizerMeasureElement(node)}
+            style={{
+              position: 'absolute',
+              transform: `translate3d(0, ${virtualRow.start}px, 0)`,
+              willChange: 'transform',
+              width: '100%',
+            }}
+          >
+            <GenAiTracesTableBodyRow
+              row={row}
+              exportableTrace={exportableTrace}
+              enableRowSelection={enableRowSelection}
+              isSelected={isSessionTrace ? undefined : row.getIsSelected()}
+              displayCheckbox={!isSessionTrace}
+              isComparing={isComparing}
+              selectedColumns={selectedColumns}
+              rowSelectionChangeHandler={isSessionTrace ? undefined : rowSelectionChangeHandler}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+});
+
+// Session header component
+const SessionHeaderRow = React.memo(function SessionHeaderRow({
+  sessionId,
+  otherSessionId,
+  traces,
+  otherTraces,
+  goal,
+  persona,
+  selectedColumns,
+  experimentId,
+  isExpanded,
+  isComparing,
+  enableRowSelection,
+  isSessionSelected,
+  isSessionIndeterminate,
+  onToggleSessionSelection,
+  toggleSessionExpanded,
+  getRunColor,
+  runUuid,
+  compareToRunUuid,
+  searchQuery,
+}: SessionHeaderRowProps) {
+  // Handle toggle all rows in this session
+  const handleToggleExpanded = useCallback(() => {
+    toggleSessionExpanded(sessionId);
+  }, [toggleSessionExpanded, sessionId]);
+
+  const handleToggleSelection = useCallback(
+    (event: unknown) => {
+      onToggleSessionSelection?.(sessionId, traces, event);
+    },
+    [onToggleSessionSelection, sessionId, traces],
+  );
+
+  const { theme } = useDesignSystemTheme();
+
+  return (
+    <TableRow isHeader>
+      <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs, flexShrink: 0 }}>
+        {enableRowSelection && (
+          // Clip the Ant checkbox's label overhang so its hitbox doesn't extend under the expand toggle.
+          <div css={{ overflow: 'hidden' }}>
+            <TableRowSelectCell
+              componentId="mlflow.genai-traces-table.session-header.select-cell"
+              checked={isSessionSelected}
+              indeterminate={isSessionIndeterminate}
+              onChange={handleToggleSelection}
+              isDisabled={isComparing}
+            />
+          </div>
+        )}
+        {/* Hide expand/collapse button when comparing - sessions are non-expandable in comparison mode */}
+        {!isComparing && (
+          <Button
+            componentId="mlflow.genai-traces-table.session-header.toggle-expanded"
+            size="small"
+            icon={isExpanded ? <ChevronDownIcon /> : <ChevronRightIcon />}
+            onClick={handleToggleExpanded}
+          />
+        )}
+      </div>
+      {/* Render a cell for each visible column from the table */}
+      {selectedColumns.map((column) => (
+        <SessionHeaderCell
+          key={column.id}
+          column={column}
+          sessionId={sessionId}
+          otherSessionId={otherSessionId}
+          traces={traces}
+          otherTraces={otherTraces}
+          goal={goal}
+          persona={persona}
+          experimentId={experimentId}
+          isComparing={isComparing}
+          getRunColor={getRunColor}
+          runUuid={runUuid}
+          compareToRunUuid={compareToRunUuid}
+          onExpandSession={!isComparing ? handleToggleExpanded : undefined}
+          searchQuery={searchQuery}
+        />
+      ))}
+    </TableRow>
+  );
+});
+
+export const MemoizedGenAiTracesTableSessionGroupedRows = React.memo(
+  GenAiTracesTableSessionGroupedRows,
+) as typeof GenAiTracesTableSessionGroupedRows;

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/TestCaseDetail.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/TestCaseDetail.tsx
@@ -1,0 +1,331 @@
+/**
+ * Test-case detail drawer for a regression-test run.
+ *
+ * Opens when a row in the Test cases table is clicked (replacing the generic
+ * trace review). Shows the test name + overall Result, the agent Input/Output
+ * (rendered with the same conversation renderer as the trace viewer), and a
+ * two-column Assertions/Result table: each assertion's text is expandable, and
+ * its pass/fail tag carries the same LLM-judge hover card as the traces table.
+ * A "Trace" button still jumps to the raw trace.
+ */
+import {
+  Button,
+  ChevronDownIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  ChevronUpIcon,
+  ListIcon,
+  Table,
+  TableCell,
+  TableHeader,
+  TableRow,
+  Tag,
+  Typography,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
+import { useContext, useMemo, useState } from 'react';
+import { FormattedMessage, useIntl } from 'react-intl';
+
+import { GenAITracesTableContext } from './GenAITracesTableContext';
+
+import { EvaluationsReviewAssessmentTag } from './components/EvaluationsReviewAssessmentTag';
+import { getEvaluationResultAssessmentValue } from './components/GenAiEvaluationTracesReview.utils';
+import type { AssessmentInfo, EvalTraceComparisonEntry, RunEvaluationResultAssessment } from './types';
+import { useQuery } from '../query-client/queryClient';
+import type { ModelTrace } from '../model-trace-explorer/ModelTrace.types';
+import { SingleChatTurnMessages } from '../model-trace-explorer/session-view/SingleChatTurnMessages';
+
+const isPass = (v: unknown): boolean =>
+  typeof v === 'boolean'
+    ? v
+    : typeof v === 'number'
+      ? v >= 0.5
+      : typeof v === 'string'
+        ? ['yes', 'pass', 'true'].includes(v.trim().toLowerCase())
+        : false;
+
+const readTag = (info: any, key: string): string | undefined => {
+  const tags = info?.tags;
+  if (Array.isArray(tags)) return tags.find((t: any) => t?.key === key)?.value;
+  if (tags && typeof tags === 'object' && tags[key] != null) return String(tags[key]);
+  const meta = info?.trace_metadata?.[key];
+  return meta != null ? String(meta) : undefined;
+};
+
+const stringify = (v: any): string => {
+  if (v == null) return '';
+  if (typeof v === 'string') return v;
+  try {
+    return JSON.stringify(v, null, 2);
+  } catch {
+    return String(v);
+  }
+};
+
+// When the table doesn't carry an AssessmentInfo for a scorer (rare), build a
+// minimal one so the value tag + hover still render with the right value type.
+const fallbackAssessmentInfo = (name: string, a: RunEvaluationResultAssessment): AssessmentInfo => ({
+  name,
+  displayName: name,
+  isKnown: false,
+  isOverall: false,
+  metricName: name,
+  isCustomMetric: false,
+  isEditable: false,
+  isRetrievalAssessment: false,
+  dtype: typeof a.booleanValue === 'boolean' ? 'boolean' : a.numericValue != null ? 'numeric' : 'pass-fail',
+  uniqueValues: new Set(),
+  docsLink: '',
+  missingTooltip: '',
+  description: '',
+});
+
+const ResultPill = ({ passed }: { passed: boolean }) => (
+  <Tag
+    componentId="mlflow.regression-test-detail.result-pill"
+    color={passed ? 'turquoise' : 'coral'}
+    css={{ margin: 0 }}
+  >
+    {passed ? (
+      <FormattedMessage defaultMessage="Passed" description="Pass status pill in the regression-test detail" />
+    ) : (
+      <FormattedMessage defaultMessage="Failed" description="Fail status pill in the regression-test detail" />
+    )}
+  </Tag>
+);
+
+// Assertion text that clamps to two lines, with a chevron toggle to expand the
+// full text so long guideline rubrics don't blow out the row height.
+const ExpandableAssertionText = ({ text }: { text: string }) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+  const [expanded, setExpanded] = useState(false);
+  // Roughly two lines at the column width; longer text gets a chevron toggle.
+  const isLong = text.length > 60;
+  return (
+    <div css={{ display: 'flex', alignItems: 'flex-start', gap: theme.spacing.xs, minWidth: 0 }}>
+      <Typography.Text
+        css={
+          expanded
+            ? { whiteSpace: 'normal', wordBreak: 'break-word' }
+            : {
+                display: '-webkit-box',
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: 'vertical',
+                overflow: 'hidden',
+                whiteSpace: 'normal',
+                wordBreak: 'break-word',
+              }
+        }
+      >
+        {text}
+      </Typography.Text>
+      {isLong && (
+        <Button
+          componentId="mlflow.regression-test-detail.assertion-expand"
+          type="tertiary"
+          size="small"
+          icon={expanded ? <ChevronUpIcon /> : <ChevronDownIcon />}
+          aria-label={
+            expanded
+              ? intl.formatMessage({
+                  defaultMessage: 'Collapse assertion text',
+                  description: 'Aria label for the chevron that collapses a long assertion text',
+                })
+              : intl.formatMessage({
+                  defaultMessage: 'Expand assertion text',
+                  description: 'Aria label for the chevron that expands a long assertion text',
+                })
+          }
+          css={{ flexShrink: 0 }}
+          onClick={() => setExpanded((e) => !e)}
+        />
+      )}
+    </div>
+  );
+};
+
+export const TestCaseDetail = ({
+  evaluation,
+  experimentId,
+  assessmentInfos,
+  onClose,
+  onPrev,
+  onNext,
+}: {
+  evaluation: EvalTraceComparisonEntry;
+  experimentId?: string;
+  assessmentInfos?: AssessmentInfo[];
+  onClose: () => void;
+  onPrev?: () => void;
+  onNext?: () => void;
+}) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+  const { DrawerComponent } = useContext(GenAITracesTableContext);
+  const run = evaluation.currentRunValue;
+  const info: any = run?.traceInfo;
+  const traceId: string | undefined = info?.trace_id;
+
+  const baseName = readTag(info, 'mlflow.test.name') ?? traceId ?? 'Test case';
+  const caseId = readTag(info, 'mlflow.test.case_id');
+  const testName = caseId ? `${baseName}[${caseId}]` : baseName;
+
+  const infoByName = useMemo(() => new Map((assessmentInfos ?? []).map((i) => [i.name, i])), [assessmentInfos]);
+
+  // Flatten every assertion (one row each) -- multiple guideline assertions can
+  // share the default "guidelines" name, so we don't collapse to the first.
+  // Each row keeps the raw assessment + its AssessmentInfo so the Result cell
+  // can render the same value tag + LLM-judge hover the traces table uses.
+  const byName = run?.responseAssessmentsByName ?? {};
+  const assertions = Object.entries(byName)
+    .filter(([name]) => name !== 'Result')
+    .flatMap(([name, arr]) =>
+      (arr ?? []).map((a: RunEvaluationResultAssessment, i: number) => {
+        const value = getEvaluationResultAssessmentValue(a);
+        const named = arr.length > 1 ? `${name} ${i + 1}` : name;
+        const metaGuideline = stringify(a?.metadata?.['guideline'] ?? a?.metadata?.['guidelines']);
+        const label = metaGuideline || named || 'Assertion';
+        const assessmentInfo = infoByName.get(name) ?? fallbackAssessmentInfo(name, a);
+        return { label, assessment: a, assessmentInfo, passed: isPass(value) };
+      }),
+    );
+  const allPassed = assertions.length > 0 && assertions.every((a) => a.passed);
+
+  // Fetch the full trace (info + spans) so SingleChatTurnMessages can render
+  // the deduped user/assistant conversation exactly like the session view does.
+  // useQuery survives the IIFE-based remount pattern in GenAiTracesTableBody.
+  const { data: fullTrace } = useQuery<ModelTrace | null>({
+    queryKey: ['testCaseDetailTrace', traceId],
+    queryFn: async (): Promise<ModelTrace | null> => {
+      const [infoResp, dataResp] = await Promise.all([
+        fetch(`/ajax-api/3.0/mlflow/traces/${encodeURIComponent(traceId!)}`).then((r) => (r.ok ? r.json() : null)),
+        fetch(`/ajax-api/3.0/mlflow/get-trace-artifact?request_id=${encodeURIComponent(traceId!)}`).then((r) =>
+          r.ok ? r.json() : null,
+        ),
+      ]);
+      if (!dataResp) return null;
+      return { info: infoResp?.trace?.trace_info ?? {}, data: dataResp } as ModelTrace;
+    },
+    enabled: !!traceId,
+    staleTime: Infinity,
+  });
+
+  return (
+    <DrawerComponent.Root
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DrawerComponent.Content
+        componentId="mlflow.regression-test-detail.drawer"
+        width="60vw"
+        title={
+          <div css={{ display: 'flex', gap: theme.spacing.sm, alignItems: 'center' }}>
+            <Button
+              componentId="mlflow.regression-test-detail.prev"
+              disabled={!onPrev}
+              onClick={() => onPrev?.()}
+            >
+              <ChevronLeftIcon />
+            </Button>
+            <Button
+              componentId="mlflow.regression-test-detail.next"
+              disabled={!onNext}
+              onClick={() => onNext?.()}
+            >
+              <ChevronRightIcon />
+            </Button>
+            <div css={{ flex: 1, overflow: 'hidden', display: 'flex', alignItems: 'center', gap: theme.spacing.sm }}>
+              <Typography.Title level={4} withoutMargins css={{ fontFamily: 'monospace' }}>
+                {testName}
+              </Typography.Title>
+              <ResultPill passed={allPassed} />
+            </div>
+          </div>
+        }
+      >
+        <div css={{ display: 'flex', gap: theme.spacing.sm, marginBottom: theme.spacing.lg }}>
+          {traceId && experimentId && (
+            <Button
+              componentId="mlflow.regression-test-detail.open-trace"
+              icon={<ListIcon />}
+              onClick={() => {
+                window.location.hash = `#/experiments/${experimentId}/traces?selectedTraceId=${traceId}`;
+              }}
+            >
+              <FormattedMessage defaultMessage="Trace" description="Button to open the raw trace from the detail" />
+            </Button>
+          )}
+        </div>
+
+        {fullTrace && (
+          <div
+            css={{
+              marginBottom: theme.spacing.lg,
+              // Add visible borders to the chat message bubbles rendered by
+              // SingleChatTurnMessages (the component sets borderWidth but
+              // not borderStyle/borderColor on the message elements).
+              '& > div > div': {
+                border: `1px solid ${theme.colors.border}`,
+                borderRadius: theme.borders.borderRadiusMd,
+              },
+            }}
+          >
+            <SingleChatTurnMessages trace={fullTrace} />
+          </div>
+        )}
+
+        <div
+          css={{
+            border: `1px solid ${theme.colors.border}`,
+            borderRadius: theme.legacyBorders.borderRadiusMd,
+            overflow: 'hidden',
+          }}
+        >
+          <Table>
+            <TableRow isHeader>
+              <TableHeader componentId="mlflow.regression-test-detail.col-assertion" css={{ flexGrow: 1 }}>
+                <FormattedMessage defaultMessage="Assertions" description="Assertions column header" />
+              </TableHeader>
+              <TableHeader componentId="mlflow.regression-test-detail.col-result" css={{ flexGrow: 1 }}>
+                <FormattedMessage defaultMessage="Result" description="Result column header" />
+              </TableHeader>
+            </TableRow>
+            {assertions.length === 0 ? (
+              <TableRow>
+                <TableCell css={{ flexGrow: 1 }}>
+                  <Typography.Text color="secondary">
+                    {intl.formatMessage({
+                      defaultMessage: 'No assertions recorded for this test.',
+                      description: 'Empty assertions state in the regression-test detail',
+                    })}
+                  </Typography.Text>
+                </TableCell>
+              </TableRow>
+            ) : (
+              assertions.map((a, i) => (
+                <TableRow key={`${a.label}-${i}`}>
+                  <TableCell css={{ flexGrow: 1, alignItems: 'flex-start' }}>
+                    <ExpandableAssertionText text={a.label} />
+                  </TableCell>
+                  <TableCell css={{ flexGrow: 1, alignItems: 'flex-start' }}>
+                    <EvaluationsReviewAssessmentTag
+                      type="value"
+                      assessment={a.assessment}
+                      assessmentInfo={a.assessmentInfo}
+                      showRationaleInTooltip
+                      hideAssessmentName
+                      disableJudgeTypeIcon
+                    />
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </Table>
+        </div>
+      </DrawerComponent.Content>
+    </DrawerComponent.Root>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/ErrorCell.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/ErrorCell.tsx
@@ -1,0 +1,20 @@
+import { DangerIcon, useDesignSystemTheme } from '@databricks/design-system';
+import { FormattedMessage } from '@databricks/i18n';
+
+export const ErrorCell = () => {
+  const { theme } = useDesignSystemTheme();
+  return (
+    <span
+      css={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: theme.spacing.sm,
+        svg: { width: '12px', height: '12px' },
+        color: theme.colors.textValidationWarning,
+      }}
+    >
+      <DangerIcon css={{ color: theme.colors.textValidationWarning }} />
+      <FormattedMessage defaultMessage="Error" description="Error status in the evaluations table." />{' '}
+    </span>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/ExecutionDurationTag.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/ExecutionDurationTag.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import { ClockIcon, Tag } from '@databricks/design-system';
+
+interface ExecutionDurationTagProps {
+  value: string;
+}
+
+export const ExecutionDurationTag: React.FC<ExecutionDurationTagProps> = ({ value }) => (
+  <Tag
+    icon={<ClockIcon />}
+    css={{ width: 'fit-content', maxWidth: '100%' }}
+    componentId="mlflow.genai-traces-table.execution-time"
+  >
+    <span
+      css={{
+        display: 'block',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+      }}
+      title={value}
+    >
+      {value}
+    </span>
+  </Tag>
+);

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/HeaderCellRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/HeaderCellRenderer.tsx
@@ -1,0 +1,76 @@
+import type { HeaderContext } from '@tanstack/react-table';
+
+import { HoverCard, useDesignSystemTheme } from '@databricks/design-system';
+import { useIntl } from '@databricks/i18n';
+
+import { TracesTableColumnGroup, TracesTableColumnGroupToLabelMap, type EvalTraceComparisonEntry } from '../types';
+
+type HeaderCellRendererMeta = {
+  groupId: TracesTableColumnGroup;
+  visibleCount: number;
+  totalCount: number;
+  enableGrouping?: boolean;
+};
+
+export const HeaderCellRenderer = (props: HeaderContext<EvalTraceComparisonEntry, unknown>) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+  const { groupId, visibleCount, totalCount, enableGrouping } = props.column.columnDef.meta as HeaderCellRendererMeta;
+
+  if (!enableGrouping) {
+    return TracesTableColumnGroupToLabelMap[groupId as TracesTableColumnGroup];
+  }
+
+  const groupName = TracesTableColumnGroupToLabelMap[groupId as TracesTableColumnGroup];
+  return (
+    <div
+      css={{
+        height: '100%',
+        width: '100%',
+        display: 'flex',
+        overflow: 'hidden',
+        gap: theme.spacing.sm,
+      }}
+    >
+      <div>{groupName}</div>
+      {groupId === TracesTableColumnGroup.INFO ? null : visibleCount === totalCount ? (
+        <div
+          css={{
+            color: theme.colors.textSecondary,
+            fontWeight: 'normal',
+          }}
+        >
+          ({visibleCount}/{totalCount})
+        </div>
+      ) : (
+        <HoverCard
+          trigger={
+            <div
+              css={{
+                color: theme.colors.textSecondary,
+                ':hover': {
+                  textDecoration: 'underline',
+                },
+                fontWeight: 'normal',
+              }}
+            >
+              ({visibleCount}/{totalCount})
+            </div>
+          }
+          content={intl.formatMessage(
+            {
+              defaultMessage: 'Showing {visibleCount} out of {totalCount} {groupName}. Select columns to view more.',
+              description: 'Tooltip for the group column header',
+            },
+            {
+              visibleCount,
+              totalCount,
+              groupName,
+            },
+          )}
+          align="start"
+        />
+      )}
+    </div>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/IssuesCell.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/IssuesCell.tsx
@@ -1,0 +1,113 @@
+import { HoverCard, Overflow, Tag, useDesignSystemTheme } from '@databricks/design-system';
+import { useNavigate } from '@mlflow/mlflow/src/common/utils/RoutingUtils';
+import Routes from '@mlflow/mlflow/src/experiment-tracking/routes';
+import { RunPageTabName } from '@mlflow/mlflow/src/experiment-tracking/constants';
+import { getIssue } from '@mlflow/mlflow/src/experiment-tracking/components/run-page/hooks/useGetIssueQuery';
+import { SELECTED_ISSUE_ID_PARAM } from '@mlflow/mlflow/src/experiment-tracking/constants';
+
+import { NullCell } from './NullCell';
+import { StackedComponents } from './StackedComponents';
+
+export interface Issue {
+  id: string;
+  name: string;
+}
+
+const IssueTag = ({ issue }: { issue: Issue }) => {
+  const navigate = useNavigate();
+
+  const handleClick = async () => {
+    try {
+      const issueData = await getIssue(issue.id);
+      if (issueData.source_run_id && issueData.experiment_id) {
+        const baseUrl = Routes.getIssueDetectionRunDetailsTabRoute(
+          issueData.experiment_id,
+          issueData.source_run_id,
+          RunPageTabName.ISSUES,
+        );
+        const params = new URLSearchParams({ [SELECTED_ISSUE_ID_PARAM]: issue.id });
+        const url = `${baseUrl}?${params.toString()}`;
+        navigate(url);
+      }
+    } catch (error) {
+      // fail silently
+    }
+  };
+
+  return (
+    <Tag
+      componentId="mlflow.genai-traces-table.issue-tag"
+      color="coral"
+      css={{ width: 'min-content', maxWidth: '100%', cursor: 'pointer' }}
+      onClick={handleClick}
+    >
+      {issue.name}
+    </Tag>
+  );
+};
+
+const IssuesList = ({ issues, isComparing }: { issues: Issue[] | undefined; isComparing: boolean }) => {
+  const { theme } = useDesignSystemTheme();
+
+  if (!issues || issues.length === 0) {
+    return <NullCell isComparing={isComparing} />;
+  }
+
+  const firstIssue = issues[0];
+  const remainingIssues = issues.slice(1);
+
+  return (
+    <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs, minWidth: 0 }}>
+      <Overflow>
+        <IssueTag issue={firstIssue} />
+      </Overflow>
+      {remainingIssues.length > 0 && (
+        <HoverCard
+          trigger={
+            <Tag
+              componentId="mlflow.genai-traces-table.issue-tag-overflow-trigger"
+              css={{
+                cursor: 'default',
+                width: 'fit-content',
+              }}
+            >
+              +{remainingIssues.length}
+            </Tag>
+          }
+          content={
+            <div
+              css={{
+                display: 'flex',
+                flexDirection: 'column',
+                gap: theme.spacing.xs,
+                maxHeight: 200,
+                overflowY: 'auto',
+              }}
+            >
+              {remainingIssues.map((issue) => (
+                <IssueTag key={issue.id} issue={issue} />
+              ))}
+            </div>
+          }
+        />
+      )}
+    </div>
+  );
+};
+
+export const IssuesCell = ({
+  issues,
+  otherIssues,
+  isComparing,
+}: {
+  issues: Issue[] | undefined;
+  otherIssues: Issue[] | undefined;
+  isComparing: boolean;
+}) => {
+  return (
+    <StackedComponents
+      first={<IssuesList issues={issues} isComparing={isComparing} />}
+      second={isComparing && <IssuesList issues={otherIssues} isComparing={isComparing} />}
+    />
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/LoggedModelCell.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/LoggedModelCell.tsx
@@ -1,0 +1,173 @@
+import { isNil } from 'lodash';
+
+import {
+  ModelsIcon,
+  ParagraphSkeleton,
+  Typography,
+  Tooltip,
+  Tag,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
+import { useQuery } from '../../query-client/queryClient';
+
+import { ErrorCell } from './ErrorCell';
+import { NullCell } from './NullCell';
+import { StackedComponents } from './StackedComponents';
+import type { ModelTraceInfoV3 } from '../../model-trace-explorer/ModelTrace.types';
+import { getAjaxUrl, makeRequest } from '../utils/FetchUtils';
+import MlflowUtils from '../utils/MlflowUtils';
+import { Link } from '../utils/RoutingUtils';
+import { getExperimentIdFromTraceLocation } from '../utils/TraceUtils';
+
+export const LoggedModelCell = (props: {
+  experimentId?: string;
+  currentTraceInfo?: ModelTraceInfoV3;
+  otherTraceInfo?: ModelTraceInfoV3;
+  isComparing: boolean;
+}) => {
+  const { experimentId, currentTraceInfo, otherTraceInfo, isComparing } = props;
+  const currentModelId = currentTraceInfo?.trace_metadata?.['mlflow.modelId'];
+  const otherModelId = otherTraceInfo?.trace_metadata?.['mlflow.modelId'];
+
+  return (
+    <StackedComponents
+      first={
+        currentModelId ? (
+          <LoggedModelComponent
+            experimentId={getExperimentIdFromTraceLocation(currentTraceInfo?.trace_location) ?? experimentId}
+            modelId={currentModelId}
+            isComparing={isComparing}
+          />
+        ) : (
+          <NullCell isComparing={isComparing} />
+        )
+      }
+      second={
+        isComparing &&
+        (otherModelId ? (
+          <LoggedModelComponent
+            experimentId={getExperimentIdFromTraceLocation(otherTraceInfo?.trace_location) ?? experimentId}
+            modelId={otherModelId}
+            isComparing={isComparing}
+          />
+        ) : (
+          <NullCell isComparing={isComparing} />
+        ))
+      }
+    />
+  );
+};
+
+const LoggedModelComponent = (props: { experimentId?: string; modelId: string; isComparing: boolean }) => {
+  const { experimentId, modelId, isComparing } = props;
+  const { theme } = useDesignSystemTheme();
+
+  const { data, isLoading, error } = useLoggedModelName({ loggedModelId: modelId });
+  const modelName = data?.info?.name;
+
+  if (isLoading) {
+    return <ParagraphSkeleton />;
+  }
+
+  if (error) {
+    return <ErrorCell />;
+  }
+
+  if (!modelName) {
+    return <NullCell isComparing={isComparing} />;
+  }
+
+  const content = (
+    <span
+      css={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: theme.spacing.xs,
+        maxWidth: '100%',
+      }}
+    >
+      <ModelsIcon css={{ color: theme.colors.textPrimary, fontSize: 16 }} />
+      <Typography.Text css={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        {modelName}
+      </Typography.Text>
+    </span>
+  );
+
+  return (
+    <Tooltip componentId="mlflow.eval-runs.model-version-cell-tooltip" content={modelName}>
+      <Tag
+        componentId="mlflow.eval-runs.model-version-cell"
+        id="model-version-cell"
+        css={{ width: 'fit-content', maxWidth: '100%', marginRight: 0, cursor: experimentId ? 'pointer' : undefined }}
+      >
+        {experimentId ? (
+          <Link
+            componentId="mlflow.genai-traces-table.logged_model_cell.model_link"
+            to={MlflowUtils.getLoggedModelPageRoute(experimentId, modelId)}
+            target="_blank"
+            css={{
+              maxWidth: '100%',
+              display: 'block',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+            title={modelName}
+          >
+            {content}
+          </Link>
+        ) : (
+          <span
+            css={{
+              maxWidth: '100%',
+              display: 'block',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+            title={modelName}
+          >
+            {content}
+          </span>
+        )}
+      </Tag>
+    </Tooltip>
+  );
+};
+
+interface LoggedModelNameResponse {
+  model: {
+    info: {
+      name?: string;
+    };
+  };
+}
+
+/**
+ * Retrieve logged model from API based on its ID
+ */
+const useLoggedModelName = ({ loggedModelId }: { loggedModelId?: string }) => {
+  const { data, isLoading, isFetching, refetch, error } = useQuery<LoggedModelNameResponse, Error>({
+    queryKey: ['loggedModelName', loggedModelId],
+    queryFn: async () => {
+      const res: LoggedModelNameResponse = await makeRequest(
+        getAjaxUrl(`ajax-api/2.0/mlflow/logged-models/${loggedModelId}`),
+        'GET',
+      );
+      return res;
+    },
+    cacheTime: Infinity,
+    staleTime: Infinity,
+    refetchOnMount: false,
+    retry: 1,
+    enabled: !isNil(loggedModelId),
+  });
+
+  return {
+    isLoading,
+    isFetching,
+    data: data?.model,
+    refetch,
+    error,
+  } as const;
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/NullCell.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/NullCell.tsx
@@ -1,0 +1,15 @@
+import { useDesignSystemTheme } from '@databricks/design-system';
+
+export const NullCell = ({ isComparing }: { isComparing?: boolean }) => {
+  const { theme } = useDesignSystemTheme();
+
+  return (
+    <span
+      css={{
+        height: '20px',
+      }}
+    >
+      {isComparing && <span css={{ fontStyle: 'italic', color: theme.colors.textSecondary }}>null</span>}
+    </span>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/RunName.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/RunName.tsx
@@ -1,0 +1,87 @@
+import { ParagraphSkeleton } from '@databricks/design-system';
+import type { NetworkRequestError } from '../../errors/PredefinedErrors';
+import { useQuery } from '../../query-client/queryClient';
+
+import { ErrorCell } from './ErrorCell';
+import { NullCell } from './NullCell';
+import { getAjaxUrl, makeRequest } from '../utils/FetchUtils';
+import MlflowUtils from '../utils/MlflowUtils';
+import { Link } from '../utils/RoutingUtils';
+
+export const RunName = (props: { experimentId?: string; runUuid: string }) => {
+  const { experimentId, runUuid } = props;
+
+  // When experimentId is not available, we can't fetch the run name
+  // since the API requires experiment_ids to scope the search.
+  if (!experimentId) {
+    return <NullCell />;
+  }
+
+  return <RunNameInner experimentId={experimentId} runUuid={runUuid} />;
+};
+
+const RunNameInner = ({ experimentId, runUuid }: { experimentId: string; runUuid: string }) => {
+  const { data, isLoading, error } = useRunName(experimentId, runUuid);
+
+  const runName = data?.runs?.[0]?.info?.run_name;
+
+  if (isLoading) {
+    return <ParagraphSkeleton />;
+  }
+
+  if (error) {
+    return <ErrorCell />;
+  }
+
+  if (!runName) {
+    return <NullCell />;
+  }
+
+  return (
+    <Link
+      componentId="mlflow.genai-traces-table.run_name_link"
+      css={{
+        display: 'flex',
+        maxWidth: '100%',
+        textOverflow: 'ellipsis',
+        overflow: 'hidden',
+        whiteSpace: 'nowrap',
+      }}
+      to={MlflowUtils.getRunPageRoute(experimentId, runUuid)}
+      title={runName}
+    >
+      {runName}
+    </Link>
+  );
+};
+
+interface RunNameResponse {
+  runs: {
+    data: {
+      tags: { [key: string]: string };
+    };
+    info: {
+      run_name: string;
+    };
+  }[];
+}
+const useRunName = (experimentId: string, runUuid: string) => {
+  return useQuery<RunNameResponse, NetworkRequestError>({
+    queryKey: ['runName', experimentId, runUuid],
+    cacheTime: Infinity,
+    staleTime: Infinity,
+    retry: 1, // limit retries so we don't spam the api
+    refetchOnMount: false,
+    queryFn: async () => {
+      const filter = `run_id IN ('${runUuid}')`;
+      const url = getAjaxUrl('ajax-api/2.0/mlflow/runs/search');
+
+      const res: RunNameResponse = await makeRequest(url, 'POST', {
+        experiment_ids: [experimentId],
+        filter,
+      });
+
+      return res;
+    },
+  });
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/SessionHeaderCellRenderers.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/SessionHeaderCellRenderers.tsx
@@ -1,0 +1,748 @@
+import React from 'react';
+
+import {
+  SpeechBubbleIcon,
+  TableCell,
+  Tag,
+  Tooltip,
+  Typography,
+  UserIcon,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
+import { useIntl } from '@databricks/i18n';
+import type { FeedbackAssessment, ModelTraceInfoV3 } from '../../model-trace-explorer/ModelTrace.types';
+import {
+  ASSESSMENT_SESSION_METADATA_KEY,
+  TOKEN_USAGE_METADATA_KEY,
+  MLFLOW_TRACE_USER_KEY,
+  SESSION_ID_METADATA_KEY,
+} from '../../model-trace-explorer/constants';
+import { isFeedbackAssessment } from '../../model-trace-explorer/assessments-pane/utils';
+
+import { NullCell } from './NullCell';
+import { SessionIdLinkWrapper } from './SessionIdLinkWrapper';
+import { StackedComponents } from './StackedComponents';
+import { IssuesCell, type Issue } from './IssuesCell';
+import { formatDateTime } from './rendererFunctions';
+import { EvaluationsReviewAssessmentTag } from '../components/EvaluationsReviewAssessmentTag';
+import { RunColorCircle } from '../components/RunColorCircle';
+import { formatResponseTitle } from '../GenAiTracesTableBody.utils';
+import { ExecutionDurationTag } from './ExecutionDurationTag';
+import {
+  EXECUTION_DURATION_COLUMN_ID,
+  INPUTS_COLUMN_ID,
+  ISSUES_COLUMN_ID,
+  REQUEST_TIME_COLUMN_ID,
+  RESPONSE_COLUMN_ID,
+  SESSION_COLUMN_ID,
+  SIMULATION_GOAL_COLUMN_ID,
+  SIMULATION_PERSONA_COLUMN_ID,
+  STATE_COLUMN_ID,
+  TOKENS_COLUMN_ID,
+  USER_COLUMN_ID,
+} from '../hooks/useTableColumns';
+import { TracesTableColumnType, type TracesTableColumn } from '../types';
+import { COMPARE_TO_RUN_COLOR, CURRENT_RUN_COLOR } from '../utils/Colors';
+import { escapeCssSpecialCharacters, highlightSearchInText, normalizeDurationString } from '../utils/DisplayUtils';
+import {
+  convertFeedbackAssessmentToRunEvalAssessment,
+  getExperimentIdFromTraceLocation,
+  getTraceInfoInputs,
+  getTraceInfoOutputs,
+  MLFLOW_SOURCE_RUN_KEY,
+} from '../utils/TraceUtils';
+import { compact } from 'lodash';
+import { getUniqueValueCountsBySourceId } from '../utils/AggregationUtils';
+import { TokenComponent } from './TokensCell';
+import { SessionHeaderPassFailAggregatedCell } from './SessionHeaderPassFailAggregatedCell';
+import { SessionHeaderNumericAggregatedCell } from './SessionHeaderNumericAggregatedCell';
+import { SessionHeaderStringAggregatedCell } from './SessionHeaderStringAggregatedCell';
+import { StatusCellRenderer } from './StatusRenderer';
+import { calculateSessionDuration } from '../sessions-table/utils';
+
+const getSessionIdFromTrace = (trace: ModelTraceInfoV3): string | null => {
+  return trace.trace_metadata?.[SESSION_ID_METADATA_KEY] ?? null;
+};
+
+interface SessionHeaderCellProps {
+  column: TracesTableColumn;
+  sessionId: string;
+  otherSessionId?: string;
+  traces: ModelTraceInfoV3[];
+  otherTraces?: ModelTraceInfoV3[];
+  goal?: string;
+  persona?: string;
+  onChangeEvaluationId?: (evaluationId: string | undefined, traceInfo?: ModelTraceInfoV3) => void;
+  experimentId?: string;
+  isComparing?: boolean;
+  getRunColor?: (runUuid: string) => string;
+  runUuid?: string;
+  compareToRunUuid?: string;
+  onExpandSession?: () => void;
+  /** When set, matching text in the Request column is highlighted. */
+  searchQuery?: string;
+}
+
+/**
+ * Renders a cell in the session header row based on the column type.
+ * Returns null for columns that don't have session-level representations.
+ */
+export const SessionHeaderCell: React.FC<SessionHeaderCellProps> = ({
+  column,
+  sessionId,
+  otherSessionId,
+  traces,
+  otherTraces,
+  goal,
+  persona,
+  experimentId: experimentIdProp,
+  isComparing,
+  getRunColor,
+  runUuid,
+  compareToRunUuid,
+  onExpandSession,
+  searchQuery,
+}) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+  const firstTrace = traces[0];
+  const experimentId = getExperimentIdFromTraceLocation(firstTrace?.trace_location) ?? experimentIdProp;
+  const firstOtherTrace = otherTraces?.[0];
+
+  // Get run colors - use the passed runUuid/compareToRunUuid props directly for consistency with the comparison header.
+  // Fall back to extracting from trace metadata if not available.
+  const currentRunUuidResolved = runUuid || firstTrace?.trace_metadata?.[MLFLOW_SOURCE_RUN_KEY];
+  const otherRunUuidResolved = compareToRunUuid || firstOtherTrace?.trace_metadata?.[MLFLOW_SOURCE_RUN_KEY];
+  const currentRunColor =
+    getRunColor && currentRunUuidResolved ? getRunColor(currentRunUuidResolved) : CURRENT_RUN_COLOR;
+  const otherRunColor = getRunColor && otherRunUuidResolved ? getRunColor(otherRunUuidResolved) : COMPARE_TO_RUN_COLOR;
+
+  // Default: render empty cell for columns without session-level data
+  let cellContent: React.ReactNode = null;
+
+  // Render specific columns with data from the first trace
+  if (column.id === SESSION_COLUMN_ID) {
+    // Session ID column - render as a tag with link to session view
+    // In comparison mode, show both session IDs stacked only if they're different
+    const effectiveOtherSessionId = otherSessionId || (otherTraces?.[0] ? getSessionIdFromTrace(otherTraces[0]) : null);
+    const showBothSessionIds = isComparing && effectiveOtherSessionId && effectiveOtherSessionId !== sessionId;
+
+    if (isComparing && showBothSessionIds) {
+      // Different session IDs - show stacked
+      cellContent = (
+        <StackedComponents
+          first={
+            sessionId ? (
+              <SessionIdLinkWrapper sessionId={sessionId} experimentId={experimentId}>
+                <Tag
+                  componentId="mlflow.genai-traces-table.session-header-session-id"
+                  title={sessionId}
+                  css={{ maxWidth: '100%' }}
+                >
+                  <SpeechBubbleIcon css={{ fontSize: theme.typography.fontSizeBase, marginRight: theme.spacing.xs }} />
+                  <Typography.Text ellipsis>{sessionId}</Typography.Text>
+                </Tag>
+              </SessionIdLinkWrapper>
+            ) : (
+              <NullCell isComparing />
+            )
+          }
+          second={
+            <SessionIdLinkWrapper sessionId={effectiveOtherSessionId} experimentId={experimentId}>
+              <Tag
+                componentId="mlflow.genai-traces-table.session-header-session-id-other"
+                title={effectiveOtherSessionId}
+                css={{ maxWidth: '100%' }}
+              >
+                <SpeechBubbleIcon css={{ fontSize: theme.typography.fontSizeBase, marginRight: theme.spacing.xs }} />
+                <Typography.Text ellipsis>{effectiveOtherSessionId}</Typography.Text>
+              </Tag>
+            </SessionIdLinkWrapper>
+          }
+        />
+      );
+    } else if (isComparing) {
+      // Same session ID or only one exists - show single session ID (not stacked)
+      const displaySessionId = sessionId || effectiveOtherSessionId;
+      cellContent = displaySessionId ? (
+        <div css={{ overflow: 'hidden', minWidth: 0, maxWidth: '100%' }}>
+          <SessionIdLinkWrapper sessionId={displaySessionId} experimentId={experimentId}>
+            <Tag
+              componentId="mlflow.genai-traces-table.session-header-session-id"
+              title={displaySessionId}
+              css={{ maxWidth: '100%' }}
+            >
+              <SpeechBubbleIcon css={{ fontSize: theme.typography.fontSizeBase, marginRight: theme.spacing.xs }} />
+              <Typography.Text ellipsis>{displaySessionId}</Typography.Text>
+            </Tag>
+          </SessionIdLinkWrapper>
+        </div>
+      ) : (
+        <NullCell />
+      );
+    } else {
+      cellContent = (
+        <div css={{ overflow: 'hidden', minWidth: 0, maxWidth: '100%' }}>
+          <SessionIdLinkWrapper sessionId={sessionId} experimentId={experimentId}>
+            <Tag
+              componentId="mlflow.genai-traces-table.session-header-session-id"
+              title={sessionId}
+              css={{ maxWidth: '100%' }}
+            >
+              <SpeechBubbleIcon css={{ fontSize: theme.typography.fontSizeBase, marginRight: theme.spacing.xs }} />
+              <Typography.Text ellipsis>{sessionId}</Typography.Text>
+            </Tag>
+          </SessionIdLinkWrapper>
+        </div>
+      );
+    }
+  } else if (column.id === INPUTS_COLUMN_ID) {
+    // Request/Input column - get from first trace's request_preview
+    // In comparison mode, show stacked inputs with run colors
+    const inputTitle = firstTrace ? getTraceInfoInputs(firstTrace) : undefined;
+    const otherInputTitle = firstOtherTrace ? getTraceInfoInputs(firstOtherTrace) : undefined;
+    const displayInputTitle = inputTitle && searchQuery ? highlightSearchInText(inputTitle, searchQuery) : inputTitle;
+    const displayOtherInputTitle =
+      otherInputTitle && searchQuery ? highlightSearchInText(otherInputTitle, searchQuery) : otherInputTitle;
+
+    if (isComparing) {
+      cellContent = (
+        <div
+          css={{
+            display: 'flex',
+            width: '100%',
+            overflow: 'hidden',
+            alignItems: 'center',
+            gap: theme.spacing.sm,
+          }}
+        >
+          <div css={{ flex: 1, minWidth: 0, overflow: 'hidden' }}>
+            <StackedComponents
+              first={
+                displayInputTitle ? (
+                  <div
+                    css={{
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                      minWidth: 0,
+                    }}
+                    title={typeof inputTitle === 'string' ? inputTitle : undefined}
+                  >
+                    {displayInputTitle}
+                  </div>
+                ) : (
+                  <NullCell isComparing />
+                )
+              }
+              second={
+                displayOtherInputTitle ? (
+                  <div
+                    css={{
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                      minWidth: 0,
+                    }}
+                    title={typeof otherInputTitle === 'string' ? otherInputTitle : undefined}
+                  >
+                    {displayOtherInputTitle}
+                  </div>
+                ) : (
+                  <NullCell isComparing />
+                )
+              }
+            />
+          </div>
+          <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md, flexShrink: 0 }}>
+            <div css={{ display: 'flex' }}>
+              {firstTrace ? <RunColorCircle color={currentRunColor} /> : <div css={{ width: 12, height: 12 }} />}
+            </div>
+            <div css={{ display: 'flex' }}>
+              {firstOtherTrace ? <RunColorCircle color={otherRunColor} /> : <div css={{ width: 12, height: 12 }} />}
+            </div>
+          </div>
+        </div>
+      );
+    } else {
+      cellContent = displayInputTitle ? (
+        <SessionIdLinkWrapper sessionId={sessionId} experimentId={experimentId}>
+          <span
+            css={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              minWidth: 0,
+              color: theme.colors.actionPrimaryBackgroundDefault,
+              cursor: 'pointer',
+              '&:hover': {
+                textDecoration: 'underline',
+              },
+            }}
+            title={typeof inputTitle === 'string' ? inputTitle : undefined}
+          >
+            {displayInputTitle}
+          </span>
+        </SessionIdLinkWrapper>
+      ) : (
+        <NullCell />
+      );
+    }
+  } else if (column.id === REQUEST_TIME_COLUMN_ID) {
+    // Request time - format timestamp from first trace
+    const timestamp = firstTrace?.[REQUEST_TIME_COLUMN_ID];
+    const date = timestamp ? new Date(timestamp) : null;
+    const otherTimestamp = firstOtherTrace?.[REQUEST_TIME_COLUMN_ID];
+    const otherDate = otherTimestamp ? new Date(otherTimestamp) : null;
+
+    const formatOptions = {
+      year: 'numeric' as const,
+      month: '2-digit' as const,
+      day: '2-digit' as const,
+      hour: '2-digit' as const,
+      minute: '2-digit' as const,
+      second: '2-digit' as const,
+      hour12: false as const,
+    };
+
+    if (isComparing) {
+      cellContent = (
+        <StackedComponents
+          first={
+            date ? (
+              <Tooltip
+                componentId="mlflow.genai-traces-table.session-header-request-time"
+                content={date.toLocaleString(navigator.language, { timeZoneName: 'short' })}
+              >
+                <Typography.Text ellipsis>{formatDateTime(date, intl, formatOptions)}</Typography.Text>
+              </Tooltip>
+            ) : (
+              <NullCell isComparing />
+            )
+          }
+          second={
+            otherDate ? (
+              <Tooltip
+                componentId="mlflow.genai-traces-table.session-header-request-time-other"
+                content={otherDate.toLocaleString(navigator.language, { timeZoneName: 'short' })}
+              >
+                <Typography.Text ellipsis>{formatDateTime(otherDate, intl, formatOptions)}</Typography.Text>
+              </Tooltip>
+            ) : (
+              <NullCell isComparing />
+            )
+          }
+        />
+      );
+    } else {
+      cellContent = date ? (
+        <Tooltip
+          componentId="mlflow.genai-traces-table.session-header-request-time"
+          content={date.toLocaleString(navigator.language, { timeZoneName: 'short' })}
+        >
+          <Typography.Text ellipsis>{formatDateTime(date, intl, formatOptions)}</Typography.Text>
+        </Tooltip>
+      ) : (
+        <NullCell />
+      );
+    }
+  } else if (column.id === STATE_COLUMN_ID) {
+    // State column - show error/success status
+    const lastTrace = traces[traces.length - 1];
+    const lastOtherTrace = otherTraces?.[otherTraces.length - 1];
+
+    if (isComparing) {
+      cellContent = (
+        <StackedComponents
+          first={lastTrace ? <StatusCellRenderer original={lastTrace} isComparing /> : <NullCell isComparing />}
+          second={
+            lastOtherTrace ? <StatusCellRenderer original={lastOtherTrace} isComparing /> : <NullCell isComparing />
+          }
+        />
+      );
+    } else {
+      cellContent = lastTrace ? <StatusCellRenderer original={lastTrace} isComparing={false} /> : <NullCell />;
+    }
+  } else if (column.id === USER_COLUMN_ID) {
+    // User column - get from first trace's metadata or tags
+    const value = firstTrace?.trace_metadata?.[MLFLOW_TRACE_USER_KEY];
+    const otherValue = firstOtherTrace?.trace_metadata?.[MLFLOW_TRACE_USER_KEY];
+
+    if (isComparing) {
+      cellContent = (
+        <StackedComponents
+          first={
+            value ? (
+              <div
+                css={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: theme.spacing.xs,
+                  overflow: 'hidden',
+                  minWidth: 0,
+                }}
+                title={value}
+              >
+                <UserIcon css={{ color: theme.colors.textSecondary, fontSize: 16, flexShrink: 0 }} />
+                <Typography.Text ellipsis>{value}</Typography.Text>
+              </div>
+            ) : (
+              <NullCell isComparing />
+            )
+          }
+          second={
+            otherValue ? (
+              <div
+                css={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: theme.spacing.xs,
+                  overflow: 'hidden',
+                  minWidth: 0,
+                }}
+                title={otherValue}
+              >
+                <UserIcon css={{ color: theme.colors.textSecondary, fontSize: 16, flexShrink: 0 }} />
+                <Typography.Text ellipsis>{otherValue}</Typography.Text>
+              </div>
+            ) : (
+              <NullCell isComparing />
+            )
+          }
+        />
+      );
+    } else {
+      cellContent = value ? (
+        <div
+          css={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: theme.spacing.xs,
+            overflow: 'hidden',
+            minWidth: 0,
+          }}
+          title={value}
+        >
+          <UserIcon css={{ color: theme.colors.textSecondary, fontSize: 16, flexShrink: 0 }} />
+          <Typography.Text ellipsis>{value}</Typography.Text>
+        </div>
+      ) : (
+        <NullCell />
+      );
+    }
+  } else if (column.id === RESPONSE_COLUMN_ID) {
+    // Response column - get output from the last trace
+    const lastTrace = traces[traces.length - 1];
+    const lastOtherTrace = otherTraces?.[otherTraces.length - 1];
+    const value = lastTrace ? formatResponseTitle(getTraceInfoOutputs(lastTrace)) : undefined;
+    const otherValue = lastOtherTrace ? formatResponseTitle(getTraceInfoOutputs(lastOtherTrace)) : undefined;
+    const displayValue = value && searchQuery ? highlightSearchInText(value, searchQuery) : value;
+    const displayOtherValue = otherValue && searchQuery ? highlightSearchInText(otherValue, searchQuery) : otherValue;
+
+    if (isComparing) {
+      cellContent = (
+        <StackedComponents
+          first={
+            displayValue ? (
+              <div
+                css={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0 }}
+                title={typeof value === 'string' ? value : undefined}
+              >
+                {displayValue}
+              </div>
+            ) : (
+              <NullCell isComparing />
+            )
+          }
+          second={
+            displayOtherValue ? (
+              <div
+                css={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0 }}
+                title={typeof otherValue === 'string' ? otherValue : undefined}
+              >
+                {displayOtherValue}
+              </div>
+            ) : (
+              <NullCell isComparing />
+            )
+          }
+        />
+      );
+    } else {
+      cellContent = displayValue ? (
+        <div
+          css={{
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            minWidth: 0,
+          }}
+          title={typeof value === 'string' ? value : undefined}
+        >
+          {displayValue}
+        </div>
+      ) : (
+        <NullCell />
+      );
+    }
+  } else if (column.id === TOKENS_COLUMN_ID) {
+    // Tokens - sum all token counts
+    const calculateTokens = (tracesList: ModelTraceInfoV3[]) => {
+      let totalTokens = 0;
+      let totalInputTokens = 0;
+      let totalOutputTokens = 0;
+
+      tracesList.forEach((trace) => {
+        const tokenUsage = trace.trace_metadata?.[TOKEN_USAGE_METADATA_KEY];
+        try {
+          const parsedTokenUsage = tokenUsage ? JSON.parse(tokenUsage) : {};
+          totalTokens += parsedTokenUsage.total_tokens || 0;
+          totalInputTokens += parsedTokenUsage.input_tokens || 0;
+          totalOutputTokens += parsedTokenUsage.output_tokens || 0;
+        } catch {
+          // Skip invalid token data
+        }
+      });
+
+      return { totalTokens, totalInputTokens, totalOutputTokens };
+    };
+
+    const currentTokens = traces.length > 0 ? calculateTokens(traces) : null;
+    const otherTokens = otherTraces && otherTraces.length > 0 ? calculateTokens(otherTraces) : null;
+
+    if (isComparing) {
+      cellContent = (
+        <StackedComponents
+          first={
+            currentTokens ? (
+              <TokenComponent
+                inputTokens={currentTokens.totalInputTokens}
+                outputTokens={currentTokens.totalOutputTokens}
+                totalTokens={currentTokens.totalTokens}
+                isComparing={false}
+              />
+            ) : (
+              <NullCell isComparing />
+            )
+          }
+          second={
+            otherTokens ? (
+              <TokenComponent
+                inputTokens={otherTokens.totalInputTokens}
+                outputTokens={otherTokens.totalOutputTokens}
+                totalTokens={otherTokens.totalTokens}
+                isComparing={false}
+              />
+            ) : (
+              <NullCell isComparing />
+            )
+          }
+        />
+      );
+    } else {
+      cellContent = currentTokens ? (
+        <TokenComponent
+          inputTokens={currentTokens.totalInputTokens}
+          outputTokens={currentTokens.totalOutputTokens}
+          totalTokens={currentTokens.totalTokens}
+          isComparing={false}
+        />
+      ) : (
+        <NullCell />
+      );
+    }
+  } else if (column.id === EXECUTION_DURATION_COLUMN_ID) {
+    // Duration - sum all execution durations
+    const duration = traces.length > 0 ? normalizeDurationString(calculateSessionDuration(traces) ?? undefined) : null;
+    const otherDuration =
+      otherTraces && otherTraces.length > 0
+        ? normalizeDurationString(calculateSessionDuration(otherTraces) ?? undefined)
+        : null;
+
+    if (isComparing) {
+      cellContent = (
+        <StackedComponents
+          first={duration ? <ExecutionDurationTag value={duration} /> : <NullCell isComparing />}
+          second={otherDuration ? <ExecutionDurationTag value={otherDuration} /> : <NullCell isComparing />}
+        />
+      );
+    } else {
+      cellContent = duration ? <ExecutionDurationTag value={duration} /> : <NullCell />;
+    }
+  } else if (column.id === SIMULATION_GOAL_COLUMN_ID) {
+    // Goal column - show the simulation goal (same for matched sessions, so show once)
+    // Goal should be the same across matched sessions, so just show one value
+    cellContent = goal ? (
+      <div
+        css={{
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          minWidth: 0,
+        }}
+        title={goal}
+      >
+        {goal}
+      </div>
+    ) : (
+      <NullCell />
+    );
+  } else if (column.id === SIMULATION_PERSONA_COLUMN_ID) {
+    // Persona column - show the simulation persona (same for matched sessions, so show once)
+    // Persona should be the same across matched sessions, so just show one value
+    cellContent = persona ? (
+      <div
+        css={{
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          minWidth: 0,
+        }}
+        title={persona}
+      >
+        {persona}
+      </div>
+    ) : (
+      <NullCell />
+    );
+  } else if (
+    column.type === TracesTableColumnType.ASSESSMENT &&
+    column.assessmentInfo &&
+    column.assessmentInfo?.isSessionLevelAssessment
+  ) {
+    // Session-level assessment column - find the assessment with session metadata
+    const assessmentInfo = column.assessmentInfo;
+
+    const getSessionLevelAssessments = (tracesList: ModelTraceInfoV3[]) => {
+      const allFeedback = tracesList.flatMap((trace) =>
+        compact(
+          trace.assessments?.filter(
+            (a): a is FeedbackAssessment =>
+              Boolean(a.metadata?.[ASSESSMENT_SESSION_METADATA_KEY]) && isFeedbackAssessment(a),
+          ),
+        ),
+      );
+      const entries = allFeedback.map(convertFeedbackAssessmentToRunEvalAssessment);
+      return getUniqueValueCountsBySourceId(assessmentInfo, entries);
+    };
+
+    const renderAssessmentTags = (uniqueValueCounts: ReturnType<typeof getUniqueValueCountsBySourceId>) => (
+      <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
+        {uniqueValueCounts.map((uniqueValueCount) => (
+          <EvaluationsReviewAssessmentTag
+            key={`tag_${uniqueValueCount.latestAssessment.name}_${uniqueValueCount.value}`}
+            showRationaleInTooltip
+            disableJudgeTypeIcon
+            hideAssessmentName
+            assessment={uniqueValueCount.latestAssessment}
+            isRootCauseAssessment={false}
+            assessmentInfo={assessmentInfo}
+            type="value"
+            count={uniqueValueCount.count}
+          />
+        ))}
+      </div>
+    );
+
+    const currentUniqueValueCounts = traces.length > 0 ? getSessionLevelAssessments(traces) : [];
+    const otherUniqueValueCounts = otherTraces && otherTraces.length > 0 ? getSessionLevelAssessments(otherTraces) : [];
+
+    if (isComparing) {
+      cellContent = (
+        <StackedComponents
+          first={
+            currentUniqueValueCounts.length > 0 ? (
+              renderAssessmentTags(currentUniqueValueCounts)
+            ) : (
+              <NullCell isComparing />
+            )
+          }
+          second={
+            otherUniqueValueCounts.length > 0 ? renderAssessmentTags(otherUniqueValueCounts) : <NullCell isComparing />
+          }
+        />
+      );
+    } else {
+      cellContent = currentUniqueValueCounts.length > 0 ? renderAssessmentTags(currentUniqueValueCounts) : <NullCell />;
+    }
+  } else if (column.id === ISSUES_COLUMN_ID) {
+    // Issues column - collect all unique issues from all traces in the session
+    const collectUniqueIssues = (tracesList: ModelTraceInfoV3[]): Issue[] => {
+      const issueMap = new Map<string, Issue>();
+      tracesList.forEach((trace) => {
+        trace.assessments?.forEach((assessment) => {
+          if ('issue' in assessment && assessment.issue) {
+            const issueName = assessment.issue.issue_name;
+            const issueId = assessment.assessment_name;
+            // Use issue name as key to deduplicate (same issue name = same issue type)
+            if (!issueMap.has(issueName)) {
+              issueMap.set(issueName, { id: issueId, name: issueName });
+            }
+          }
+        });
+      });
+      return Array.from(issueMap.values());
+    };
+
+    const currentIssues = traces.length > 0 ? collectUniqueIssues(traces) : [];
+    const otherIssuesCollected = otherTraces && otherTraces.length > 0 ? collectUniqueIssues(otherTraces) : [];
+
+    cellContent = (
+      <IssuesCell issues={currentIssues} otherIssues={otherIssuesCollected} isComparing={isComparing ?? false} />
+    );
+  } else if (
+    column.type === TracesTableColumnType.ASSESSMENT &&
+    column.assessmentInfo &&
+    !column.assessmentInfo?.isSessionLevelAssessment
+  ) {
+    // Non-session-level assessment column - aggregate values from all traces
+    const assessmentInfo = column.assessmentInfo;
+    const { dtype } = assessmentInfo;
+
+    const renderAggregatedCell = (tracesList: ModelTraceInfoV3[]) => {
+      if (dtype === 'pass-fail' || dtype === 'boolean') {
+        return (
+          <SessionHeaderPassFailAggregatedCell
+            assessmentInfo={assessmentInfo}
+            traces={tracesList}
+            onExpandSession={onExpandSession}
+          />
+        );
+      } else if (dtype === 'numeric') {
+        return <SessionHeaderNumericAggregatedCell assessmentInfo={assessmentInfo} traces={tracesList} />;
+      } else if (dtype === 'string' || dtype === 'unknown') {
+        return <SessionHeaderStringAggregatedCell assessmentInfo={assessmentInfo} traces={tracesList} />;
+      } else {
+        return <NullCell isComparing={isComparing} />;
+      }
+    };
+
+    if (isComparing) {
+      cellContent = (
+        <StackedComponents
+          first={traces.length > 0 ? renderAggregatedCell(traces) : <NullCell isComparing />}
+          second={otherTraces && otherTraces.length > 0 ? renderAggregatedCell(otherTraces) : <NullCell isComparing />}
+        />
+      );
+    } else {
+      cellContent = traces.length > 0 ? renderAggregatedCell(traces) : <NullCell />;
+    }
+  }
+
+  return (
+    <TableCell
+      key={column.id}
+      wrapContent={false}
+      style={{
+        flex: `1 1 var(--col-${escapeCssSpecialCharacters(column.id)}-size)`,
+      }}
+      css={{
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+      }}
+    >
+      <div css={{ display: 'flex', overflow: 'hidden', minWidth: 0, flex: 1 }}>{cellContent}</div>
+    </TableCell>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/SessionHeaderNumericAggregatedCell.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/SessionHeaderNumericAggregatedCell.tsx
@@ -1,0 +1,48 @@
+import { Tag, Tooltip, Typography } from '@databricks/design-system';
+import { aggregateNumericAssessments } from '../utils/SessionAggregationUtils';
+import type { AssessmentInfo } from '../types';
+import { FormattedMessage } from '@databricks/i18n';
+import type { ModelTraceInfoV3 } from '../../model-trace-explorer/ModelTrace.types';
+import { NullCell } from './NullCell';
+
+const getDisplayValue = (average: number) => {
+  const formattedAverage = Number.isInteger(average) ? average.toString() : average.toFixed(2).replace(/\.?0+$/, '');
+  return (
+    <FormattedMessage
+      defaultMessage="{formattedAverage} (AVG)"
+      description="Label showing the average value of numeric assessments"
+      values={{ formattedAverage }}
+    />
+  );
+};
+
+export const SessionHeaderNumericAggregatedCell = ({
+  assessmentInfo,
+  traces,
+}: {
+  assessmentInfo: AssessmentInfo;
+  traces: ModelTraceInfoV3[];
+}) => {
+  const { average, count } = aggregateNumericAssessments(traces, assessmentInfo.name);
+
+  if (average === null) {
+    return <NullCell />;
+  }
+
+  return (
+    <Tooltip
+      componentId="mlflow.genai-traces-table.session-numeric-assessment"
+      content={
+        <FormattedMessage
+          defaultMessage="Average of {count} values"
+          description="Tooltip for numeric assessment average in session header"
+          values={{ count }}
+        />
+      }
+    >
+      <Tag componentId="mlflow.genai-traces-table.average-values-tag">
+        <Typography.Text size="sm">{getDisplayValue(average)}</Typography.Text>
+      </Tag>
+    </Tooltip>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/SessionHeaderPassFailAggregatedCell.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/SessionHeaderPassFailAggregatedCell.tsx
@@ -1,0 +1,153 @@
+import { DangerIcon, Tooltip, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import type { AssessmentInfo } from '../types';
+import type { ModelTraceInfoV3 } from '../../model-trace-explorer/ModelTrace.types';
+import { FormattedMessage, useIntl } from '@databricks/i18n';
+import { aggregatePassFailAssessments } from '../utils/SessionAggregationUtils';
+import { FAIL_BARCHART_BAR_COLOR, PASS_BARCHART_BAR_COLOR } from '../utils/Colors';
+import { NullCell } from './NullCell';
+
+export const SessionHeaderPassFailAggregatedCell = ({
+  assessmentInfo,
+  traces,
+  onExpandSession,
+}: {
+  assessmentInfo: AssessmentInfo;
+  traces: ModelTraceInfoV3[];
+  onExpandSession?: () => void;
+}) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+
+  // Non-session-level assessment column - aggregate values from all traces
+  const { passCount, totalCount, errorCount } = aggregatePassFailAssessments(traces, assessmentInfo);
+
+  if (totalCount > 0 || errorCount > 0) {
+    const handleClick = () => {
+      onExpandSession?.();
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        onExpandSession?.();
+      }
+    };
+
+    const content = (
+      <div
+        css={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: theme.spacing.xs,
+          minWidth: 0,
+          width: totalCount > 0 ? '100%' : 'fit-content',
+          cursor: onExpandSession ? 'pointer' : undefined,
+          borderRadius: theme.borders.borderRadiusSm,
+          '&:hover': onExpandSession
+            ? {
+                backgroundColor: theme.colors.actionTertiaryBackgroundHover,
+              }
+            : undefined,
+        }}
+        onClick={onExpandSession ? handleClick : undefined}
+        onKeyDown={onExpandSession ? handleKeyDown : undefined}
+        role={onExpandSession ? 'button' : undefined}
+        tabIndex={onExpandSession ? 0 : undefined}
+      >
+        {totalCount > 0 && (
+          <div
+            css={{
+              display: 'flex',
+              flex: 1,
+              minWidth: 0,
+              height: theme.spacing.sm,
+              borderRadius: theme.borders.borderRadiusMd,
+              overflow: 'hidden',
+            }}
+          >
+            {passCount > 0 && (
+              <div
+                css={{
+                  flex: passCount,
+                  backgroundColor: PASS_BARCHART_BAR_COLOR,
+                }}
+              />
+            )}
+            {passCount < totalCount && (
+              <div
+                css={{
+                  flex: totalCount - passCount,
+                  backgroundColor: FAIL_BARCHART_BAR_COLOR,
+                }}
+              />
+            )}
+          </div>
+        )}
+        <span
+          css={{
+            display: 'flex',
+            alignItems: 'center',
+            flexShrink: 0,
+            fontSize: theme.typography.fontSizeSm,
+            color: theme.colors.textPrimary,
+            whiteSpace: 'nowrap',
+            width: 50,
+          }}
+        >
+          {totalCount > 0 ? (
+            <>
+              <Typography.Text bold size="sm">
+                {passCount}/{totalCount}
+              </Typography.Text>
+              {errorCount > 0 && (
+                <DangerIcon css={{ fontSize: 12, marginLeft: 4, color: theme.colors.textValidationWarning }} />
+              )}
+            </>
+          ) : (
+            <span css={{ display: 'flex', alignItems: 'center', color: theme.colors.textValidationWarning }}>
+              <DangerIcon css={{ fontSize: 12, marginRight: 4 }} />
+              <Typography.Text size="sm" color="warning">
+                <FormattedMessage defaultMessage="Error" description="Label shown when all assessments have errors" />
+              </Typography.Text>
+            </span>
+          )}
+        </span>
+      </div>
+    );
+
+    const getTooltipContent = () => {
+      const expandMessage = intl.formatMessage({
+        defaultMessage: 'Click to expand',
+        description: 'Tooltip for expandable session cell',
+      });
+
+      if (errorCount > 0) {
+        const errorMessage = intl.formatMessage(
+          {
+            defaultMessage: '{errorCount, plural, one {# error} other {# errors}}',
+            description: 'Error count in tooltip',
+          },
+          { errorCount },
+        );
+        return `${errorMessage} · ${expandMessage}`;
+      }
+
+      return expandMessage;
+    };
+
+    if (onExpandSession || errorCount > 0) {
+      return (
+        <Tooltip
+          componentId="mlflow.genai-traces-table.session-header.pass-fail-aggregated-tooltip"
+          content={getTooltipContent()}
+        >
+          {content}
+        </Tooltip>
+      );
+    }
+
+    return content;
+  }
+
+  return <NullCell />;
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/SessionHeaderStringAggregatedCell.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/SessionHeaderStringAggregatedCell.tsx
@@ -1,0 +1,58 @@
+import { HoverCard, Tag, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { aggregateStringAssessments } from '../utils/SessionAggregationUtils';
+import type { AssessmentInfo } from '../types';
+import { FormattedMessage } from '@databricks/i18n';
+import type { ModelTraceInfoV3 } from '../../model-trace-explorer/ModelTrace.types';
+import { NullCell } from './NullCell';
+
+export const SessionHeaderStringAggregatedCell = ({
+  assessmentInfo,
+  traces,
+}: {
+  assessmentInfo: AssessmentInfo;
+  traces: ModelTraceInfoV3[];
+}) => {
+  const { valueCounts, totalCount } = aggregateStringAssessments(traces, assessmentInfo.name);
+  const { theme } = useDesignSystemTheme();
+  const uniqueCount = valueCounts.size;
+
+  // Sort values by count (descending)
+  const sortedEntries = Array.from(valueCounts.entries()).sort((a, b) => b[1] - a[1]);
+
+  if (totalCount === 0) {
+    return <NullCell />;
+  }
+
+  return (
+    <HoverCard
+      trigger={
+        <Tag css={{ cursor: 'default' }} componentId="mlflow.genai-traces-table.session-string-tag">
+          <FormattedMessage
+            defaultMessage="{count} {count, plural, one {value} other {values}}"
+            description="Tag showing the number of unique string values in session assessment"
+            values={{ count: uniqueCount }}
+          />
+        </Tag>
+      }
+      content={
+        <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+          {sortedEntries.map(([value, count]) => (
+            <div
+              key={value}
+              css={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                gap: theme.spacing.md,
+              }}
+            >
+              <Typography.Text ellipsis css={{ maxWidth: 200 }}>
+                {value}
+              </Typography.Text>
+              <Typography.Text color="secondary">{count}</Typography.Text>
+            </div>
+          ))}
+        </div>
+      }
+    />
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/SessionIdLinkWrapper.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/SessionIdLinkWrapper.tsx
@@ -1,0 +1,35 @@
+import { SELECTED_TRACE_ID_QUERY_PARAM } from '../../model-trace-explorer/constants';
+
+import MlflowUtils from '../utils/MlflowUtils';
+import { Link } from '../utils/RoutingUtils';
+
+export const SessionIdLinkWrapper = ({
+  sessionId,
+  experimentId,
+  traceId,
+  children,
+}: {
+  sessionId: string;
+  experimentId?: string;
+  traceId?: string;
+  children: React.ReactElement;
+}) => {
+  if (!experimentId) {
+    return children;
+  }
+
+  const baseUrl = MlflowUtils.getExperimentChatSessionPageRoute(experimentId, sessionId);
+  const url = traceId
+    ? `${baseUrl}?${new URLSearchParams({ [SELECTED_TRACE_ID_QUERY_PARAM]: traceId }).toString()}`
+    : baseUrl;
+
+  return (
+    <Link
+      componentId="mlflow.genai-traces-table.session_id_link"
+      // prettier-ignore
+      to={url}
+    >
+      {children}
+    </Link>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/Source/ExperimentSourceTypeIcon.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/Source/ExperimentSourceTypeIcon.tsx
@@ -1,0 +1,28 @@
+import { FolderBranchIcon, HomeIcon, NotebookIcon, WorkflowsIcon } from '@databricks/design-system';
+
+enum SourceType {
+  NOTEBOOK = 'NOTEBOOK',
+  JOB = 'JOB',
+  PROJECT = 'PROJECT',
+  LOCAL = 'LOCAL',
+  UNKNOWN = 'UNKNOWN',
+}
+
+export const ExperimentSourceTypeIcon = ({
+  sourceType,
+  className,
+}: {
+  sourceType: SourceType | string;
+  className?: string;
+}) => {
+  if (sourceType === SourceType.NOTEBOOK) {
+    return <NotebookIcon className={className} />;
+  } else if (sourceType === SourceType.LOCAL) {
+    return <HomeIcon className={className} />;
+  } else if (sourceType === SourceType.PROJECT) {
+    return <FolderBranchIcon className={className} />;
+  } else if (sourceType === SourceType.JOB) {
+    return <WorkflowsIcon className={className} />;
+  }
+  return null;
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/Source/SourceRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/Source/SourceRenderer.tsx
@@ -1,0 +1,47 @@
+import { useDesignSystemTheme } from '@databricks/design-system';
+
+import { ExperimentSourceTypeIcon } from './ExperimentSourceTypeIcon';
+import type { ModelTraceInfoV3 } from '../../../model-trace-explorer/ModelTrace.types';
+import MlflowUtils from '../../utils/MlflowUtils';
+import { NullCell } from '../NullCell';
+
+export const SourceCellRenderer = (props: {
+  traceInfo: ModelTraceInfoV3;
+  isComparing: boolean;
+  disableLinks?: boolean;
+}) => {
+  const tags = props.traceInfo.tags;
+  const { theme } = useDesignSystemTheme();
+
+  if (!tags) {
+    return <NullCell isComparing={props.isComparing} />;
+  }
+
+  const sourceType = props.traceInfo.trace_metadata?.[MlflowUtils.sourceTypeTag];
+
+  const sourceLink = MlflowUtils.renderSourceFromMetadata(props.traceInfo);
+
+  return sourceLink && sourceType ? (
+    <div
+      css={{
+        display: 'flex',
+        gap: theme.spacing.xs,
+        alignItems: 'center',
+        // Disable links if the disableLinks prop is true
+        ...(props.disableLinks && {
+          '& a': {
+            pointerEvents: 'none',
+            color: 'inherit',
+            textDecoration: 'none',
+            cursor: 'default',
+          },
+        }),
+      }}
+    >
+      <ExperimentSourceTypeIcon sourceType={sourceType} css={{ color: theme.colors.textSecondary }} />
+      <span css={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{sourceLink}</span>
+    </div>
+  ) : (
+    <NullCell isComparing={props.isComparing} />
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/StackedComponents.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/StackedComponents.tsx
@@ -1,0 +1,31 @@
+import { useDesignSystemTheme } from '@databricks/design-system';
+
+export interface StackedComponentsProps {
+  first: React.ReactNode;
+  second?: React.ReactNode;
+  // Allow overriding the default styles if needed:
+  gap?: string;
+  borderRadius?: string;
+  marginY?: string;
+}
+
+export const StackedComponents = (props: StackedComponentsProps) => {
+  const { first, second, gap, borderRadius, marginY } = props;
+  const { theme } = useDesignSystemTheme();
+
+  return (
+    <div
+      css={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: gap || theme.spacing.sm,
+        borderRadius: borderRadius || theme.legacyBorders.borderRadiusMd,
+        marginTop: marginY || 'auto',
+        marginBottom: marginY || 'auto',
+      }}
+    >
+      {first}
+      {second}
+    </div>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/StatusRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/StatusRenderer.tsx
@@ -1,0 +1,93 @@
+import type { Theme } from '@emotion/react';
+
+import {
+  CheckCircleIcon,
+  ClockIcon,
+  useDesignSystemTheme,
+  XCircleIcon,
+  Tag,
+  type TagColors,
+} from '@databricks/design-system';
+import { useIntl, defineMessage } from '@databricks/i18n';
+
+import { NullCell } from './NullCell';
+import type { ModelTraceInfoV3 } from '../../model-trace-explorer/ModelTrace.types';
+
+export const ExperimentViewTracesStatusLabels = {
+  STATE_UNSPECIFIED: null,
+  IN_PROGRESS: defineMessage({
+    defaultMessage: 'In progress',
+    description: 'Experiment page > traces table > status label > in progress',
+  }),
+  OK: defineMessage({
+    defaultMessage: 'OK',
+    description: 'Experiment page > traces table > status label > ok',
+  }),
+  ERROR: defineMessage({
+    defaultMessage: 'Error',
+    description: 'Experiment page > traces table > status label > error',
+  }),
+};
+
+const getIcon = (state: ModelTraceInfoV3['state'], theme: Theme) => {
+  if (state === 'IN_PROGRESS') {
+    return <ClockIcon css={{ color: theme.colors.textValidationWarning, width: 14, height: 14 }} />;
+  }
+
+  if (state === 'OK') {
+    return <CheckCircleIcon css={{ color: theme.colors.textValidationSuccess, width: 14, height: 14 }} />;
+  }
+
+  if (state === 'ERROR') {
+    return <XCircleIcon css={{ color: theme.colors.textValidationDanger, width: 14, height: 14 }} />;
+  }
+
+  return null;
+};
+
+const getTagColor = (state: ModelTraceInfoV3['state']): TagColors | undefined => {
+  if (state === 'IN_PROGRESS') {
+    return 'lemon';
+  }
+
+  if (state === 'OK') {
+    return 'teal';
+  }
+
+  if (state === 'ERROR') {
+    return 'coral';
+  }
+
+  return undefined;
+};
+
+export const StatusCellRenderer = ({
+  original,
+  isComparing,
+}: {
+  original: ModelTraceInfoV3 | undefined;
+  isComparing: boolean;
+}) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+
+  const labelDescriptor = ExperimentViewTracesStatusLabels[original?.state || 'STATE_UNSPECIFIED'];
+  const state = original?.state || 'STATE_UNSPECIFIED';
+
+  return labelDescriptor ? (
+    <Tag
+      color={getTagColor(state)}
+      componentId="mlflow.genai-traces-table.status"
+      css={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        width: 'fit-content',
+      }}
+    >
+      {getIcon(state, theme)}
+      <span css={{ marginLeft: theme.spacing.xs }}>{intl.formatMessage(labelDescriptor)}</span>
+    </Tag>
+  ) : (
+    <NullCell isComparing={isComparing} />
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/Tags/KeyValueTag.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/Tags/KeyValueTag.tsx
@@ -1,0 +1,125 @@
+import type { Interpolation, Theme } from '@emotion/react';
+import React, { useState } from 'react';
+
+import { Tag, Tooltip, Typography } from '@databricks/design-system';
+import { useIntl } from '@databricks/i18n';
+
+import { KeyValueTagFullViewModal } from './KeyValueTagFullViewModal';
+
+/**
+ * An arbitrary number that is used to determine if a tag is too
+ * long and should be truncated. We want to avoid short keys or values
+ * in a long tag to be truncated
+ * */
+const TRUNCATE_ON_CHARS_LENGTH = 30;
+
+function getTruncatedStyles(shouldTruncate = true): Interpolation<Theme> {
+  return shouldTruncate
+    ? {
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        textWrap: 'nowrap',
+        whiteSpace: 'nowrap' as const,
+      }
+    : { whiteSpace: 'nowrap' as const };
+}
+
+interface KeyValueEntity {
+  key: string;
+  value: string;
+}
+
+/**
+ * A <Tag /> wrapper used for displaying key-value entity
+ */
+export const KeyValueTag = ({
+  isClosable = false,
+  onClose,
+  tag,
+  enableFullViewModal = false,
+  charLimit = TRUNCATE_ON_CHARS_LENGTH,
+  maxWidth = 300,
+  className,
+}: {
+  isClosable?: boolean;
+  onClose?: () => void;
+  tag: KeyValueEntity;
+  enableFullViewModal?: boolean;
+  charLimit?: number;
+  maxWidth?: number;
+  className?: string;
+}) => {
+  const intl = useIntl();
+
+  const [isKeyValueTagFullViewModalVisible, setIsKeyValueTagFullViewModalVisible] = useState(false);
+
+  const { shouldTruncateKey, shouldTruncateValue } = getKeyAndValueComplexTruncation(tag, charLimit);
+  const allowFullViewModal = enableFullViewModal && (shouldTruncateKey || shouldTruncateValue);
+
+  const fullViewModalLabel = intl.formatMessage({
+    defaultMessage: 'Click to see more',
+    description: 'Run page > Overview > Tags cell > Tag',
+  });
+
+  return (
+    <div>
+      <Tag
+        componentId="codegen_mlflow_app_src_common_components_keyvaluetag.tsx_60"
+        closable={isClosable}
+        onClose={onClose}
+        title={tag.key}
+        className={className}
+      >
+        <Tooltip
+          componentId="web-shared.genai-traces-table.key-value-tag.full-view-tooltip"
+          content={allowFullViewModal ? <span>{fullViewModalLabel}</span> : undefined}
+        >
+          <span
+            css={{ maxWidth, display: 'inline-flex' }}
+            onClick={() => (allowFullViewModal ? setIsKeyValueTagFullViewModalVisible(true) : undefined)}
+          >
+            <Typography.Text bold title={tag.key} css={getTruncatedStyles(shouldTruncateKey)}>
+              {tag.key}
+            </Typography.Text>
+            {tag.value && (
+              <Typography.Text title={tag.value} css={getTruncatedStyles(shouldTruncateValue)}>
+                : {tag.value}
+              </Typography.Text>
+            )}
+          </span>
+        </Tooltip>
+      </Tag>
+      <div>
+        {isKeyValueTagFullViewModalVisible && (
+          <KeyValueTagFullViewModal
+            tagKey={tag.key}
+            tagValue={tag.value}
+            isKeyValueTagFullViewModalVisible={isKeyValueTagFullViewModalVisible}
+            setIsKeyValueTagFullViewModalVisible={setIsKeyValueTagFullViewModalVisible}
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export function getKeyAndValueComplexTruncation(
+  tag: KeyValueEntity,
+  charLimit = TRUNCATE_ON_CHARS_LENGTH,
+): { shouldTruncateKey: boolean; shouldTruncateValue: boolean } {
+  const { key, value } = tag;
+  const fullLength = key.length + value.length;
+  const isKeyLonger = key.length > value.length;
+  const shorterLength = isKeyLonger ? value.length : key.length;
+
+  // No need to truncate if tag is short enough
+  if (fullLength <= charLimit) return { shouldTruncateKey: false, shouldTruncateValue: false };
+  // If the shorter string is too long, truncate both key and value.
+  if (shorterLength > charLimit / 2) return { shouldTruncateKey: true, shouldTruncateValue: true };
+
+  // Otherwise truncate the longer string
+  return {
+    shouldTruncateKey: isKeyLonger,
+    shouldTruncateValue: !isKeyLonger,
+  };
+}

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/Tags/KeyValueTagFullViewModal.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/Tags/KeyValueTagFullViewModal.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+import { Modal, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { CopyActionButton } from '../../../copy/CopyActionButton';
+const { Paragraph } = Typography;
+
+export interface KeyValueTagFullViewModalProps {
+  tagKey: string;
+  tagValue: string;
+  setIsKeyValueTagFullViewModalVisible: React.Dispatch<React.SetStateAction<boolean>>;
+  isKeyValueTagFullViewModalVisible: boolean;
+}
+
+// eslint-disable-next-line react-component-name/react-component-name -- TODO(FEINF-4716)
+export const KeyValueTagFullViewModal = React.memo((props: KeyValueTagFullViewModalProps) => {
+  const { theme } = useDesignSystemTheme();
+
+  return (
+    <Modal
+      componentId="codegen_mlflow_app_src_common_components_keyvaluetagfullviewmodal.tsx_17"
+      title={'Tag: ' + props.tagKey}
+      visible={props.isKeyValueTagFullViewModalVisible}
+      onCancel={() => props.setIsKeyValueTagFullViewModalVisible(false)}
+    >
+      <div css={{ display: 'flex', alignItems: 'center' }}>
+        <Paragraph css={{ flexGrow: 1 }}>
+          <pre
+            css={{
+              backgroundColor: theme.colors.backgroundPrimary,
+              marginTop: theme.spacing.sm,
+              whiteSpace: 'pre-wrap',
+              wordBreak: 'break-all',
+            }}
+          >
+            {props.tagValue}
+          </pre>
+        </Paragraph>
+        <div
+          css={{
+            marginBottom: theme.spacing.md,
+          }}
+        >
+          <CopyActionButton
+            componentId="mlflow.genai-traces-table.tag_view_modal.tag_value_copy_button"
+            copyText={props.tagValue}
+          />
+        </div>
+      </div>
+    </Modal>
+  );
+});

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/Tags/TagsCellRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/Tags/TagsCellRenderer.tsx
@@ -1,0 +1,68 @@
+import { Button, PencilIcon, useDesignSystemTheme } from '@databricks/design-system';
+import { FormattedMessage } from '@databricks/i18n';
+
+import { KeyValueTag } from './KeyValueTag';
+import { MLFLOW_INTERNAL_PREFIX } from '../../utils/TraceUtils';
+
+export const TagsCellRenderer = ({
+  onAddEditTags,
+  tags,
+  baseComponentId,
+}: {
+  tags: { key: string; value: string }[];
+  onAddEditTags?: () => void;
+  baseComponentId: string;
+}) => {
+  const { theme } = useDesignSystemTheme();
+  const visibleTagList = tags?.filter(({ key }) => key && !key.startsWith(MLFLOW_INTERNAL_PREFIX)) || [];
+  const containsTags = visibleTagList.length > 0;
+  return (
+    <div
+      css={{
+        display: 'flex',
+        alignItems: 'center',
+        flexWrap: 'wrap',
+        columnGap: theme.spacing.xs,
+        rowGap: theme.spacing.xs,
+      }}
+    >
+      {visibleTagList.map((tag) => (
+        <KeyValueTag
+          key={tag.key}
+          tag={tag}
+          css={{ marginRight: 0 }}
+          charLimit={20}
+          maxWidth={150}
+          enableFullViewModal
+        />
+      ))}
+      {onAddEditTags && (
+        <Button
+          componentId="mlflow.tags_cell_renderer.traces_table.edit_tag"
+          size="small"
+          icon={!containsTags ? undefined : <PencilIcon />}
+          onClick={onAddEditTags}
+          children={
+            !containsTags ? (
+              <FormattedMessage
+                defaultMessage="Add tags"
+                description="Button text to add tags to a trace in the experiment traces table"
+              />
+            ) : undefined
+          }
+          css={{
+            flexShrink: 0,
+            opacity: 0,
+            '[role=row]:hover &': {
+              opacity: 1,
+            },
+            '[role=row]:focus-within &': {
+              opacity: 1,
+            },
+          }}
+          type="tertiary"
+        />
+      )}
+    </div>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/TokensCell.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/TokensCell.tsx
@@ -1,0 +1,217 @@
+import { HoverCard, Tag, Typography } from '@databricks/design-system';
+import { useIntl } from '@databricks/i18n';
+import { getTraceTokenUsage } from '../../model-trace-explorer/ModelTraceExplorer.utils';
+import type { ModelTraceInfoV3 } from '../../model-trace-explorer/ModelTrace.types';
+
+import { NullCell } from './NullCell';
+import { StackedComponents } from './StackedComponents';
+
+export const TokensCell = (props: {
+  currentTraceInfo?: ModelTraceInfoV3;
+  otherTraceInfo?: ModelTraceInfoV3;
+  isComparing: boolean;
+}) => {
+  const { currentTraceInfo, otherTraceInfo, isComparing } = props;
+
+  const currentTokenUsage = currentTraceInfo ? getTraceTokenUsage(currentTraceInfo) : undefined;
+  const otherTokenUsage = otherTraceInfo ? getTraceTokenUsage(otherTraceInfo) : undefined;
+
+  return (
+    <StackedComponents
+      first={
+        <TokenComponent
+          inputTokens={currentTokenUsage?.input_tokens}
+          outputTokens={currentTokenUsage?.output_tokens}
+          totalTokens={currentTokenUsage?.total_tokens}
+          cachedInputTokens={currentTokenUsage?.cache_read_input_tokens}
+          cacheCreationInputTokens={currentTokenUsage?.cache_creation_input_tokens}
+          isComparing={isComparing}
+        />
+      }
+      second={
+        isComparing && (
+          <TokenComponent
+            inputTokens={otherTokenUsage?.input_tokens}
+            outputTokens={otherTokenUsage?.output_tokens}
+            totalTokens={otherTokenUsage?.total_tokens}
+            cachedInputTokens={otherTokenUsage?.cache_read_input_tokens}
+            cacheCreationInputTokens={otherTokenUsage?.cache_creation_input_tokens}
+            isComparing={isComparing}
+          />
+        )
+      }
+    />
+  );
+};
+
+export const TokenComponent = ({
+  inputTokens,
+  outputTokens,
+  totalTokens,
+  cachedInputTokens,
+  cacheCreationInputTokens,
+  isComparing,
+}: {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  cachedInputTokens?: number;
+  cacheCreationInputTokens?: number;
+  isComparing: boolean;
+}) => {
+  const intl = useIntl();
+
+  if (!totalTokens) {
+    return <NullCell isComparing={isComparing} />;
+  }
+
+  return (
+    <HoverCard
+      trigger={
+        <Tag css={{ width: 'fit-content', maxWidth: '100%' }} componentId="mlflow.genai-traces-table.tokens">
+          <span
+            css={{
+              display: 'block',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {totalTokens}
+          </span>
+        </Tag>
+      }
+      content={
+        <div
+          css={{
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+        >
+          {totalTokens && (
+            <div
+              css={{
+                display: 'flex',
+                flexDirection: 'row',
+              }}
+            >
+              <div
+                css={{
+                  width: '35%',
+                }}
+              >
+                <Typography.Text>
+                  {intl.formatMessage({
+                    defaultMessage: 'Total',
+                    description: 'Label for the total tokensin the tooltip for the tokens cell.',
+                  })}
+                </Typography.Text>
+              </div>
+              <div>
+                <Typography.Text color="secondary">{totalTokens}</Typography.Text>
+              </div>
+            </div>
+          )}
+          {inputTokens && (
+            <div
+              css={{
+                display: 'flex',
+                flexDirection: 'row',
+              }}
+            >
+              <div
+                css={{
+                  width: '35%',
+                }}
+              >
+                <Typography.Text>
+                  {intl.formatMessage({
+                    defaultMessage: 'Input',
+                    description: 'Label for the input tokens in the tooltip for the tokens cell.',
+                  })}
+                </Typography.Text>
+              </div>
+              <div>
+                <Typography.Text color="secondary">{inputTokens}</Typography.Text>
+              </div>
+            </div>
+          )}
+          {outputTokens && (
+            <div
+              css={{
+                display: 'flex',
+                flexDirection: 'row',
+              }}
+            >
+              <div
+                css={{
+                  width: '35%',
+                }}
+              >
+                <Typography.Text>
+                  {intl.formatMessage({
+                    defaultMessage: 'Output',
+                    description: 'Label for the output tokens in the tooltip for the tokens cell.',
+                  })}
+                </Typography.Text>
+              </div>
+              <div>
+                <Typography.Text color="secondary">{outputTokens}</Typography.Text>
+              </div>
+            </div>
+          )}
+          {cachedInputTokens !== null && cachedInputTokens !== undefined && cachedInputTokens > 0 && (
+            <div
+              css={{
+                display: 'flex',
+                flexDirection: 'row',
+              }}
+            >
+              <div
+                css={{
+                  width: '35%',
+                }}
+              >
+                <Typography.Text>
+                  {intl.formatMessage({
+                    defaultMessage: 'Cached',
+                    description: 'Label for the cached input tokens in the tooltip for the tokens cell.',
+                  })}
+                </Typography.Text>
+              </div>
+              <div>
+                <Typography.Text color="secondary">{cachedInputTokens}</Typography.Text>
+              </div>
+            </div>
+          )}
+          {cacheCreationInputTokens !== null &&
+            cacheCreationInputTokens !== undefined &&
+            cacheCreationInputTokens > 0 && (
+              <div
+                css={{
+                  display: 'flex',
+                  flexDirection: 'row',
+                }}
+              >
+                <div
+                  css={{
+                    width: '35%',
+                  }}
+                >
+                  <Typography.Text>
+                    {intl.formatMessage({
+                      defaultMessage: 'Cache write',
+                      description: 'Label for the cache creation input tokens in the tooltip for the tokens cell.',
+                    })}
+                  </Typography.Text>
+                </div>
+                <div>
+                  <Typography.Text color="secondary">{cacheCreationInputTokens}</Typography.Text>
+                </div>
+              </div>
+            )}
+        </div>
+      }
+    />
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/rendererFunctions.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/cellRenderers/rendererFunctions.tsx
@@ -1,0 +1,1176 @@
+import type { CellContext } from '@tanstack/react-table';
+import { first, isNil } from 'lodash';
+import React, { useContext, useMemo } from 'react';
+import type { FormatDateOptions } from 'react-intl';
+
+import type { ThemeType } from '@databricks/design-system';
+import {
+  ArrowRightIcon,
+  CheckCircleIcon,
+  HoverCard,
+  Overflow,
+  Spinner,
+  Tag,
+  Tooltip,
+  Typography,
+  useDesignSystemTheme,
+  UserIcon,
+  XCircleIcon,
+} from '@databricks/design-system';
+import { FormattedMessage, useIntl, type IntlShape } from '@databricks/i18n';
+import type { ModelTraceInfoV3 } from '../../model-trace-explorer/ModelTrace.types';
+import { ExpectationValuePreview } from '../../model-trace-explorer/assessments-pane/ExpectationValuePreview';
+import { useModelTraceExplorerRunJudgesContext } from '../../model-trace-explorer/contexts/RunJudgesContext';
+
+import { GenAITracesTableContext } from '../GenAITracesTableContext';
+
+import { ExecutionDurationTag } from './ExecutionDurationTag';
+import { IssuesCell } from './IssuesCell';
+import { LoggedModelCell } from './LoggedModelCell';
+import { NullCell } from './NullCell';
+import { RunName } from './RunName';
+import { Link, generatePath } from '../utils/RoutingUtils';
+import { SessionIdLinkWrapper } from './SessionIdLinkWrapper';
+import { SourceCellRenderer } from './Source/SourceRenderer';
+import { StackedComponents } from './StackedComponents';
+import { StatusCellRenderer } from './StatusRenderer';
+import { TagsCellRenderer } from './Tags/TagsCellRenderer';
+import { TokensCell } from './TokensCell';
+import { getTraceInfoValueWithColId } from '../GenAiTracesTable.utils';
+import { compareAssessmentValues, formatResponseTitle } from '../GenAiTracesTableBody.utils';
+import { EvaluationsReviewAssessmentTag } from '../components/EvaluationsReviewAssessmentTag';
+import {
+  getEvaluationResultAssessmentValue,
+  getEvaluationResultInputTitle,
+  KnownEvaluationResultAssessmentValueMissingTooltip,
+  stringifyValue,
+} from '../components/GenAiEvaluationTracesReview.utils';
+import { RunColorCircle } from '../components/RunColorCircle';
+import {
+  CUSTOM_METADATA_COLUMN_ID,
+  EXECUTION_DURATION_COLUMN_ID,
+  ISSUES_COLUMN_ID,
+  LINKED_PROMPTS_COLUMN_ID,
+  LOGGED_MODEL_COLUMN_ID,
+  REQUEST_TIME_COLUMN_ID,
+  RESPONSE_COLUMN_ID,
+  RUN_NAME_COLUMN_ID,
+  SESSION_COLUMN_ID,
+  SIMULATION_GOAL_COLUMN_ID,
+  SIMULATION_PERSONA_COLUMN_ID,
+  SOURCE_COLUMN_ID,
+  STATE_COLUMN_ID,
+  TAGS_COLUMN_ID,
+  TOKENS_COLUMN_ID,
+  TRACE_ID_COLUMN_ID,
+  TRACE_NAME_COLUMN_ID,
+  USER_COLUMN_ID,
+} from '../hooks/useTableColumns';
+import type { AssessmentInfo, EvalTraceComparisonEntry } from '../types';
+import { getUniqueValueCountsBySourceId } from '../utils/AggregationUtils';
+import { COMPARE_TO_RUN_COLOR, CURRENT_RUN_COLOR } from '../utils/Colors';
+import { highlightSearchInText, normalizeDurationString, timeSinceStr } from '../utils/DisplayUtils';
+import { shouldEnableTagGrouping } from '../utils/FeatureUtils';
+import {
+  getCustomMetadataKeyFromColumnId,
+  getExperimentIdFromTraceLocation,
+  getTagKeyFromColumnId,
+  getTraceInfoOutputs,
+  MLFLOW_SOURCE_RUN_KEY,
+} from '../utils/TraceUtils';
+
+type timestampType = number | string | Date | null;
+
+/**
+ * Formats a timestamp into a date and time string.
+ * @param timestamp
+ * @param intl
+ * @param options
+ * @returns {string} formatted date and time string
+ * @example
+ * formatDateTime(1626825600000, intl);
+ * // => 'Jul 21, 2021, 12:00 AM'
+ * formatDateTime(1626825600000, intl, { hour: 'numeric', minute: '2-digit' });
+ * // => 'Jul 21, 2021, 5:30 AM'
+ * formatDateTime(1626825600000, intl, { hour: '2-digit', minute: '2-digit', timeZoneName: 'short' });
+ * // => 'Jul 21, 2021, 05:30 AM PDT'
+ * formatDateTime(1626825600000, intl, { month: 'long', minute: '2-digit'});
+ * // => 'July 21, 2021, 05:30 AM'
+ **/
+export function formatDateTime(timestamp: timestampType, intl: IntlShape, options?: FormatDateOptions): string {
+  if (!timestamp) {
+    return '';
+  }
+
+  return intl.formatDate(timestamp, {
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    ...options,
+  });
+}
+
+export const assessmentCellRenderer = (
+  theme: ThemeType,
+  intl: IntlShape,
+  isComparing: boolean,
+  assessmentInfo: AssessmentInfo,
+  comparisonEntry: EvalTraceComparisonEntry,
+) => {
+  const assessmentName = assessmentInfo.name;
+
+  // Regression-test "Result" column: show N/M assertions passed (+ icon) per
+  // row, tallied from the row's scorer assessments. The column header still
+  // renders the standard pass-fail graph off the synthetic Result value.
+  if (assessmentName === 'Result') {
+    const isPass = (v: any): boolean =>
+      typeof v === 'boolean'
+        ? v
+        : typeof v === 'number'
+          ? v >= 0.5
+          : typeof v === 'string'
+            ? ['yes', 'pass', 'true'].includes(v.trim().toLowerCase())
+            : false;
+    const breakdown = (runValue: typeof comparisonEntry.currentRunValue) => {
+      const byName = runValue?.responseAssessmentsByName ?? {};
+      const rows: { label: string; passed: boolean }[] = [];
+      for (const name of Object.keys(byName)) {
+        if (name === 'Result') continue;
+        for (const r of byName[name] ?? []) {
+          const label =
+            name !== 'guidelines'
+              ? name
+              : ((r as any)?.metadata?.['guideline'] ?? (r as any)?.metadata?.['guidelines'] ?? r?.rationale ?? name);
+          const displayLabel = typeof label === 'string' ? label : JSON.stringify(label);
+          rows.push({
+            label: displayLabel.length > 80 ? `${displayLabel.slice(0, 77)}...` : displayLabel,
+            passed: isPass(getEvaluationResultAssessmentValue(r)),
+          });
+        }
+      }
+      return rows;
+    };
+    const tally = (runValue: typeof comparisonEntry.currentRunValue) => {
+      const rows = breakdown(runValue);
+      return { passed: rows.filter((r) => r.passed).length, total: rows.length };
+    };
+    const badge = (runValue: typeof comparisonEntry.currentRunValue) => {
+      const { passed, total } = tally(runValue);
+      if (total === 0) return null;
+      const allPassed = passed === total;
+      const tag = (
+        <Tag
+          componentId="mlflow.regression-test-table.result"
+          color={allPassed ? 'turquoise' : 'coral'}
+          css={{
+            margin: 0,
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 4,
+            width: 'fit-content',
+            cursor: 'default',
+          }}
+        >
+          {allPassed ? (
+            <CheckCircleIcon css={{ color: theme.colors.textValidationSuccess }} />
+          ) : (
+            <XCircleIcon css={{ color: theme.colors.textValidationDanger }} />
+          )}
+          {passed}/{total}
+        </Tag>
+      );
+      // Hover shows the per-assertion breakdown (name + pass/fail, no rationale).
+      return (
+        <HoverCard
+          side="bottom"
+          content={
+            <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs, maxWidth: '22rem' }}>
+              {breakdown(runValue).map((row, i) => (
+                <div key={i} css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
+                  {row.passed ? (
+                    <CheckCircleIcon css={{ color: theme.colors.textValidationSuccess }} />
+                  ) : (
+                    <XCircleIcon css={{ color: theme.colors.textValidationDanger }} />
+                  )}
+                  <Typography.Text css={{ wordBreak: 'break-word' }}>{row.label}</Typography.Text>
+                </div>
+              ))}
+            </div>
+          }
+          trigger={tag}
+        />
+      );
+    };
+    return (
+      <div css={{ display: 'flex', gap: theme.spacing.sm, alignItems: 'center' }}>
+        {badge(comparisonEntry.currentRunValue)}
+        {isComparing && badge(comparisonEntry.otherRunValue)}
+      </div>
+    );
+  }
+
+  const assessment = {
+    currentValue: first(comparisonEntry.currentRunValue?.responseAssessmentsByName[assessmentName]),
+    otherValue: first(comparisonEntry.otherRunValue?.responseAssessmentsByName[assessmentName]),
+  };
+
+  const uniqueValueCounts = getUniqueValueCountsBySourceId(
+    assessmentInfo,
+    comparisonEntry.currentRunValue?.responseAssessmentsByName[assessmentName] || [],
+  );
+
+  const currentIsAssessmentRootCause =
+    comparisonEntry.currentRunValue?.overallAssessments[0]?.rootCauseAssessment?.assessmentName === assessmentName;
+  const otherIsAssessmentRootCause =
+    comparisonEntry.otherRunValue?.overallAssessments[0]?.rootCauseAssessment?.assessmentName === assessmentName;
+
+  const currentValue = assessment.currentValue
+    ? getEvaluationResultAssessmentValue(assessment.currentValue)
+    : undefined;
+  const otherValue = assessment.otherValue ? getEvaluationResultAssessmentValue(assessment.otherValue) : undefined;
+  const assessmentComparison = compareAssessmentValues(
+    assessmentInfo,
+    isNil(currentValue) ? undefined : currentValue,
+    isNil(otherValue) ? undefined : otherValue,
+  );
+
+  const assessmentChanged = otherValue !== currentValue;
+
+  const missingTooltip = KnownEvaluationResultAssessmentValueMissingTooltip[assessmentName];
+  return (
+    <div
+      css={{
+        display: 'flex',
+        gap: theme.spacing.sm,
+        alignItems: 'center',
+        marginTop: 'auto',
+        marginBottom: 'auto',
+      }}
+    >
+      {isComparing ? (
+        <div
+          css={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: theme.spacing.sm,
+            borderRadius: theme.legacyBorders.borderRadiusMd,
+            marginTop: 'auto',
+            marginBottom: 'auto',
+          }}
+        >
+          <div
+            css={{
+              display: 'flex',
+              gap: theme.spacing.sm,
+              alignItems: 'center',
+            }}
+          >
+            <EvaluationsReviewAssessmentTag
+              key={`tag_${comparisonEntry.currentRunValue?.evaluationId}_${assessment.currentValue?.name}`}
+              showRationaleInTooltip
+              disableJudgeTypeIcon
+              hideAssessmentName
+              assessment={assessment.currentValue}
+              isRootCauseAssessment={currentIsAssessmentRootCause}
+              assessmentInfo={assessmentInfo}
+              type="value"
+            />
+            {assessmentChanged && (
+              <ArrowRightIcon
+                css={{
+                  // Rotate by 45 degrees when the current is passing
+                  transform: assessmentComparison === 'greater' ? 'rotate(-45deg)' : 'rotate(45deg)',
+                  color: theme.colors.textSecondary,
+                }}
+              />
+            )}
+          </div>
+          <div
+            css={{
+              display: 'flex',
+              gap: theme.spacing.sm,
+              alignItems: 'center',
+            }}
+          >
+            <EvaluationsReviewAssessmentTag
+              key={`tag_${comparisonEntry.otherRunValue?.evaluationId}_${assessment.currentValue?.name}`}
+              showRationaleInTooltip
+              disableJudgeTypeIcon
+              hideAssessmentName
+              assessment={assessment.otherValue}
+              isRootCauseAssessment={otherIsAssessmentRootCause}
+              assessmentInfo={assessmentInfo}
+              type="value"
+            />
+            {/* This invisible icon aligns the values. */}
+            {assessmentChanged && (
+              <ArrowRightIcon
+                css={{
+                  visibility: 'hidden',
+                }}
+              />
+            )}
+          </div>
+        </div>
+      ) : assessment.currentValue ? (
+        <div
+          css={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: theme.spacing.sm,
+          }}
+        >
+          {uniqueValueCounts.map((uniqueValueCount) => {
+            const assessment = uniqueValueCount.latestAssessment;
+            const count = uniqueValueCount.count;
+            return (
+              <EvaluationsReviewAssessmentTag
+                key={`tag_${uniqueValueCount.latestAssessment.name}_${uniqueValueCount.value}`}
+                showRationaleInTooltip
+                disableJudgeTypeIcon
+                hideAssessmentName
+                assessment={assessment}
+                isRootCauseAssessment={currentIsAssessmentRootCause}
+                assessmentInfo={assessmentInfo}
+                type="value"
+                count={count}
+              />
+            );
+          })}
+        </div>
+      ) : (
+        <EvaluationsReviewAssessmentTag
+          key={`tag_${assessmentName}_${comparisonEntry.currentRunValue?.evaluationId}`}
+          showRationaleInTooltip
+          disableJudgeTypeIcon
+          hideAssessmentName
+          isRootCauseAssessment={currentIsAssessmentRootCause}
+          assessmentInfo={assessmentInfo}
+          assessment={{
+            name: assessmentName,
+            rationale: missingTooltip
+              ? intl.formatMessage(missingTooltip)
+              : intl.formatMessage({
+                  defaultMessage: 'No assessment for this evaluation',
+                  description: 'Text displayed when there is no assessment for a given evaluation',
+                }),
+            source: {
+              sourceId: '',
+              sourceType: 'AI_JUDGE',
+              metadata: {},
+            },
+            stringValue: null,
+            booleanValue: null,
+            rootCauseAssessment: null,
+            numericValue: null,
+            timestamp: null,
+            metadata: {},
+          }}
+          type="value"
+        />
+      )}
+    </div>
+  );
+};
+
+/**
+ * Wrapper component for assessment cells that checks the context for session grouping.
+ * Hides session-level assessments in regular rows when grouped by session.
+ * Shows a spinner when a judge is currently running on this trace.
+ */
+export const AssessmentCell: React.FC<{
+  isComparing: boolean;
+  assessmentInfo: AssessmentInfo;
+  comparisonEntry: EvalTraceComparisonEntry;
+}> = ({ isComparing, assessmentInfo, comparisonEntry }) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+  const { isGroupedBySession } = useContext(GenAITracesTableContext);
+  const { evaluations } = useModelTraceExplorerRunJudgesContext();
+
+  const traceId = comparisonEntry.currentRunValue?.traceInfo?.trace_id;
+
+  const isJudgeRunning = useMemo(() => {
+    if (!traceId || !evaluations) return false;
+    return Object.values(evaluations).some(
+      (evaluation) =>
+        evaluation.isLoading &&
+        evaluation.label === assessmentInfo.name &&
+        (!evaluation.tracesData || traceId in evaluation.tracesData),
+    );
+  }, [traceId, evaluations, assessmentInfo.name]);
+
+  // Hide session-level assessments in regular rows when grouped by session
+  if (isGroupedBySession && assessmentInfo.isSessionLevelAssessment) {
+    return <NullCell />;
+  }
+
+  if (isJudgeRunning) {
+    return (
+      <Tooltip
+        componentId="mlflow.genai-traces-table.assessment-cell-judge-running"
+        content={intl.formatMessage({
+          defaultMessage: 'Judge is running…',
+          description: 'Tooltip shown in assessment cell while a judge is executing on this trace',
+        })}
+      >
+        <span css={{ display: 'inline-flex', alignItems: 'center', color: theme.colors.textSecondary }}>
+          <Spinner size="small" />
+        </span>
+      </Tooltip>
+    );
+  }
+
+  return assessmentCellRenderer(theme, intl, isComparing, assessmentInfo, comparisonEntry);
+};
+
+export const expectationCellRenderer = (
+  theme: ThemeType,
+  intl: IntlShape,
+  isComparing: boolean,
+  expectationName: string,
+  comparisonEntry: EvalTraceComparisonEntry,
+) => {
+  const currentValue = comparisonEntry.currentRunValue?.targets?.[expectationName];
+  const otherValue = comparisonEntry.otherRunValue?.targets?.[expectationName];
+
+  const currentValuePreview = currentValue ? (
+    <ExpectationValuePreview parsedValue={currentValue} singleLine />
+  ) : (
+    <NullCell isComparing={isComparing} />
+  );
+  const otherValuePreview = otherValue ? (
+    <ExpectationValuePreview parsedValue={otherValue} singleLine />
+  ) : (
+    <NullCell isComparing={isComparing} />
+  );
+
+  return isComparing ? (
+    <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
+      <div css={{ display: 'flex', flex: 1 }}>{currentValuePreview}</div>
+      <div css={{ display: 'flex', flex: 1 }}>{otherValuePreview}</div>
+    </div>
+  ) : (
+    currentValuePreview
+  );
+};
+
+export const inputColumnCellRenderer = (
+  onChangeEvaluationId: (evaluationId: string | undefined, traceInfo?: ModelTraceInfoV3) => void,
+  row: CellContext<EvalTraceComparisonEntry, unknown>,
+  isComparing: boolean,
+  theme: ThemeType,
+  inputColumn: string,
+  getRunColor?: (runUuid: string) => string,
+) => {
+  const value = row.getValue() as EvalTraceComparisonEntry;
+
+  const evalId = value.currentRunValue?.evaluationId || value.otherRunValue?.evaluationId;
+
+  // fetch colors if possible
+  const currentRunUuid = value.currentRunValue?.traceInfo?.trace_metadata?.[MLFLOW_SOURCE_RUN_KEY];
+  const otherRunUuid = value.otherRunValue?.traceInfo?.trace_metadata?.[MLFLOW_SOURCE_RUN_KEY];
+  const currentRunColor = getRunColor && currentRunUuid ? getRunColor(currentRunUuid) : CURRENT_RUN_COLOR;
+  const otherRunColor = getRunColor && otherRunUuid ? getRunColor(otherRunUuid) : COMPARE_TO_RUN_COLOR;
+
+  const currentInputColumnTitle = value.currentRunValue
+    ? getEvaluationResultInputTitle(value.currentRunValue, inputColumn)
+    : undefined;
+
+  const otherInputColumnTitle = value.otherRunValue
+    ? getEvaluationResultInputTitle(value.otherRunValue, inputColumn)
+    : undefined;
+
+  const inputColumnTitle = currentInputColumnTitle || otherInputColumnTitle;
+  const meta = row?.table?.options?.meta as
+    | { getRunColor?: (runUuid: string) => string; searchQuery?: string }
+    | undefined;
+  const searchQuery = meta?.searchQuery;
+  const displayContent =
+    inputColumnTitle && searchQuery ? highlightSearchInText(String(inputColumnTitle), searchQuery) : inputColumnTitle;
+
+  return (
+    <div
+      css={{
+        height: '100%',
+        width: '100%',
+        display: 'flex',
+        overflow: 'hidden',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: theme.spacing.sm,
+      }}
+    >
+      <Typography.Link
+        css={{
+          display: 'block',
+          overflow: 'hidden',
+          whiteSpace: 'nowrap',
+          textOverflow: 'ellipsis',
+        }}
+        title={inputColumnTitle ? String(inputColumnTitle) : undefined}
+        componentId="mlflow.evaluations_review.table_ui.evaluation_id_link"
+        onClick={() => onChangeEvaluationId(evalId, value.currentRunValue?.traceInfo)}
+      >
+        {displayContent ? (
+          displayContent
+        ) : (
+          <Typography.Text
+            color="secondary"
+            css={{
+              fontStyle: 'italic',
+            }}
+          >
+            null
+          </Typography.Text>
+        )}
+      </Typography.Link>
+      {isComparing && (
+        <div
+          css={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: theme.spacing.md,
+          }}
+        >
+          <div
+            css={{
+              display: 'flex',
+            }}
+          >
+            {currentRunUuid ? <RunColorCircle color={currentRunColor} /> : <div css={{ width: 12, height: 12 }} />}
+          </div>
+          <div
+            css={{
+              display: 'flex',
+            }}
+          >
+            {otherRunUuid ? <RunColorCircle color={otherRunColor} /> : <div css={{ width: 12, height: 12 }} />}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export const traceInfoCellRenderer = (
+  isComparing: boolean,
+  colId: string,
+  comparisonEntry: EvalTraceComparisonEntry,
+  onChangeEvaluationId: (evalId: string, traceInfo?: ModelTraceInfoV3) => void,
+  intl: IntlShape,
+  theme: ThemeType,
+  experimentId?: string,
+  onTraceTagsEdit?: (trace: ModelTraceInfoV3) => void,
+  traceIdToTurnMap?: Record<string, number>,
+  searchQuery?: string,
+) => {
+  const currentTraceInfo = comparisonEntry.currentRunValue?.traceInfo;
+  const otherTraceInfo = isComparing ? comparisonEntry.otherRunValue?.traceInfo : undefined;
+
+  if (colId === REQUEST_TIME_COLUMN_ID) {
+    const date = currentTraceInfo?.request_time ? new Date(currentTraceInfo.request_time) : undefined;
+    const otherDate = otherTraceInfo?.request_time ? new Date(otherTraceInfo.request_time) : undefined;
+
+    return (
+      <StackedComponents
+        first={
+          date ? (
+            <Tooltip
+              componentId="mlflow.experiment-evaluation-monitoring.trace-info-hover-request-time"
+              content={date.toLocaleString(navigator.language, { timeZoneName: 'short' })}
+            >
+              <span css={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                {formatDateTime(date, intl, {
+                  year: 'numeric',
+                  month: '2-digit',
+                  day: '2-digit',
+                  hour: '2-digit',
+                  minute: '2-digit',
+                  second: '2-digit',
+                  hour12: false,
+                })}
+              </span>
+            </Tooltip>
+          ) : (
+            <NullCell isComparing={isComparing} />
+          )
+        }
+        second={
+          isComparing &&
+          (otherDate ? (
+            <Tooltip
+              componentId="mlflow.experiment-evaluation-monitoring.trace-info-hover-other-request-time"
+              content={otherDate.toLocaleString(navigator.language, { timeZoneName: 'short' })}
+            >
+              <span css={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{timeSinceStr(otherDate)}</span>
+            </Tooltip>
+          ) : (
+            <NullCell isComparing={isComparing} />
+          ))
+        }
+      />
+    );
+  } else if (colId === STATE_COLUMN_ID) {
+    return (
+      <StackedComponents
+        first={<StatusCellRenderer original={currentTraceInfo} isComparing={isComparing} />}
+        second={
+          isComparing &&
+          (otherTraceInfo ? (
+            <StatusCellRenderer original={otherTraceInfo} isComparing={isComparing} />
+          ) : (
+            <NullCell isComparing={isComparing} />
+          ))
+        }
+      />
+    );
+  } else if (colId === SOURCE_COLUMN_ID) {
+    return (
+      <StackedComponents
+        first={
+          currentTraceInfo ? (
+            <SourceCellRenderer traceInfo={currentTraceInfo} isComparing={isComparing} />
+          ) : (
+            <NullCell isComparing={isComparing} />
+          )
+        }
+        second={
+          isComparing &&
+          (otherTraceInfo ? (
+            <SourceCellRenderer traceInfo={otherTraceInfo} isComparing={isComparing} />
+          ) : (
+            <NullCell isComparing={isComparing} />
+          ))
+        }
+      />
+    );
+  } else if (colId === TAGS_COLUMN_ID) {
+    const tagsArr: { key: string; value: string }[] = Object.entries(currentTraceInfo?.tags || {}).map(
+      ([key, value]) => ({
+        key,
+        value,
+      }),
+    );
+
+    const otherTagsArr: { key: string; value: string }[] = Object.entries(otherTraceInfo?.tags || {}).map(
+      ([key, value]) => ({
+        key,
+        value,
+      }),
+    );
+
+    // We only support editing tags in single trace mode
+    const onAddEditTags = !otherTraceInfo && currentTraceInfo ? () => onTraceTagsEdit?.(currentTraceInfo) : undefined;
+
+    return (
+      <StackedComponents
+        first={<TagsCellRenderer baseComponentId="tags-cell-renderer" tags={tagsArr} onAddEditTags={onAddEditTags} />}
+        second={
+          isComparing &&
+          (otherTraceInfo ? (
+            <TagsCellRenderer baseComponentId="tags-cell-renderer-other" tags={otherTagsArr} />
+          ) : (
+            <NullCell isComparing={isComparing} />
+          ))
+        }
+      />
+    );
+  } else if (shouldEnableTagGrouping() && colId.startsWith(TAGS_COLUMN_ID)) {
+    const tagKey = getTagKeyFromColumnId(colId);
+    if (!tagKey) {
+      return <NullCell isComparing={isComparing} />;
+    }
+    const tagValue = currentTraceInfo?.tags?.[tagKey];
+    const otherTagValue = otherTraceInfo?.tags?.[tagKey];
+    return (
+      <StackedComponents
+        first={
+          tagValue ? (
+            <span
+              title={tagValue}
+              css={{
+                display: 'block',
+                overflow: 'hidden',
+                whiteSpace: 'nowrap',
+                textOverflow: 'ellipsis',
+              }}
+            >
+              {tagValue}
+            </span>
+          ) : (
+            <NullCell isComparing={isComparing} />
+          )
+        }
+        second={
+          isComparing &&
+          (otherTagValue ? (
+            <span
+              title={tagValue}
+              css={{
+                display: 'block',
+                overflow: 'hidden',
+                whiteSpace: 'nowrap',
+                textOverflow: 'ellipsis',
+              }}
+            >
+              {otherTagValue}
+            </span>
+          ) : (
+            <NullCell isComparing={isComparing} />
+          ))
+        }
+      />
+    );
+  } else if (colId === TRACE_NAME_COLUMN_ID) {
+    const evalId = comparisonEntry.currentRunValue?.evaluationId;
+
+    const currentTraceName = currentTraceInfo?.tags?.['mlflow.traceName'];
+    const otherTraceName = otherTraceInfo?.tags?.['mlflow.traceName'];
+
+    return (
+      <StackedComponents
+        first={
+          currentTraceName ? (
+            !isComparing ? (
+              <Typography.Link
+                css={{
+                  display: 'block',
+                  overflow: 'hidden',
+                  whiteSpace: 'nowrap',
+                  textOverflow: 'ellipsis',
+                }}
+                componentId="mlflow.evaluations_review.table_ui.evaluation_id_link"
+                onClick={() => evalId && onChangeEvaluationId(evalId, comparisonEntry.currentRunValue?.traceInfo)}
+              >
+                {currentTraceInfo?.tags?.['mlflow.traceName']}
+              </Typography.Link>
+            ) : (
+              <div>{currentTraceInfo?.tags?.['mlflow.traceName']}</div>
+            )
+          ) : (
+            <NullCell isComparing={isComparing} />
+          )
+        }
+        second={isComparing && (otherTraceName ? <div>{otherTraceName}</div> : <NullCell isComparing={isComparing} />)}
+      />
+    );
+  } else if (colId === RUN_NAME_COLUMN_ID) {
+    // This column is only shown on experiment level traces which does not support comparison mode
+
+    const runUuid = currentTraceInfo?.trace_metadata?.[MLFLOW_SOURCE_RUN_KEY];
+
+    if (!runUuid) {
+      return <NullCell />;
+    }
+
+    return (
+      <RunName
+        experimentId={getExperimentIdFromTraceLocation(currentTraceInfo?.trace_location) ?? experimentId}
+        runUuid={runUuid}
+      />
+    );
+  } else if (colId === USER_COLUMN_ID) {
+    const value = currentTraceInfo?.trace_metadata?.['mlflow.trace.user'] || currentTraceInfo?.tags?.['mlflow.user'];
+    const otherValue = otherTraceInfo?.trace_metadata?.['mlflow.trace.user'] || otherTraceInfo?.tags?.['mlflow.user'];
+
+    return (
+      <StackedComponents
+        first={
+          value ? (
+            <span
+              css={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: theme.spacing.xs,
+              }}
+              title={value}
+            >
+              <UserIcon css={{ color: theme.colors.textSecondary, fontSize: 16 }} />
+              <span css={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{value}</span>
+            </span>
+          ) : (
+            <NullCell isComparing={isComparing} />
+          )
+        }
+        second={
+          isComparing &&
+          (otherValue ? (
+            <span
+              css={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: theme.spacing.xs,
+              }}
+              title={otherValue}
+            >
+              <UserIcon css={{ color: theme.colors.textSecondary, fontSize: 16 }} />
+              <span css={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{otherValue}</span>
+            </span>
+          ) : (
+            <NullCell isComparing={isComparing} />
+          ))
+        }
+      />
+    );
+  } else if (colId === TRACE_ID_COLUMN_ID) {
+    // Regression-test view: display the test name (from the mlflow.test.* tags),
+    // but keep the real trace id for click/navigation.
+    const testDisplayName = (info: any): string | undefined => {
+      if (!info) return undefined;
+      const readTag = (key: string) => {
+        const tags = info.tags;
+        if (Array.isArray(tags)) return tags.find((t: any) => t?.key === key)?.value;
+        if (tags && typeof tags === 'object') return tags[key];
+        return info.trace_metadata?.[key];
+      };
+      const name = readTag('mlflow.test.name');
+      if (!name) return undefined;
+      const caseId = readTag('mlflow.test.case_id');
+      return caseId ? `${name}[${caseId}]` : name;
+    };
+    const navId = currentTraceInfo?.trace_id;
+    const otherNavId = otherTraceInfo?.trace_id;
+    const value = testDisplayName(currentTraceInfo) ?? navId;
+    const otherValue = testDisplayName(otherTraceInfo) ?? otherNavId;
+    const displayValue = value && searchQuery ? highlightSearchInText(value, searchQuery) : value;
+    const displayOtherValue = otherValue && searchQuery ? highlightSearchInText(otherValue, searchQuery) : otherValue;
+    return (
+      <StackedComponents
+        first={
+          value ? (
+            <Tag
+              css={{ width: 'fit-content', maxWidth: '100%' }}
+              componentId="mlflow.genai-traces-table.trace-id"
+              color="purple"
+              title={value}
+              onClick={() => navId && onChangeEvaluationId(navId, currentTraceInfo)}
+            >
+              <span
+                css={{
+                  display: 'block',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {displayValue}
+              </span>
+            </Tag>
+          ) : (
+            <NullCell isComparing={isComparing} />
+          )
+        }
+        second={
+          isComparing &&
+          (otherValue ? (
+            <Tag
+              css={{ width: 'fit-content', maxWidth: '100%' }}
+              componentId="mlflow.genai-traces-table.trace-id"
+              color="purple"
+              title={otherValue}
+              onClick={() => otherNavId && onChangeEvaluationId(otherNavId, otherTraceInfo)}
+            >
+              <span
+                css={{
+                  display: 'inline-block',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {displayOtherValue}
+              </span>
+            </Tag>
+          ) : (
+            <NullCell isComparing={isComparing} />
+          ))
+        }
+      />
+    );
+  } else if (colId === SESSION_COLUMN_ID) {
+    const value = currentTraceInfo?.trace_metadata?.['mlflow.trace.session'];
+    const otherValue = otherTraceInfo?.trace_metadata?.['mlflow.trace.session'];
+    const currentTraceId = currentTraceInfo?.trace_id;
+    const otherTraceId = otherTraceInfo?.trace_id;
+
+    const turnNumber = traceIdToTurnMap?.[currentTraceId ?? ''];
+    const otherTurnNumber = traceIdToTurnMap?.[otherTraceId ?? ''];
+
+    return (
+      <StackedComponents
+        first={
+          value ? (
+            <SessionIdLinkWrapper
+              sessionId={value}
+              experimentId={getExperimentIdFromTraceLocation(currentTraceInfo?.trace_location) ?? experimentId}
+              traceId={currentTraceId}
+            >
+              <Tag
+                css={{ width: 'fit-content', maxWidth: '100%' }}
+                componentId="mlflow.genai-traces-table.session"
+                title={value}
+              >
+                <span
+                  css={{
+                    display: 'inline-block',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {!isNil(turnNumber) ? (
+                    <FormattedMessage
+                      defaultMessage="Turn {turnNumber}"
+                      description="Label for a single turn within an experiment chat session"
+                      values={{ turnNumber }}
+                    />
+                  ) : (
+                    value
+                  )}
+                </span>
+              </Tag>
+            </SessionIdLinkWrapper>
+          ) : (
+            <NullCell isComparing={isComparing} />
+          )
+        }
+        second={
+          isComparing &&
+          (otherValue ? (
+            <SessionIdLinkWrapper
+              sessionId={otherValue}
+              experimentId={getExperimentIdFromTraceLocation(otherTraceInfo?.trace_location) ?? experimentId}
+              traceId={otherTraceId}
+            >
+              <Tag
+                css={{ width: 'fit-content', maxWidth: '100%' }}
+                componentId="mlflow.genai-traces-table.session"
+                title={otherValue}
+              >
+                <span
+                  css={{
+                    display: 'inline-block',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {!isNil(otherTurnNumber) ? (
+                    <FormattedMessage
+                      defaultMessage="Turn {turnNumber}"
+                      description="Label for a single turn within an experiment chat session"
+                      values={{ turnNumber: otherTurnNumber }}
+                    />
+                  ) : (
+                    value
+                  )}
+                </span>
+              </Tag>
+            </SessionIdLinkWrapper>
+          ) : (
+            <NullCell isComparing={isComparing} />
+          ))
+        }
+      />
+    );
+  } else if (colId === RESPONSE_COLUMN_ID) {
+    const value = currentTraceInfo ? formatResponseTitle(getTraceInfoOutputs(currentTraceInfo)) : '';
+    const otherValue = otherTraceInfo ? formatResponseTitle(getTraceInfoOutputs(otherTraceInfo)) : '';
+    const displayValue = value && searchQuery ? highlightSearchInText(value, searchQuery) : value;
+    const displayOtherValue = otherValue && searchQuery ? highlightSearchInText(otherValue, searchQuery) : otherValue;
+    return (
+      <StackedComponents
+        first={
+          displayValue ? (
+            <div css={{ overflow: 'hidden', textOverflow: 'ellipsis' }} title={value}>
+              {displayValue}
+            </div>
+          ) : (
+            <Typography.Text
+              color="secondary"
+              css={{
+                fontStyle: 'italic',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              null
+            </Typography.Text>
+          )
+        }
+        second={
+          isComparing &&
+          (displayOtherValue ? (
+            <div css={{ overflow: 'hidden', textOverflow: 'ellipsis' }} title={otherValue}>
+              {displayOtherValue}
+            </div>
+          ) : (
+            <Typography.Text
+              color="secondary"
+              css={{
+                fontStyle: 'italic',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              null
+            </Typography.Text>
+          ))
+        }
+      />
+    );
+  } else if (colId === LOGGED_MODEL_COLUMN_ID) {
+    return (
+      <LoggedModelCell
+        experimentId={experimentId}
+        currentTraceInfo={currentTraceInfo}
+        otherTraceInfo={otherTraceInfo}
+        isComparing={isComparing}
+      />
+    );
+  } else if (colId === TOKENS_COLUMN_ID) {
+    return <TokensCell currentTraceInfo={currentTraceInfo} otherTraceInfo={otherTraceInfo} isComparing={isComparing} />;
+  } else if (colId === ISSUES_COLUMN_ID) {
+    const issues = comparisonEntry.currentRunValue?.issues;
+    const otherIssues = comparisonEntry.otherRunValue?.issues;
+    return <IssuesCell issues={issues} otherIssues={otherIssues} isComparing={isComparing} />;
+  } else if (colId.startsWith(CUSTOM_METADATA_COLUMN_ID)) {
+    const metadataKey = getCustomMetadataKeyFromColumnId(colId);
+    if (!metadataKey) {
+      return <NullCell isComparing={isComparing} />;
+    }
+    const value = currentTraceInfo?.trace_metadata?.[metadataKey];
+    const otherValue = otherTraceInfo?.trace_metadata?.[metadataKey];
+    return (
+      <StackedComponents
+        first={
+          value ? (
+            <div css={{ overflow: 'hidden', textOverflow: 'ellipsis' }} title={value}>
+              {value}
+            </div>
+          ) : (
+            <NullCell isComparing={isComparing} />
+          )
+        }
+        second={
+          isComparing &&
+          (otherValue ? (
+            <div css={{ overflow: 'hidden', textOverflow: 'ellipsis' }} title={otherValue}>
+              {otherValue}
+            </div>
+          ) : (
+            <NullCell isComparing={isComparing} />
+          ))
+        }
+      />
+    );
+  } else if (colId === EXECUTION_DURATION_COLUMN_ID) {
+    const value = normalizeDurationString(currentTraceInfo?.[EXECUTION_DURATION_COLUMN_ID]);
+    const otherValue = normalizeDurationString(otherTraceInfo?.[EXECUTION_DURATION_COLUMN_ID]);
+
+    return (
+      <StackedComponents
+        first={!isNil(value) ? <ExecutionDurationTag value={value} /> : <NullCell isComparing={isComparing} />}
+        second={
+          isComparing &&
+          (!isNil(otherValue) ? <ExecutionDurationTag value={otherValue} /> : <NullCell isComparing={isComparing} />)
+        }
+      />
+    );
+  } else if (colId === LINKED_PROMPTS_COLUMN_ID) {
+    const PROMPT_VERSION_QUERY_PARAM = 'promptVersion';
+    const PROMPT_PATH = '/experiments/:experimentId/prompts/:promptName';
+
+    const formatPrompts = (promptsJson: string | undefined, traceExperimentId: string | undefined) => {
+      if (!promptsJson) return null;
+      try {
+        const prompts = JSON.parse(promptsJson);
+        if (Array.isArray(prompts) && prompts.length > 0) {
+          return prompts.map((prompt: { name: string; version: string }, index: number) => {
+            const label = `${prompt.name}/${prompt.version}`;
+            if (traceExperimentId) {
+              const basePath = generatePath(PROMPT_PATH, { experimentId: traceExperimentId, promptName: prompt.name });
+              const url = prompt.version
+                ? `${basePath}?${new URLSearchParams({ [PROMPT_VERSION_QUERY_PARAM]: prompt.version }).toString()}`
+                : basePath;
+              return (
+                <div key={index}>
+                  <Link componentId="mlflow.genai-traces-table.prompt_link" to={url}>
+                    {label}
+                  </Link>
+                </div>
+              );
+            }
+            return <div key={index}>{label}</div>;
+          });
+        }
+      } catch (e) {
+        // Invalid JSON, return as-is
+        return promptsJson;
+      }
+      return null;
+    };
+
+    const currentPrompts = currentTraceInfo?.tags?.['mlflow.linkedPrompts'];
+    const otherPrompts = otherTraceInfo?.tags?.['mlflow.linkedPrompts'];
+    const currentExperimentId = getExperimentIdFromTraceLocation(currentTraceInfo?.trace_location) ?? experimentId;
+    const otherExperimentId = getExperimentIdFromTraceLocation(otherTraceInfo?.trace_location) ?? experimentId;
+    const formattedCurrentPrompts = formatPrompts(currentPrompts, currentExperimentId);
+    const formattedOtherPrompts = formatPrompts(otherPrompts, otherExperimentId);
+
+    return (
+      <StackedComponents
+        first={
+          formattedCurrentPrompts ? (
+            <div css={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{formattedCurrentPrompts}</div>
+          ) : (
+            <NullCell isComparing={isComparing} />
+          )
+        }
+        second={
+          isComparing &&
+          (formattedOtherPrompts ? (
+            <div css={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{formattedOtherPrompts}</div>
+          ) : (
+            <NullCell isComparing={isComparing} />
+          ))
+        }
+      />
+    );
+  } else if (colId === SIMULATION_GOAL_COLUMN_ID || colId === SIMULATION_PERSONA_COLUMN_ID) {
+    // Goal/Persona are session-level columns, only rendered in session header rows
+    return <NullCell isComparing={isComparing} />;
+  }
+
+  const value = currentTraceInfo ? stringifyValue(getTraceInfoValueWithColId(currentTraceInfo, colId)) : '';
+  const otherValue = otherTraceInfo ? stringifyValue(getTraceInfoValueWithColId(otherTraceInfo, colId)) : '';
+
+  return (
+    <StackedComponents
+      first={
+        value ? (
+          <div css={{ overflow: 'hidden', textOverflow: 'ellipsis' }} title={value}>
+            {value}
+          </div>
+        ) : (
+          <NullCell isComparing={isComparing} />
+        )
+      }
+      second={
+        isComparing &&
+        (otherValue ? (
+          <div css={{ overflow: 'hidden', textOverflow: 'ellipsis' }} title={otherValue}>
+            {otherValue}
+          </div>
+        ) : (
+          <NullCell isComparing={isComparing} />
+        ))
+      }
+    />
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/components/DetectIssuesButton.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/components/DetectIssuesButton.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { Button, CloseIcon, Popover, SparkleIcon, useDesignSystemTheme } from '@databricks/design-system';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { useLocalStorage } from '../../hooks/useLocalStorage';
+
+// Default storage key for tracking first-time user guidance
+export const DEFAULT_DETECT_ISSUES_GUIDANCE_STORAGE_KEY = 'mlflow.detectIssues.guidanceShown';
+const DETECT_ISSUES_GUIDANCE_STORAGE_VERSION = 1;
+
+interface DetectIssuesButtonProps {
+  componentId: string;
+  onClick: () => void;
+}
+
+export const DetectIssuesButton: React.FC<DetectIssuesButtonProps> = ({ componentId, onClick }) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+
+  // Track whether the user has seen the guidance
+  const [hasSeenGuidance, setHasSeenGuidance] = useLocalStorage({
+    key: DEFAULT_DETECT_ISSUES_GUIDANCE_STORAGE_KEY,
+    version: DETECT_ISSUES_GUIDANCE_STORAGE_VERSION,
+    initialValue: false,
+  });
+
+  const handleDismissGuidance = () => {
+    setHasSeenGuidance(true);
+  };
+
+  const buttonContent = (
+    <Button
+      componentId={componentId}
+      onClick={onClick}
+      aria-label={intl.formatMessage({
+        defaultMessage: 'Detect issues in traces',
+        description: 'Aria label for the detect issues button',
+      })}
+      icon={<SparkleIcon color="ai" />}
+      css={{
+        border: '1px solid transparent !important',
+        background: `linear-gradient(${theme.colors.backgroundPrimary}, ${theme.colors.backgroundPrimary}) padding-box, ${theme.gradients.aiBorderGradient} border-box`,
+      }}
+    >
+      <FormattedMessage defaultMessage="Detect Issues" description="Label for the detect issues button" />
+    </Button>
+  );
+
+  // Wrap in Popover if guidance should be shown
+  if (!hasSeenGuidance) {
+    return (
+      <Popover.Root
+        componentId="mlflow.detect_issues.guidance"
+        open={!hasSeenGuidance}
+        onOpenChange={(open) => {
+          // Only allow closing via explicit dismiss actions, not by clicking outside
+          if (!open) {
+            return;
+          }
+        }}
+        modal
+      >
+        <Popover.Trigger asChild>
+          <div css={{ position: 'relative', zIndex: 1001 }}>{buttonContent}</div>
+        </Popover.Trigger>
+        <Popover.Content
+          side="bottom"
+          align="end"
+          onEscapeKeyDown={(e) => e.preventDefault()}
+          onPointerDownOutside={(e) => e.preventDefault()}
+          onInteractOutside={(e) => e.preventDefault()}
+          css={{
+            maxWidth: 320,
+            padding: theme.spacing.md,
+            zIndex: 1000,
+            boxShadow: '0 0 0 9999px rgba(0, 0, 0, 0.5), 0 8px 24px rgba(0, 0, 0, 0.4)',
+          }}
+        >
+          <Popover.Arrow css={{ fill: theme.colors.backgroundPrimary }} />
+          <div
+            css={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'flex-start',
+              marginBottom: theme.spacing.sm,
+            }}
+          >
+            <div
+              css={{
+                fontWeight: theme.typography.typographyBoldFontWeight,
+                fontSize: theme.typography.fontSizeMd,
+              }}
+            >
+              <FormattedMessage
+                defaultMessage="Detect Issues in Your Traces"
+                description="Detect issues guidance popover title"
+              />
+            </div>
+            <Button
+              componentId="mlflow.detect_issues.guidance.dismiss"
+              icon={<CloseIcon />}
+              onClick={handleDismissGuidance}
+              aria-label={intl.formatMessage({
+                defaultMessage: 'Close guidance',
+                description: 'Aria label for closing the detect issues guidance popover',
+              })}
+              css={{
+                padding: 0,
+                minWidth: 'auto',
+                border: 'none',
+                background: 'transparent',
+              }}
+            />
+          </div>
+          <div css={{ fontSize: theme.typography.fontSizeSm, color: theme.colors.textSecondary }}>
+            <FormattedMessage
+              defaultMessage="Use this button to automatically detect quality issues in your traces using AI. This feature helps you identify problems like correctness, latency, and other quality concerns in your agent."
+              description="Detect issues guidance popover message"
+            />
+          </div>
+          <Button
+            componentId="mlflow.detect_issues.guidance.got_it"
+            onClick={handleDismissGuidance}
+            css={{ marginTop: theme.spacing.md, width: '100%' }}
+          >
+            <FormattedMessage defaultMessage="Got it" description="Detect issues guidance dismiss button" />
+          </Button>
+        </Popover.Content>
+      </Popover.Root>
+    );
+  }
+
+  return <div>{buttonContent}</div>;
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationTraceDataDrawer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationTraceDataDrawer.tsx
@@ -1,0 +1,79 @@
+import { isNil } from 'lodash';
+
+import { Drawer, Empty, Spacer, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { FormattedMessage } from '@databricks/i18n';
+import type { ModelTrace } from '../../model-trace-explorer/ModelTrace.types';
+import { ModelTraceExplorer } from '../../model-trace-explorer/ModelTraceExplorer';
+
+export const EvaluationTraceDataDrawer = ({
+  requestId,
+  onClose,
+  trace,
+}: {
+  requestId: string;
+  onClose: () => void;
+  trace: ModelTrace;
+}) => {
+  const { theme } = useDesignSystemTheme();
+  const title = (
+    <Typography.Title level={2} withoutMargins>
+      {requestId}
+    </Typography.Title>
+  );
+
+  const renderContent = () => {
+    const containsSpans = trace.data.spans.length > 0;
+    if (isNil(trace) || !containsSpans) {
+      return (
+        <>
+          <Spacer size="lg" />
+          <Empty
+            description={null}
+            title={
+              <FormattedMessage
+                defaultMessage="No trace data recorded"
+                description="Experiment page > traces data drawer > no trace data recorded empty state"
+              />
+            }
+          />
+        </>
+      );
+    } else {
+      return (
+        <div
+          css={{
+            height: '100%',
+            marginLeft: -theme.spacing.lg,
+            marginRight: -theme.spacing.lg,
+            marginBottom: -theme.spacing.lg,
+          }}
+          // This is required for mousewheel scrolling within `Drawer`
+          onWheel={(e) => e.stopPropagation()}
+        >
+          <ModelTraceExplorer modelTrace={trace} />
+        </div>
+      );
+    }
+  };
+
+  return (
+    <Drawer.Root
+      modal
+      open
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose();
+        }
+      }}
+    >
+      <Drawer.Content
+        componentId="mlflow.evaluations_review.trace_data_drawer"
+        width="85vw"
+        title={title}
+        expandContentToFullHeight
+      >
+        {renderContent()}
+      </Drawer.Content>
+    </Drawer.Root>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsAssessmentHoverCard.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsAssessmentHoverCard.tsx
@@ -1,0 +1,184 @@
+import {
+  BinaryIcon,
+  BracketsXIcon,
+  NumbersIcon,
+  SparkleDoubleIcon,
+  Tag,
+  Typography,
+  useDesignSystemTheme,
+  UserIcon,
+} from '@databricks/design-system';
+import { useIntl } from '@databricks/i18n';
+
+import { EvaluationsRcaStats } from './EvaluationsRcaStats';
+import { KnownEvaluationResultAssessmentName } from '../enum';
+import type { AssessmentAggregates, AssessmentFilter, AssessmentInfo, AssessmentValueType } from '../types';
+
+export const EvaluationsAssessmentHoverCard = ({
+  assessmentInfo,
+  assessmentNameToAggregates,
+  allAssessmentFilters,
+  toggleAssessmentFilter,
+  runUuid,
+  compareToRunUuid,
+}: {
+  assessmentInfo: AssessmentInfo;
+  assessmentNameToAggregates: Record<string, AssessmentAggregates>;
+  allAssessmentFilters: AssessmentFilter[];
+  toggleAssessmentFilter: (
+    assessmentName: string,
+    filterValue: AssessmentValueType,
+    run: string,
+    filterType?: AssessmentFilter['filterType'],
+  ) => void;
+  runUuid?: string;
+  compareToRunUuid?: string;
+}) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+  return (
+    <>
+      <div
+        css={{
+          maxWidth: '25rem',
+          display: 'flex',
+          flexDirection: 'column',
+          overflowWrap: 'break-word',
+          wordBreak: 'break-word',
+          gap: theme.spacing.sm,
+        }}
+      >
+        <div
+          css={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: theme.spacing.xs,
+          }}
+        >
+          <div
+            css={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: theme.spacing.xs,
+              paddingBottom: theme.spacing.sm,
+              borderBottom: `1px solid ${theme.colors.border}`,
+            }}
+          >
+            <div
+              css={{
+                display: 'flex',
+                gap: theme.spacing.xs,
+                alignItems: 'center',
+              }}
+            >
+              {/* Dtype icon  */}
+              {assessmentInfo.dtype === 'numeric' ? (
+                <NumbersIcon />
+              ) : assessmentInfo.dtype === 'boolean' ? (
+                <BinaryIcon />
+              ) : (
+                <></>
+              )}
+
+              <Typography.Title
+                level={4}
+                css={{
+                  marginBottom: 0,
+                  marginRight: theme.spacing.xs,
+                }}
+              >
+                {assessmentInfo.displayName}
+              </Typography.Title>
+              {assessmentInfo.source?.sourceType === 'AI_JUDGE' && (
+                <Tag color="turquoise" componentId="mlflow.experiment.evaluations.ai-judge-tag">
+                  <div
+                    css={{
+                      display: 'flex',
+                      gap: theme.spacing.xs,
+                    }}
+                  >
+                    <SparkleDoubleIcon
+                      css={{
+                        color: theme.colors.textSecondary,
+                      }}
+                    />
+                    <Typography.Hint>
+                      {intl.formatMessage({
+                        defaultMessage: 'AI Judge',
+                        description: 'Label for AI judge in the tooltip for the assessment in the evaluation metrics.',
+                      })}
+                    </Typography.Hint>
+                  </div>
+                </Tag>
+              )}
+              {assessmentInfo.source?.sourceType === 'HUMAN' && (
+                <Tag color="coral" componentId="mlflow.experiment.evaluations.human-judge-tag">
+                  <div
+                    css={{
+                      display: 'flex',
+                      gap: theme.spacing.xs,
+                    }}
+                  >
+                    <UserIcon />
+                    <Typography.Hint>
+                      {intl.formatMessage({
+                        defaultMessage: 'Human judge',
+                        description:
+                          'Label for human judge in the tooltip for the assessment in the evaluation metrics.',
+                      })}
+                    </Typography.Hint>
+                  </div>
+                </Tag>
+              )}
+              {assessmentInfo.isCustomMetric && (
+                <Tag color="indigo" componentId="mlflow.experiment.evaluations.ai-judge-tag">
+                  <div
+                    css={{
+                      display: 'flex',
+                      gap: theme.spacing.xs,
+                    }}
+                  >
+                    <Typography.Hint>
+                      <BracketsXIcon />
+                    </Typography.Hint>
+
+                    <Typography.Hint>{assessmentInfo.metricName}</Typography.Hint>
+                  </div>
+                </Tag>
+              )}
+            </div>
+            <div>
+              <Typography.Hint>{assessmentInfo.name}</Typography.Hint>
+            </div>
+          </div>
+        </div>
+        <div>
+          <span
+            css={{
+              display: 'contents',
+              '& p': {
+                marginBottom: 0,
+              },
+            }}
+          >
+            {assessmentInfo.description}
+          </span>
+        </div>
+        {assessmentInfo.name === KnownEvaluationResultAssessmentName.OVERALL_ASSESSMENT && runUuid ? (
+          <div>
+            <EvaluationsRcaStats
+              overallAssessmentInfo={assessmentInfo}
+              assessmentNameToAggregates={assessmentNameToAggregates}
+              allAssessmentFilters={allAssessmentFilters}
+              toggleAssessmentFilter={toggleAssessmentFilter}
+              runUuid={runUuid}
+              compareToRunUuid={compareToRunUuid}
+            />
+          </div>
+        ) : (
+          <></>
+        )}
+      </div>
+    </>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsOverviewColumnSelector.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsOverviewColumnSelector.tsx
@@ -1,0 +1,80 @@
+import {
+  ChevronDownIcon,
+  DialogCombobox,
+  DialogComboboxContent,
+  DialogComboboxCustomButtonTriggerWrapper,
+  DialogComboboxOptionList,
+  DialogComboboxOptionListCheckboxItem,
+  Button,
+  ColumnsIcon,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
+import { useIntl } from '@databricks/i18n';
+
+import type { TracesTableColumn } from '../types';
+
+/**
+ * Component for column selector in MLflow monitoring traces view. Allows user to control which assessments show up in table to prevent too much clutter.
+ */
+export const EvaluationsOverviewColumnSelector = ({
+  columns,
+  selectedColumns,
+  setSelectedColumns,
+  setSelectedColumnsWithHiddenColumns,
+}: {
+  columns: TracesTableColumn[];
+  selectedColumns: TracesTableColumn[];
+  // @deprecated use setSelectedColumnsWithHiddenColumns instead
+  setSelectedColumns?: React.Dispatch<React.SetStateAction<TracesTableColumn[]>>;
+  setSelectedColumnsWithHiddenColumns?: (newColumns: TracesTableColumn[]) => void;
+}) => {
+  const intl = useIntl();
+  const { theme } = useDesignSystemTheme();
+
+  const handleChange = (newColumn: TracesTableColumn) => {
+    if (setSelectedColumnsWithHiddenColumns) {
+      return setSelectedColumnsWithHiddenColumns([newColumn]);
+    } else if (setSelectedColumns) {
+      setSelectedColumns((current: TracesTableColumn[]) => {
+        const newSelectedColumns = current.some((col) => col.id === newColumn.id)
+          ? current.filter((col) => col.id !== newColumn.id)
+          : [...current, newColumn];
+        return newSelectedColumns;
+      });
+    }
+  };
+
+  return (
+    <DialogCombobox componentId="mlflow.evaluations_overview.column_selector_dropdown" label="Columns" multiSelect>
+      <DialogComboboxCustomButtonTriggerWrapper>
+        <Button endIcon={<ChevronDownIcon />} componentId="mlflow.evaluations_review.table_ui.filter_button">
+          <div
+            css={{
+              display: 'flex',
+              gap: theme.spacing.sm,
+              alignItems: 'center',
+            }}
+          >
+            <ColumnsIcon />
+            {intl.formatMessage({
+              defaultMessage: 'Columns',
+              description: 'Evaluation review > evaluations list > filter dropdown button',
+            })}
+          </div>
+        </Button>
+      </DialogComboboxCustomButtonTriggerWrapper>
+      <DialogComboboxContent>
+        <DialogComboboxOptionList>
+          {columns.map((column) => (
+            <DialogComboboxOptionListCheckboxItem
+              key={column.id}
+              value={column.label}
+              checked={selectedColumns.some((col) => col.id === column.id)}
+              onChange={() => handleChange(column)}
+            />
+          ))}
+        </DialogComboboxOptionList>
+      </DialogComboboxContent>
+    </DialogCombobox>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsOverviewColumnSelectorGrouped.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsOverviewColumnSelectorGrouped.tsx
@@ -1,0 +1,206 @@
+import React, { useMemo, useState } from 'react';
+
+import {
+  ChevronDownIcon,
+  DialogCombobox,
+  DialogComboboxContent,
+  DialogComboboxCustomButtonTriggerWrapper,
+  DialogComboboxOptionList,
+  DialogComboboxOptionListCheckboxItem,
+  DialogComboboxSectionHeader,
+  Button,
+  ColumnsIcon,
+  useDesignSystemTheme,
+  DialogComboboxOptionListSearch,
+  DangerIcon,
+  Tag,
+} from '@databricks/design-system';
+import { FormattedMessage, useIntl } from '@databricks/i18n';
+
+import { sortGroupedColumns } from '../GenAiTracesTable.utils';
+import { TracesTableColumnGroup, TracesTableColumnGroupToLabelMap, type TracesTableColumn } from '../types';
+
+interface Props {
+  columns: TracesTableColumn[];
+  selectedColumns: TracesTableColumn[];
+  toggleColumns: (cols: TracesTableColumn[]) => void;
+  setSelectedColumns: (cols: TracesTableColumn[]) => void;
+  isLoading?: boolean;
+  isError?: boolean;
+}
+
+const OPTION_HEIGHT = 32;
+
+const getGroupLabel = (group: string): string => {
+  return group === TracesTableColumnGroup.INFO
+    ? 'Attributes'
+    : TracesTableColumnGroupToLabelMap[group as TracesTableColumnGroup];
+};
+
+/**
+ * Column selector with section headers for each column‐group.
+ */
+export const EvaluationsOverviewColumnSelectorGrouped: React.FC<React.PropsWithChildren<Props>> = ({
+  columns = [],
+  selectedColumns = [],
+  toggleColumns,
+  setSelectedColumns,
+  isLoading,
+  isError,
+}) => {
+  const intl = useIntl();
+  const { theme } = useDesignSystemTheme();
+
+  const [search, setSearch] = useState('');
+
+  const sortedGroupedColumns = useMemo(() => {
+    const sortedColumns = sortGroupedColumns(columns);
+    const map: Record<string, TracesTableColumn[]> = {};
+    sortedColumns.forEach((col) => {
+      const group = col.group ?? TracesTableColumnGroup.INFO;
+      if (!map[group]) map[group] = [];
+      map[group].push(col);
+    });
+
+    return map;
+  }, [columns]);
+
+  const filteredGroupedColumns = useMemo(() => {
+    if (!search.trim()) return sortedGroupedColumns;
+
+    const needle = search.trim().toLowerCase();
+    const out: Record<string, TracesTableColumn[]> = {};
+
+    Object.entries(sortedGroupedColumns).forEach(([group, cols]) => {
+      // Check if group name matches
+      const groupLabel = getGroupLabel(group);
+      const groupMatches = groupLabel.toLowerCase().includes(needle);
+
+      // Check if any columns in the group match
+      const hits = cols.filter((c) => c.label.toLowerCase().includes(needle));
+
+      // Include the group if either the group name or any columns match
+      if (groupMatches || hits.length) {
+        out[group] = groupMatches ? cols : hits;
+      }
+    });
+
+    return out;
+  }, [sortedGroupedColumns, search]);
+
+  const handleToggle = (column: TracesTableColumn) => {
+    return toggleColumns([column]);
+  };
+
+  const handleSelectAllInGroup = (groupColumns: TracesTableColumn[]) => {
+    const allSelected = groupColumns.every((col) => selectedColumns.some((c) => c.id === col.id));
+    if (allSelected) {
+      // If all are selected, deselect all in this group
+      const newSelection = selectedColumns.filter((col) => !groupColumns.some((gc) => gc.id === col.id));
+      setSelectedColumns(newSelection);
+    } else {
+      // If not all are selected, select all in this group
+      const newSelection = [...selectedColumns];
+      groupColumns.forEach((col) => {
+        if (!newSelection.some((c) => c.id === col.id)) {
+          newSelection.push(col);
+        }
+      });
+      setSelectedColumns(newSelection);
+    }
+  };
+
+  return (
+    <DialogCombobox
+      componentId="mlflow.evaluations_overview_grouped.column_selector_dropdown"
+      label="Columns"
+      multiSelect
+    >
+      <DialogComboboxCustomButtonTriggerWrapper>
+        <Button
+          endIcon={<ChevronDownIcon />}
+          data-testid="column-selector-button"
+          componentId="mlflow.evaluations_review.table_ui.filter_button"
+        >
+          <div
+            css={{
+              display: 'flex',
+              gap: theme.spacing.sm,
+              alignItems: 'center',
+            }}
+          >
+            <ColumnsIcon />
+            {intl.formatMessage({
+              defaultMessage: 'Columns',
+              description: 'Evaluation review > evaluations list > column selector button',
+            })}
+            <Tag componentId="mlflow.evaluations_review.column_count">
+              {selectedColumns.length}/{columns.length}
+            </Tag>
+          </div>
+        </Button>
+      </DialogComboboxCustomButtonTriggerWrapper>
+      <DialogComboboxContent
+        maxHeight={OPTION_HEIGHT * 15.5}
+        minWidth={300}
+        maxWidth={500}
+        loading={isLoading && !isError}
+      >
+        {isError ? (
+          <div
+            css={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: theme.spacing.xs,
+              padding: `${theme.spacing.md}px`,
+              color: theme.colors.textValidationDanger,
+            }}
+            data-testid="filter-dropdown-error"
+          >
+            <DangerIcon />
+            <FormattedMessage
+              defaultMessage="Fetching traces failed"
+              description="Error message for fetching traces failed"
+            />
+          </div>
+        ) : (
+          <DialogComboboxOptionList>
+            <DialogComboboxOptionListSearch controlledValue={search} setControlledValue={setSearch}>
+              {Object.entries(filteredGroupedColumns).map(([groupName, cols]) => (
+                <React.Fragment key={groupName}>
+                  <DialogComboboxSectionHeader>{getGroupLabel(groupName)}</DialogComboboxSectionHeader>
+
+                  <DialogComboboxOptionListCheckboxItem
+                    value={`all-${groupName}`}
+                    checked={cols.every((col) => selectedColumns.some((c) => c.id === col.id))}
+                    onChange={() => handleSelectAllInGroup(cols)}
+                  >
+                    {intl.formatMessage(
+                      {
+                        defaultMessage: 'All {groupLabel}',
+                        description: 'Evaluation review > evaluations list > select all columns in group',
+                      },
+                      { groupLabel: getGroupLabel(groupName) },
+                    )}
+                  </DialogComboboxOptionListCheckboxItem>
+
+                  {cols.map((col) => (
+                    <DialogComboboxOptionListCheckboxItem
+                      key={col.id}
+                      value={col.label}
+                      checked={selectedColumns.some((c) => c.id === col.id)}
+                      onChange={() => handleToggle(col)}
+                    >
+                      {col.label}
+                    </DialogComboboxOptionListCheckboxItem>
+                  ))}
+                </React.Fragment>
+              ))}
+            </DialogComboboxOptionListSearch>
+          </DialogComboboxOptionList>
+        )}
+      </DialogComboboxContent>
+    </DialogCombobox>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsOverviewSortDropdown.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsOverviewSortDropdown.tsx
@@ -1,0 +1,504 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import {
+  ArrowDownIcon,
+  ArrowUpIcon,
+  SortAscendingIcon,
+  SortDescendingIcon,
+  Input,
+  SearchIcon,
+  useDesignSystemTheme,
+  DropdownMenu,
+  Button,
+  ChevronDownIcon,
+  SortUnsortedIcon,
+  ToggleButton,
+  Spinner,
+  DangerIcon,
+} from '@databricks/design-system';
+import { FormattedMessage, useIntl } from '@databricks/i18n';
+
+import { sortGroupedColumns } from '../GenAiTracesTable.utils';
+import { SESSION_COLUMN_ID, SORTABLE_INFO_COLUMNS } from '../hooks/useTableColumns';
+import type { EvaluationsOverviewTableSort, AssessmentInfo, TracesTableColumn } from '../types';
+import { TracesTableColumnType, TracesTableColumnGroup, TracesTableColumnGroupToLabelMap } from '../types';
+
+export interface SortOption {
+  label: string;
+  key: string;
+  type: TracesTableColumnType;
+  group?: TracesTableColumnGroup;
+}
+
+export const EvaluationsOverviewSortDropdown = React.memo(
+  // eslint-disable-next-line react-component-name/react-component-name -- TODO(FEINF-4716)
+  ({
+    tableSort,
+    columns = [],
+    onChange,
+    enableGrouping,
+    isLoading,
+    isError,
+  }: {
+    tableSort: EvaluationsOverviewTableSort | undefined;
+    columns: TracesTableColumn[];
+    onChange: (sortOption: SortOption, orderByAsc: boolean) => void;
+    enableGrouping?: boolean;
+    isLoading?: boolean;
+    isError?: boolean;
+  }) => {
+    const intl = useIntl();
+    const { theme } = useDesignSystemTheme();
+    const [open, setOpen] = useState(false);
+
+    const sortOptions = useMemo(() => {
+      const sortOptions: SortOption[] = [];
+
+      const assessmentLabelPrefix = intl.formatMessage({
+        defaultMessage: 'Assessment',
+        description: 'Evaluation review > evaluations list > assessment sort option label prefix',
+      });
+
+      if (enableGrouping) {
+        const sortedColumns = sortGroupedColumns(columns);
+
+        for (const column of sortedColumns) {
+          if (column.type === TracesTableColumnType.ASSESSMENT) {
+            const sortableAssessmentInfo = column.assessmentInfo as AssessmentInfo;
+            const assessmentLabel = sortableAssessmentInfo.displayName;
+
+            sortOptions.push({
+              label: assessmentLabel,
+              key: column.id,
+              type: TracesTableColumnType.ASSESSMENT,
+              group: TracesTableColumnGroup.ASSESSMENT,
+            });
+          } else if (column.type === TracesTableColumnType.INPUT) {
+            sortOptions.push({
+              label: column.label,
+              key: column.id,
+              type: TracesTableColumnType.INPUT,
+              group: TracesTableColumnGroup.INFO,
+            });
+          } else if (column.type === TracesTableColumnType.TRACE_INFO) {
+            const label =
+              column.id === SESSION_COLUMN_ID
+                ? intl.formatMessage({
+                    defaultMessage: 'Session time',
+                    description: 'Session time sort option label',
+                  })
+                : column.label;
+            if (SORTABLE_INFO_COLUMNS.includes(column.id)) {
+              sortOptions.push({
+                label,
+                key: column.id,
+                type: TracesTableColumnType.TRACE_INFO,
+                group: TracesTableColumnGroup.INFO,
+              });
+            }
+          }
+        }
+
+        return sortOptions;
+      }
+
+      // First add assessments.
+      for (const sortableAssessmentCol of columns.filter(
+        (column) => column.type === TracesTableColumnType.ASSESSMENT,
+      )) {
+        const sortableAssessmentInfo = sortableAssessmentCol.assessmentInfo as AssessmentInfo;
+        const assessmentLabel = sortableAssessmentInfo.displayName;
+        sortOptions.push({
+          label: `${assessmentLabelPrefix} ﹥ ${assessmentLabel}`,
+          key: sortableAssessmentCol.id,
+          type: TracesTableColumnType.ASSESSMENT,
+        });
+      }
+      // Next add inputs.
+      const inputLabelPrefix = intl.formatMessage({
+        defaultMessage: 'Input',
+        description: 'Evaluation review > evaluations list > input sort option label prefix',
+      });
+      for (const inputColumn of columns.filter((column) => column.type === TracesTableColumnType.INPUT)) {
+        sortOptions.push({
+          label: `${inputLabelPrefix} ﹥ ${inputColumn.label}`,
+          key: inputColumn.id,
+          type: TracesTableColumnType.INPUT,
+        });
+      }
+
+      // Add info columns
+      for (const infoColumn of columns.filter(
+        (column) =>
+          (column.type === TracesTableColumnType.TRACE_INFO ||
+            column.type === TracesTableColumnType.INTERNAL_MONITOR_REQUEST_TIME) &&
+          SORTABLE_INFO_COLUMNS.includes(column.id),
+      )) {
+        sortOptions.push({
+          label: infoColumn.label,
+          key: infoColumn.id,
+          type: TracesTableColumnType.TRACE_INFO,
+        });
+      }
+
+      return sortOptions;
+    }, [columns, intl, enableGrouping]);
+
+    // Generate the label for the sort select dropdown
+    const currentSortSelectLabel = useMemo(() => {
+      // Search through all sort options generated basing on the fetched runs
+      const sortOption = sortOptions.find((option) => option.key === tableSort?.key);
+
+      let sortOptionLabel = sortOption?.label;
+
+      // If the actually chosen sort value is not found in the sort option list (e.g. because the list of fetched runs is empty),
+      // use it to generate the label
+      if (!sortOptionLabel) {
+        // The following regex extracts plain sort key name from its canonical form, i.e.
+        // metrics.`metric_key_name` => metric_key_name
+        const extractedKeyName = tableSort?.key?.match(/^.+\.`(.+)`$/);
+        if (extractedKeyName) {
+          sortOptionLabel = extractedKeyName[1];
+        }
+      }
+      const sortMessage = intl.formatMessage({
+        defaultMessage: 'Sort',
+        description: 'Experiment page > sort selector > label for the dropdown button',
+      });
+
+      return !sortOptionLabel ? sortMessage : `${sortMessage}: ${sortOptionLabel}`;
+    }, [sortOptions, intl, tableSort]);
+
+    return (
+      <DropdownMenu.Root open={open} onOpenChange={setOpen} modal={false}>
+        <DropdownMenu.Trigger data-testid="sort-select-dropdown" asChild>
+          <Button
+            componentId="mlflow.experiment_page.sort_select_v2.toggle"
+            icon={tableSort ? tableSort.asc ? <SortAscendingIcon /> : <SortDescendingIcon /> : <SortUnsortedIcon />}
+            css={{ minWidth: 32 }}
+            aria-label={currentSortSelectLabel}
+            endIcon={<ChevronDownIcon />}
+          >
+            {currentSortSelectLabel}
+          </Button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content minWidth={250}>
+          {isError ? (
+            <div
+              css={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: theme.spacing.xs,
+                padding: `${theme.spacing.md}px`,
+                color: theme.colors.textValidationDanger,
+              }}
+              data-testid="filter-dropdown-error"
+            >
+              <DangerIcon />
+              <FormattedMessage
+                defaultMessage="Fetching traces failed"
+                description="Error message for fetching traces failed"
+              />
+            </div>
+          ) : isLoading ? (
+            <div
+              css={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: theme.spacing.xs,
+                padding: `${theme.spacing.lg}px`,
+                color: theme.colors.textSecondary,
+              }}
+              data-testid="sort-dropdown-loading"
+            >
+              <Spinner size="small" />
+            </div>
+          ) : enableGrouping ? (
+            <EvaluationsOverviewSortDropdownBodyGrouped
+              sortOptions={sortOptions}
+              tableSort={tableSort}
+              onOptionSelected={(sortOption, orderByAsc) => {
+                onChange(sortOption, orderByAsc);
+                setOpen(false);
+              }}
+            />
+          ) : (
+            <EvaluationsOverviewSortDropdownBody
+              sortOptions={sortOptions}
+              tableSort={tableSort}
+              onOptionSelected={(sortOption, orderByAsc) => {
+                onChange(sortOption, orderByAsc);
+                setOpen(false);
+              }}
+            />
+          )}
+        </DropdownMenu.Content>
+      </DropdownMenu.Root>
+    );
+  },
+);
+
+const EvaluationsOverviewSortDropdownBodyGrouped = ({
+  sortOptions,
+  tableSort,
+  onOptionSelected,
+}: {
+  sortOptions: SortOption[];
+  tableSort?: EvaluationsOverviewTableSort;
+  onOptionSelected: (opt: SortOption, asc: boolean) => void;
+}) => {
+  const { theme } = useDesignSystemTheme();
+  const inputRef = useRef<React.ComponentRef<typeof Input>>(null);
+  const firstOptionRef = useRef<HTMLDivElement>(null);
+
+  const [filter, setFilter] = useState<string>('');
+
+  const filtered = useMemo(
+    () => sortOptions.filter((opt) => opt.label.toLowerCase().includes(filter.toLowerCase())),
+    [sortOptions, filter],
+  );
+
+  const grouped = useMemo(() => {
+    const m: Record<string, SortOption[]> = {};
+    filtered.forEach((opt) => {
+      const grp = opt.group ?? TracesTableColumnGroup.INFO;
+      if (!m[grp]) m[grp] = [];
+      m[grp].push(opt);
+    });
+    return m;
+  }, [filtered]);
+
+  const handleChange = useCallback(
+    (key: string) => {
+      const opt = sortOptions.find((o) => o.key === key);
+      if (!opt) return;
+      onOptionSelected(opt, tableSort?.asc ?? true);
+    },
+    [onOptionSelected, sortOptions, tableSort?.asc],
+  );
+
+  const setOrder = useCallback(
+    (asc: boolean) => {
+      const opt = sortOptions.find((o) => o.key === tableSort?.key) ?? sortOptions[0];
+      onOptionSelected(opt, asc);
+    },
+    [onOptionSelected, sortOptions, tableSort?.key],
+  );
+
+  // Autofocus won't work everywhere so let's focus input everytime the dropdown is opened
+  useEffect(() => {
+    requestAnimationFrame(() => inputRef.current?.focus());
+  }, []);
+
+  return (
+    <>
+      <div
+        css={{
+          padding: `${theme.spacing.sm}px ${theme.spacing.lg / 2}px`,
+          display: 'flex',
+          gap: theme.spacing.xs,
+        }}
+      >
+        <Input
+          ref={inputRef}
+          componentId="mlflow.genai_traces_table.sort_dropdown.search"
+          prefix={<SearchIcon />}
+          placeholder="Search"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          type="search"
+          onKeyDown={(e) => {
+            if (e.key === 'ArrowDown' || e.key === 'Tab') {
+              firstOptionRef.current?.focus();
+              e.preventDefault();
+            }
+          }}
+        />
+        <div css={{ display: 'flex', gap: theme.spacing.xs }}>
+          <ToggleButton
+            pressed={tableSort?.asc === false}
+            icon={<ArrowDownIcon />}
+            componentId="mlflow.genai_traces_table.sort_dropdown.sort_desc"
+            onClick={() => setOrder(false)}
+            aria-label="Sort descending"
+          />
+          <ToggleButton
+            pressed={tableSort?.asc === true}
+            icon={<ArrowUpIcon />}
+            componentId="mlflow.experiment_page.sort_dropdown.sort_asc"
+            onClick={() => setOrder(true)}
+            aria-label="Sort ascending"
+          />
+        </div>
+      </div>
+
+      <div css={{ maxHeight: 400, overflowY: 'auto', padding: `0 ${theme.spacing.sm}px` }}>
+        {Object.entries(grouped).map(([groupName, opts], gi) => (
+          <React.Fragment key={groupName}>
+            <DropdownMenu.Group>
+              <DropdownMenu.Label>
+                {groupName === TracesTableColumnGroup.INFO
+                  ? 'Attributes'
+                  : TracesTableColumnGroupToLabelMap[groupName as TracesTableColumnGroup]}
+              </DropdownMenu.Label>
+              {opts.map((opt, idx) => (
+                <DropdownMenu.CheckboxItem
+                  componentId="mlflow.genai_traces_table.sort_dropdown.sort_option"
+                  key={opt.key}
+                  checked={opt.key === tableSort?.key}
+                  onClick={() => handleChange(opt.key)}
+                  ref={gi === 0 && idx === 0 ? firstOptionRef : undefined}
+                  data-testid={`sort-select-${opt.label}`}
+                >
+                  <DropdownMenu.ItemIndicator />
+                  <span css={{ display: 'flex', alignItems: 'center', gap: 4 }}>{opt.label}</span>
+                </DropdownMenu.CheckboxItem>
+              ))}
+            </DropdownMenu.Group>
+          </React.Fragment>
+        ))}
+
+        {/* No results fallback */}
+        {filtered.length === 0 && (
+          <DropdownMenu.Item disabled componentId="mlflow.genai_traces_table.sort_dropdown.no_results">
+            <FormattedMessage
+              defaultMessage="No results"
+              description="Experiment page > sort selector > no results after filtering"
+            />
+          </DropdownMenu.Item>
+        )}
+      </div>
+    </>
+  );
+};
+
+const EvaluationsOverviewSortDropdownBody = ({
+  sortOptions,
+  tableSort,
+  onOptionSelected,
+}: {
+  sortOptions: SortOption[];
+  tableSort?: EvaluationsOverviewTableSort;
+  onOptionSelected: (sortOption: SortOption, orderByAsc: boolean) => void;
+}) => {
+  const { theme } = useDesignSystemTheme();
+
+  const inputElementRef = useRef<React.ComponentRef<typeof Input>>(null);
+  const [filter, setFilter] = useState('');
+  const firstElementRef = useRef<HTMLDivElement>(null);
+
+  // Merge all sort options and filter them by the search query
+  const filteredSortOptions = useMemo(
+    () =>
+      sortOptions.filter((option) => {
+        return option.label.toLowerCase().includes(filter.toLowerCase());
+      }),
+    [sortOptions, filter],
+  );
+
+  const handleChange = useCallback(
+    (orderByKey: string) => {
+      const orderByKeyOption = sortOptions.find((option) => option.key === orderByKey);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- TODO(FEINF-3982)
+      onOptionSelected(orderByKeyOption!, tableSort?.asc || true);
+    },
+    [onOptionSelected, tableSort, sortOptions],
+  );
+
+  const setOrder = useCallback(
+    (ascending: boolean) => {
+      const orderByKeyOption = sortOptions.find((option) => option.key === tableSort?.key);
+      onOptionSelected(orderByKeyOption || sortOptions[0], ascending);
+    },
+    [onOptionSelected, sortOptions, tableSort],
+  );
+
+  // Autofocus won't work everywhere so let's focus input everytime the dropdown is opened
+  useEffect(() => {
+    requestAnimationFrame(() => {
+      inputElementRef.current?.focus();
+    });
+  }, []);
+
+  return (
+    <>
+      <div
+        css={{
+          padding: `${theme.spacing.sm}px ${theme.spacing.lg / 2}px ${theme.spacing.sm}px`,
+          width: '100%',
+          display: 'flex',
+          gap: theme.spacing.xs,
+        }}
+      >
+        <Input
+          componentId="mlflow.experiment_page.sort_dropdown.search"
+          prefix={<SearchIcon />}
+          value={filter}
+          type="search"
+          onChange={(e) => setFilter(e.target.value)}
+          placeholder="Search"
+          autoFocus
+          ref={inputElementRef}
+          onKeyDown={(e) => {
+            if (e.key === 'ArrowDown' || e.key === 'Tab') {
+              firstElementRef.current?.focus();
+              return;
+            }
+            e.stopPropagation();
+          }}
+        />
+        <div
+          css={{
+            display: 'flex',
+            gap: theme.spacing.xs,
+          }}
+        >
+          <ToggleButton
+            pressed={tableSort?.asc === false}
+            icon={<ArrowDownIcon />}
+            componentId="mlflow.experiment_page.sort_dropdown.sort_desc"
+            onClick={() => setOrder(false)}
+            aria-label="Sort descending"
+            data-testid="sort-select-desc"
+          />
+          <ToggleButton
+            pressed={tableSort?.asc === true}
+            icon={<ArrowUpIcon />}
+            componentId="mlflow.experiment_page.sort_dropdown.sort_asc"
+            onClick={() => setOrder(true)}
+            aria-label="Sort ascending"
+            data-testid="sort-select-asc"
+          />
+        </div>
+      </div>
+      <DropdownMenu.Group css={{ maxHeight: 400, overflowY: 'auto' }}>
+        {filteredSortOptions.map((sortOption, index) => (
+          <DropdownMenu.CheckboxItem
+            componentId="mlflow.experiment_page.sort_dropdown.sort_option"
+            key={sortOption.key}
+            onClick={() => handleChange(sortOption.key)}
+            checked={sortOption.key === tableSort?.key}
+            data-testid={`sort-select-${sortOption.label}`}
+            ref={index === 0 ? firstElementRef : undefined}
+          >
+            <DropdownMenu.ItemIndicator />
+            <span css={{ display: 'flex', alignItems: 'center', gap: 4 }}>{sortOption.label}</span>
+          </DropdownMenu.CheckboxItem>
+        ))}
+        {!filteredSortOptions.length && (
+          <DropdownMenu.Item
+            componentId="codegen_mlflow_app_src_experiment-tracking_components_experiment-page_components_runs_experimentviewrunssortselectorv2.tsx_151"
+            disabled
+          >
+            <FormattedMessage
+              defaultMessage="No results"
+              description="Experiment page > sort selector > no results after filtering by search query"
+            />
+          </DropdownMenu.Item>
+        )}
+      </DropdownMenu.Group>
+    </>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsRcaStats.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsRcaStats.tsx
@@ -1,0 +1,324 @@
+import { useMemo } from 'react';
+
+import { Tooltip, useDesignSystemTheme, XCircleFillIcon } from '@databricks/design-system';
+import { useIntl, type IntlShape } from '@databricks/i18n';
+
+import {
+  KnownEvaluationResultAssessmentStringValue,
+  KnownEvaluationResultAssessmentValueMapping,
+  withAlpha,
+} from './GenAiEvaluationTracesReview.utils';
+import { RunColorCircle } from './RunColorCircle';
+import type { AssessmentAggregates, AssessmentFilter, AssessmentInfo, AssessmentValueType } from '../types';
+import { COMPARE_TO_RUN_COLOR, CURRENT_RUN_COLOR, getEvaluationResultAssessmentBackgroundColor } from '../utils/Colors';
+import { displayPercentage } from '../utils/DisplayUtils';
+
+interface RcaAssessmentRunDisplayInfoCount {
+  count: number;
+  fraction: number;
+  percentage: string;
+  tooltip: string;
+  toggleFilter: () => void;
+  isSelected: boolean;
+}
+
+interface RcaAssessmentDisplayInfoCount {
+  assessment: string;
+  title: string;
+  currentInfo: RcaAssessmentRunDisplayInfoCount;
+  otherInfo?: RcaAssessmentRunDisplayInfoCount;
+  icon: JSX.Element;
+}
+
+export const EvaluationsRcaStats = ({
+  overallAssessmentInfo,
+  assessmentNameToAggregates,
+  allAssessmentFilters,
+  toggleAssessmentFilter,
+  runUuid,
+  compareToRunUuid,
+}: {
+  overallAssessmentInfo: AssessmentInfo;
+  assessmentNameToAggregates: Record<string, AssessmentAggregates>;
+  allAssessmentFilters: AssessmentFilter[];
+  toggleAssessmentFilter: (
+    assessmentName: string,
+    filterValue: AssessmentValueType,
+    run: string,
+    filterType?: AssessmentFilter['filterType'],
+  ) => void;
+  runUuid?: string;
+  compareToRunUuid?: string;
+}) => {
+  const intl = useIntl();
+  const { theme } = useDesignSystemTheme();
+
+  const rcaData = useMemo(() => {
+    return getRcaData(
+      intl,
+      assessmentNameToAggregates,
+      allAssessmentFilters,
+      toggleAssessmentFilter,
+      Boolean(compareToRunUuid),
+      runUuid,
+      compareToRunUuid,
+    );
+  }, [intl, assessmentNameToAggregates, allAssessmentFilters, toggleAssessmentFilter, compareToRunUuid, runUuid]);
+
+  if (rcaData.length === 0) {
+    return <></>;
+  }
+  return (
+    <div
+      css={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: theme.spacing.sm,
+      }}
+    >
+      <div
+        css={{
+          fontWeight: theme.typography.typographyBoldFontWeight,
+        }}
+      >
+        {intl.formatMessage({
+          defaultMessage: 'Root Cause Analysis',
+          description: 'Root cause analysis section title',
+        })}
+      </div>
+
+      <div
+        css={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: theme.spacing.sm,
+        }}
+      >
+        <RcaPills
+          overallAssessmentInfo={overallAssessmentInfo}
+          rcaData={rcaData}
+          run="current"
+          runColor={compareToRunUuid ? CURRENT_RUN_COLOR : undefined}
+        />
+      </div>
+      {compareToRunUuid && (
+        <div
+          css={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: theme.spacing.xs,
+          }}
+        >
+          <RcaPills
+            overallAssessmentInfo={overallAssessmentInfo}
+            rcaData={rcaData}
+            run="other"
+            runColor={COMPARE_TO_RUN_COLOR}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export const RcaPills = ({
+  rcaData,
+  run,
+  runColor,
+  overallAssessmentInfo,
+}: {
+  rcaData: RcaAssessmentDisplayInfoCount[];
+  run: 'current' | 'other';
+  runColor?: string;
+  overallAssessmentInfo: AssessmentInfo;
+}) => {
+  const { theme } = useDesignSystemTheme();
+
+  return (
+    <div css={{ display: 'flex', flexDirection: 'row', gap: theme.spacing.sm, alignItems: 'center' }}>
+      {runColor && (
+        <div css={{ display: 'flex' }}>
+          <RunColorCircle color={runColor} />
+        </div>
+      )}
+      <div
+        css={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: theme.spacing.xs,
+        }}
+      >
+        {rcaData.map((item, i) => {
+          const runDisplayInfoCount = run === 'current' ? item.currentInfo : item.otherInfo;
+          if (!runDisplayInfoCount) {
+            // eslint-disable-next-line react/jsx-key -- TODO(FEINF-1756)
+            return <></>;
+          }
+          const backgroundColor = getEvaluationResultAssessmentBackgroundColor(theme, overallAssessmentInfo, {
+            stringValue: 'no',
+          });
+          return (
+            <Tooltip key={i} content={runDisplayInfoCount.tooltip} componentId="mlflow.evaluations_review.rca_pill">
+              <>
+                <div
+                  key={i}
+                  style={{
+                    border: runDisplayInfoCount.isSelected ? `1px solid ${theme.colors.grey400}` : '',
+                  }}
+                  css={{
+                    color: theme.colors.textSecondary,
+                    borderRadius: theme.general.borderRadiusBase,
+                    padding: `0 ${theme.spacing.xs}px`,
+                    height: '20px',
+                    display: 'flex',
+                    backgroundColor: runDisplayInfoCount.isSelected
+                      ? withAlpha(backgroundColor, 1.0)
+                      : withAlpha(backgroundColor, 0.5),
+                    // Bring back when we support filtering on RCA.
+                    // cursor: 'pointer',
+                    // '&:hover': {
+                    //   backgroundColor: withAlpha(backgroundColor, 0.9),
+                    // },
+                    gap: theme.spacing.xs,
+                    fontSize: theme.typography.fontSizeSm,
+                  }}
+                  // Bring back when we support filtering on RCA.
+                  // onClick={runDisplayInfoCount.toggleFilter}
+                >
+                  {runDisplayInfoCount.count}
+                  <div>{item.title.toLocaleLowerCase()}</div>
+                </div>
+              </>
+            </Tooltip>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+function getRcaData(
+  intl: IntlShape,
+  assessmentNameToAggregates: Record<string, AssessmentAggregates>,
+  assessmentFilters: AssessmentFilter[],
+  toggleAssessmentFilter: (
+    assessmentName: string,
+    filterValue: AssessmentValueType,
+    run: string,
+    filterType?: AssessmentFilter['filterType'],
+  ) => void,
+  isCompareToRun: boolean,
+  currentRunDisplayName?: string,
+  otherRunDisplayName?: string,
+): RcaAssessmentDisplayInfoCount[] {
+  // If all of the unfiltered assessment display infos have 0 root cause, return an empty array.
+  if (
+    Object.values(assessmentNameToAggregates).every(
+      (assessmentDisplayInfo) =>
+        assessmentDisplayInfo.currentNumRootCause === 0 && (assessmentDisplayInfo.otherNumRootCause || 0) === 0,
+    )
+  ) {
+    return [];
+  }
+  // Remove any root cause values that are 0 in the unfiltered set. This that the set of rca pills don't hide 0 values when filtered
+  // but keep the set minimal when unfiltered.
+  const sortedAssessmentAggregates = Object.values(assessmentNameToAggregates)
+    .filter((x) => x.currentNumRootCause > 0 || (x.otherNumRootCause || 0) > 0)
+    .sort((a, b) => b.currentNumRootCause - a.currentNumRootCause);
+  const maxNumRootCause = Math.max(
+    sortedAssessmentAggregates[0]?.currentNumRootCause || 0,
+    sortedAssessmentAggregates[0]?.otherNumRootCause || 0,
+  );
+  return sortedAssessmentAggregates.map((assessmentDisplayInfo) => {
+    const knownValueLabel =
+      KnownEvaluationResultAssessmentValueMapping[assessmentDisplayInfo.assessmentInfo.name]?.[
+        KnownEvaluationResultAssessmentStringValue.NO
+      ];
+    const title = knownValueLabel ? intl.formatMessage(knownValueLabel) : assessmentDisplayInfo.assessmentInfo.name;
+
+    const currentCounts = assessmentDisplayInfo.currentCounts;
+    const numPassing = currentCounts?.get(KnownEvaluationResultAssessmentStringValue.YES) || 0;
+    const numFailing = currentCounts?.get(KnownEvaluationResultAssessmentStringValue.NO) || 0;
+    const numMissing = currentCounts?.get(undefined) || 0;
+    const numRootCause = assessmentDisplayInfo.currentNumRootCause;
+
+    const numEvals = numPassing + numFailing + numMissing;
+
+    const otherCounts = assessmentDisplayInfo.otherCounts;
+    let otherNumEvals: number | undefined;
+    if (assessmentDisplayInfo.otherCounts !== undefined) {
+      const otherNumPassing = otherCounts?.get(KnownEvaluationResultAssessmentStringValue.YES) || 0;
+      const otherNumFailing = otherCounts?.get(KnownEvaluationResultAssessmentStringValue.NO) || 0;
+      const otherNumMissing = otherCounts?.get(undefined) || 0;
+      otherNumEvals = otherNumPassing + otherNumFailing + otherNumMissing;
+    }
+    const otherNumRootCause = assessmentDisplayInfo.otherNumRootCause || 0;
+    const rootCauseFraction = numRootCause / numEvals;
+    const otherRootCauseFraction = otherNumRootCause / (otherNumEvals || 1);
+    const currentPercentage = displayPercentage(rootCauseFraction);
+    const otherPercentage = displayPercentage(otherRootCauseFraction);
+
+    return {
+      assessment: assessmentDisplayInfo.assessmentInfo.name,
+      // Map assessment to known values.
+      title,
+      currentInfo: {
+        count: numRootCause,
+        fraction: numRootCause / maxNumRootCause,
+        tooltip: intl.formatMessage(
+          {
+            defaultMessage:
+              '{numRootCause}/{numEvals} ({percentage}%) runs failed due to the {assessment} judge failing for the current run "{currentRun}".',
+            description: 'Tooltip for the root cause metrics bar on the LLM evaluation page.',
+          },
+          {
+            numRootCause,
+            numEvals,
+            percentage: currentPercentage,
+            assessment: assessmentDisplayInfo.assessmentInfo.name,
+            currentRun: currentRunDisplayName,
+          },
+        ),
+        toggleFilter: () =>
+          toggleAssessmentFilter(assessmentDisplayInfo.assessmentInfo.name, 'failing_root_cause', 'current'),
+        isSelected: assessmentFilters.some(
+          (filter) =>
+            filter.filterType === 'rca' &&
+            filter.run === 'current' &&
+            filter.assessmentName === assessmentDisplayInfo.assessmentInfo.name,
+        ),
+        percentage: currentPercentage,
+      },
+      otherInfo: isCompareToRun
+        ? {
+            count: otherNumRootCause,
+            fraction: otherNumRootCause / maxNumRootCause,
+            tooltip: intl.formatMessage(
+              {
+                defaultMessage:
+                  '{numRootCause}/{numEvals} ({percentage}%) runs failed due to the {assessment} judge failing for run "{otherRunDisplayName}".',
+                description: 'Tooltip for the root cause metrics bar on the LLM evaluation page.',
+              },
+              {
+                numRootCause: otherNumRootCause,
+                numEvals: otherNumEvals,
+                percentage: otherPercentage,
+                assessment: assessmentDisplayInfo.assessmentInfo.name,
+                otherRunDisplayName,
+              },
+            ),
+            toggleFilter: () => toggleAssessmentFilter(assessmentDisplayInfo.assessmentInfo.name, 'rca', 'other'),
+            isSelected: assessmentFilters.some(
+              (filter) =>
+                filter.filterType === 'rca' &&
+                filter.run === 'other' &&
+                filter.assessmentName === assessmentDisplayInfo.assessmentInfo.name,
+            ),
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- TODO(FEINF-3982)
+            percentage: otherPercentage!,
+          }
+        : undefined,
+      icon: <XCircleFillIcon />,
+    };
+  });
+}

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsReviewAssessmentDetailedHistory.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsReviewAssessmentDetailedHistory.tsx
@@ -1,0 +1,169 @@
+import { first, isNil, isString } from 'lodash';
+import { useEffect, useMemo, useState } from 'react';
+
+import { Spacer, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { FormattedMessage, useIntl } from '@databricks/i18n';
+
+import {
+  KnownEvaluationResultAssessmentValueMapping,
+  getEvaluationResultAssessmentValue,
+  isDraftAssessment,
+} from './GenAiEvaluationTracesReview.utils';
+import type { RunEvaluationResultAssessment, RunEvaluationResultAssessmentDraft } from '../types';
+import { timeSinceStr } from '../utils/DisplayUtils';
+import { useMarkdownConverter } from '../utils/MarkdownUtils';
+
+type AssessmentWithHistory = RunEvaluationResultAssessment | RunEvaluationResultAssessmentDraft;
+
+export const EvaluationsReviewAssessmentDetailedHistory = ({
+  history,
+  alwaysExpanded = false,
+}: {
+  /**
+   * List of assessments to display, ordered from the most recent to the oldest.
+   */
+  history: AssessmentWithHistory[];
+  /**
+   * Whether the detailed view is always expanded.
+   */
+  alwaysExpanded?: boolean;
+}) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+
+  const [referenceDate, setReferenceDate] = useState<Date>(new Date());
+
+  useEffect(() => {
+    const updateDateInterval = setInterval(() => {
+      setReferenceDate(new Date());
+    }, 5000);
+    return () => {
+      clearInterval(updateDateInterval);
+    };
+  }, []);
+
+  const transitions = useMemo(() => {
+    return history.reduce<[AssessmentWithHistory, AssessmentWithHistory][]>((result, next, index) => {
+      const previous = history[index + 1];
+      if (previous) {
+        return [...result, [next, previous]];
+      }
+
+      return result;
+    }, []);
+  }, [history]);
+
+  const { makeHTML } = useMarkdownConverter();
+
+  const rationaleHtml = useMemo(() => {
+    const rationale = first(history)?.rationale;
+    return isString(rationale) ? makeHTML(rationale) : null;
+  }, [history, makeHTML]);
+
+  if (!transitions.length) {
+    if (first(history)?.rationale) {
+      return (
+        <div
+          css={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: theme.spacing.sm,
+          }}
+        >
+          {/* eslint-disable-next-line react/no-danger */}
+          <span css={{ display: 'contents' }} dangerouslySetInnerHTML={{ __html: rationaleHtml ?? '' }} />
+        </div>
+      );
+    } else if (first(history)?.errorMessage) {
+      return (
+        <>
+          <Typography.Text color="error">{first(history)?.errorMessage}</Typography.Text>
+        </>
+      );
+    } else {
+      return (
+        <>
+          {!alwaysExpanded && (
+            <div>
+              <Spacer size="sm" />
+              <Typography.Hint>
+                <FormattedMessage
+                  defaultMessage="No details for assessment"
+                  description="Evaluation review > assessments > no history"
+                />
+              </Typography.Hint>
+            </div>
+          )}
+        </>
+      );
+    }
+  }
+
+  const getMappedValue = (assessment: AssessmentWithHistory) => {
+    const value = getEvaluationResultAssessmentValue(assessment);
+    const knownMapping = KnownEvaluationResultAssessmentValueMapping[assessment.name];
+
+    if (knownMapping && !isNil(value)) {
+      const messageDescriptor = knownMapping[value.toString()] ?? knownMapping['default'];
+      if (messageDescriptor) {
+        return <FormattedMessage {...messageDescriptor} values={{ value }} />;
+      }
+    }
+
+    return value;
+  };
+
+  return (
+    <>
+      <Spacer size="sm" />
+      {transitions.map(([next, previous], index) => {
+        const prevValue = getMappedValue(previous);
+        const nextValue = getMappedValue(next);
+
+        const isSameValue = prevValue === nextValue;
+
+        const when = isDraftAssessment(next)
+          ? intl.formatMessage({
+              defaultMessage: 'just now',
+              description: 'Evaluation review > assessments > tooltip > just now',
+            })
+          : timeSinceStr(next.timestamp, referenceDate);
+
+        return (
+          <div
+            key={`${next.timestamp}-${index}`}
+            css={{ marginBottom: !alwaysExpanded ? theme.spacing.md : undefined }}
+          >
+            <Typography.Hint css={{ marginBottom: theme.spacing.xs }}>
+              {prevValue && nextValue && (
+                <>
+                  <code>{getMappedValue(previous)}</code> &#8594; <code>{getMappedValue(next)}</code>{' '}
+                </>
+              )}
+              {isSameValue ? (
+                <FormattedMessage
+                  defaultMessage="added {when} by {user}"
+                  description="Evaluation review > assessments > detailed history > added history entry"
+                  values={{
+                    when,
+                    user: next.source?.sourceId,
+                  }}
+                />
+              ) : (
+                <FormattedMessage
+                  defaultMessage="edited {when} by {user}"
+                  description="Evaluation review > assessments > detailed history > edited history entry"
+                  values={{
+                    when,
+                    user: next.source?.sourceId,
+                  }}
+                />
+              )}
+            </Typography.Hint>
+            {next.rationale && <Typography.Text>{next.rationale}</Typography.Text>}
+          </div>
+        );
+      })}
+    </>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsReviewAssessmentTag.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsReviewAssessmentTag.tsx
@@ -1,0 +1,564 @@
+import { isNil, isString } from 'lodash';
+import { useMemo } from 'react';
+
+import type { ThemeType } from '@databricks/design-system';
+import {
+  PencilIcon,
+  SparkleDoubleIcon,
+  UserIcon,
+  useDesignSystemTheme,
+  Button,
+  CheckCircleIcon,
+  XCircleIcon,
+  WarningIcon,
+  XCircleFillIcon,
+  HoverCard,
+  Typography,
+  InfoSmallIcon,
+  BracketsXIcon,
+  DangerIcon,
+} from '@databricks/design-system';
+import type { IntlShape } from '@databricks/i18n';
+import { FormattedMessage, useIntl } from '@databricks/i18n';
+
+import {
+  KnownEvaluationResultAssessmentValueLabel,
+  KnownEvaluationResultAssessmentValueMapping,
+  getEvaluationResultAssessmentValue,
+  hasBeenEditedByHuman,
+  KnownEvaluationResultAssessmentStringValue,
+  KnownEvaluationResultAssessmentValueMissingTooltip,
+  ASSESSMENTS_DOC_LINKS,
+  getJudgeMetricsLink,
+} from './GenAiEvaluationTracesReview.utils';
+import type { AssessmentInfo, RunEvaluationResultAssessment } from '../types';
+import {
+  getEvaluationResultAssessmentBackgroundColor,
+  getEvaluationResultIconColor,
+  getEvaluationResultTextColor,
+} from '../utils/Colors';
+import { displayFloat } from '../utils/DisplayUtils';
+import { useMarkdownConverter } from '../utils/MarkdownUtils';
+
+export const isAssessmentPassing = (
+  assessmentInfo: AssessmentInfo,
+  assessmentValue?: string | number | boolean | string[] | null,
+) => {
+  if (!isNil(assessmentValue)) {
+    if (assessmentInfo.dtype === 'pass-fail') {
+      if (assessmentValue === KnownEvaluationResultAssessmentStringValue.YES) {
+        return true;
+      } else if (assessmentValue === KnownEvaluationResultAssessmentStringValue.NO) {
+        return false;
+      }
+    } else if (assessmentInfo.dtype === 'boolean') {
+      return assessmentValue === true;
+    }
+  }
+  return undefined;
+};
+
+function getAssessmentTagDisplayValue(
+  theme: ThemeType,
+  intl: IntlShape,
+  type: 'value' | 'assessment-value',
+  assessmentInfo: AssessmentInfo,
+  editedByHuman: boolean,
+  assessment?: RunEvaluationResultAssessment,
+  isRootCauseAssessment?: boolean,
+): { tagText: JSX.Element | string; icon: JSX.Element; fullTagText?: JSX.Element | string | undefined } {
+  let tagText: string | JSX.Element = '';
+  let fullTagText: string | JSX.Element | undefined = undefined;
+  let icon: JSX.Element = <></>;
+
+  const errorDisplayValue = {
+    tagText: (
+      <FormattedMessage defaultMessage="Error" description="Error assessment status in the evaluations table." />
+    ),
+    icon: <DangerIcon css={{ color: theme.colors.textValidationWarning }} />,
+  };
+
+  const nullDisplayValue = {
+    tagText: (
+      <span css={{ fontStyle: 'italic' }}>
+        <FormattedMessage defaultMessage="null" description="Null value in the evaluations table." />
+      </span>
+    ),
+    icon: <WarningIcon css={{ color: theme.colors.grey400 }} />,
+  };
+
+  const value = assessment ? getEvaluationResultAssessmentValue(assessment) : undefined;
+  const isError = Boolean(assessment?.errorMessage);
+
+  if (isError) {
+    return errorDisplayValue;
+  }
+
+  if (assessmentInfo.dtype === 'pass-fail' || assessmentInfo.dtype === 'boolean') {
+    const isPassing = isAssessmentPassing(assessmentInfo, value);
+    let displayValueText = '';
+    if (assessmentInfo.dtype === 'pass-fail') {
+      // Known assessments are all pass / fail.
+      if (isPassing === true) {
+        displayValueText = intl.formatMessage({
+          defaultMessage: 'Pass',
+          description: 'Passing evaluation status in the evaluations table.',
+        });
+      } else if (isPassing === false) {
+        displayValueText = intl.formatMessage({
+          defaultMessage: 'Fail',
+          description: 'Failing evaluation status in the evaluations table.',
+        });
+      } else {
+        return nullDisplayValue;
+      }
+    } else if (isPassing === true) {
+      displayValueText = intl.formatMessage({
+        defaultMessage: 'True',
+        description: 'True value in the evaluations table.',
+      });
+    } else if (isPassing === false) {
+      displayValueText = intl.formatMessage({
+        defaultMessage: 'False',
+        description: 'False value in the evaluations table.',
+      });
+    } else {
+      return nullDisplayValue;
+    }
+
+    const iconColor = getEvaluationResultIconColor(theme, assessmentInfo, assessment);
+    icon =
+      isPassing === true ? (
+        <CheckCircleIcon
+          css={{
+            color: iconColor,
+          }}
+        />
+      ) : isPassing === false ? (
+        isRootCauseAssessment ? (
+          <XCircleFillIcon
+            css={{
+              color: iconColor,
+            }}
+          />
+        ) : (
+          <XCircleIcon
+            css={{
+              color: iconColor,
+            }}
+          />
+        )
+      ) : (
+        <WarningIcon
+          css={{
+            color: iconColor,
+          }}
+        />
+      );
+
+    if (type === 'assessment-value') {
+      const knownMapping = KnownEvaluationResultAssessmentValueMapping[assessmentInfo.name];
+
+      if (knownMapping) {
+        const messageDescriptor = value
+          ? (knownMapping[value.toString()] ?? knownMapping[KnownEvaluationResultAssessmentStringValue.YES])
+          : knownMapping[KnownEvaluationResultAssessmentStringValue.YES];
+        if (messageDescriptor) {
+          tagText = <FormattedMessage {...messageDescriptor} values={{ value }} />;
+        }
+      } else {
+        tagText = (
+          <>
+            {assessmentInfo.displayName}: {value}
+          </>
+        );
+      }
+    } else if (type === 'value') {
+      if (isNil(isPassing)) {
+        tagText = <span css={{ fontStyle: 'italic' }}>{displayValueText}</span>;
+      } else {
+        tagText = displayValueText;
+      }
+    }
+  } else if (assessmentInfo.dtype === 'numeric') {
+    const roundedValue = !isNil(value) ? displayFloat(value as number | undefined | null) : value;
+
+    if (type === 'assessment-value') {
+      tagText = (
+        <>
+          {assessmentInfo.displayName}: {roundedValue}
+        </>
+      );
+      fullTagText = (
+        <>
+          {assessmentInfo.displayName}: {value}
+        </>
+      );
+    } else {
+      if (isNil(roundedValue)) {
+        return nullDisplayValue;
+      }
+      tagText = `${roundedValue}`;
+      fullTagText = `${value}`;
+    }
+  } else {
+    // Wrap nulls in italics.
+    if (isNil(value)) {
+      return nullDisplayValue;
+    }
+    const valueElement = <>{String(value)}</>;
+    if (type === 'assessment-value') {
+      if (isNil(value)) {
+        tagText = <>{assessmentInfo.displayName}</>;
+      } else {
+        tagText = (
+          <>
+            {assessmentInfo.displayName}: {valueElement}
+          </>
+        );
+      }
+    } else {
+      tagText = valueElement;
+    }
+  }
+  return { tagText, icon, fullTagText };
+}
+
+export const EvaluationsReviewAssessmentTag = ({
+  assessment,
+  onEdit,
+  active = false,
+  disableJudgeTypeIcon,
+  showRationaleInTooltip = false,
+  showPassFailText = false,
+  hideAssessmentName = false,
+  iconOnly = false,
+  disableTooltip = false,
+  isRootCauseAssessment,
+  assessmentInfo,
+  type,
+  count,
+}: {
+  assessment?: RunEvaluationResultAssessment;
+  onEdit?: () => void;
+  active?: boolean;
+  disableJudgeTypeIcon?: boolean;
+  showRationaleInTooltip?: boolean;
+  showPassFailText?: boolean;
+  hideAssessmentName?: boolean;
+  iconOnly?: boolean;
+  disableTooltip?: boolean;
+  isRootCauseAssessment?: boolean;
+  assessmentInfo: AssessmentInfo;
+  type: 'value' | 'assessment-value';
+  count?: number;
+}) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+
+  const value = assessment ? getEvaluationResultAssessmentValue(assessment) : undefined;
+  const isPassing = useMemo(() => isAssessmentPassing(assessmentInfo, value), [value, assessmentInfo]);
+
+  const iconColor = getEvaluationResultIconColor(theme, assessmentInfo, assessment);
+  const textColor = getEvaluationResultTextColor(theme, assessmentInfo, assessment);
+
+  let errorMessage: string | undefined = undefined;
+  if (
+    assessment?.errorMessage ||
+    (isPassing === undefined && assessment && KnownEvaluationResultAssessmentValueMissingTooltip[assessment.name])
+  ) {
+    errorMessage =
+      assessment.errorMessage ||
+      intl.formatMessage(KnownEvaluationResultAssessmentValueMissingTooltip[assessment.name]);
+  }
+
+  const knownValueLabel = assessment ? KnownEvaluationResultAssessmentValueLabel[assessment.name] : undefined;
+  const assessmentTitle = useMemo(
+    () => (knownValueLabel ? intl.formatMessage(knownValueLabel) : assessment?.name),
+    [assessment, knownValueLabel, intl],
+  );
+  const learnMoreLink = useMemo(
+    () => (assessment ? getJudgeMetricsLink(ASSESSMENTS_DOC_LINKS[assessment.name]) : undefined),
+    [assessment],
+  );
+
+  const { makeHTML } = useMarkdownConverter();
+
+  const rationaleHTML = useMemo(() => {
+    const rationale = assessment?.rationale;
+    return isString(rationale) ? makeHTML(rationale) : undefined;
+  }, [assessment, makeHTML]);
+
+  const editedByHuman = useMemo(() => !isNil(assessment) && hasBeenEditedByHuman(assessment), [assessment]);
+
+  const { tagText, icon, fullTagText } = useMemo(
+    () =>
+      getAssessmentTagDisplayValue(theme, intl, type, assessmentInfo, editedByHuman, assessment, isRootCauseAssessment),
+    [theme, intl, type, assessmentInfo, assessment, isRootCauseAssessment, editedByHuman],
+  );
+
+  const tagContent = (
+    <>
+      {tagText}
+      {count && count > 1 ? ` (${count})` : ''}
+    </>
+  );
+
+  // Hide human assessment tags when not defined.
+  const hideTag = assessmentInfo.source?.sourceType === 'HUMAN' && !assessment?.source?.sourceId;
+  if (hideTag) {
+    return <></>;
+  }
+
+  const tagElement = (
+    <div>
+      <EvaluationsReviewTag
+        iconOnly={iconOnly}
+        hideAssessmentName={hideAssessmentName}
+        tagContent={tagContent}
+        active={active}
+        icon={icon}
+        iconColor={iconColor}
+        textColor={textColor}
+        sourceIcon={
+          assessmentInfo.isCustomMetric ? (
+            <BracketsXIcon />
+          ) : assessment && editedByHuman ? (
+            <UserIcon />
+          ) : (
+            <SparkleDoubleIcon />
+          )
+        }
+        backgroundColor={getEvaluationResultAssessmentBackgroundColor(theme, assessmentInfo, assessment)}
+        disableSourceTypeIcon={disableJudgeTypeIcon && !editedByHuman}
+        hasBeenEditedByHuman={editedByHuman}
+        onEdit={onEdit}
+      />
+    </div>
+  );
+
+  return (
+    <>
+      {disableTooltip ? (
+        tagElement
+      ) : (
+        <HoverCard
+          side="bottom"
+          content={
+            <div
+              css={{
+                maxWidth: '25rem',
+                display: 'flex',
+                flexDirection: 'column',
+                overflowWrap: 'break-word',
+                wordBreak: 'break-word',
+                gap: theme.spacing.sm,
+              }}
+            >
+              <div
+                css={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: theme.spacing.xs,
+                }}
+              >
+                <div
+                  css={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                  }}
+                >
+                  <div
+                    css={{
+                      display: 'flex',
+                      gap: theme.spacing.sm,
+                      alignItems: 'center',
+                    }}
+                  >
+                    <Typography.Title
+                      css={{
+                        marginBottom: 0,
+                      }}
+                    >
+                      {assessmentTitle}
+                    </Typography.Title>
+                    <EvaluationsReviewTag
+                      iconOnly={iconOnly}
+                      hideAssessmentName={hideAssessmentName}
+                      tagContent={fullTagText ? fullTagText : tagContent}
+                      active={active}
+                      icon={icon}
+                      iconColor={iconColor}
+                      textColor={textColor}
+                      sourceIcon={
+                        assessmentInfo.isCustomMetric ? (
+                          <BracketsXIcon />
+                        ) : assessment && hasBeenEditedByHuman(assessment) ? (
+                          <UserIcon />
+                        ) : (
+                          <SparkleDoubleIcon />
+                        )
+                      }
+                      backgroundColor={getEvaluationResultAssessmentBackgroundColor(theme, assessmentInfo, assessment)}
+                      disableSourceTypeIcon={disableJudgeTypeIcon}
+                      hasBeenEditedByHuman={editedByHuman}
+                    />
+                  </div>
+                  {learnMoreLink && (
+                    <a
+                      href={learnMoreLink}
+                      target="_blank"
+                      rel="noreferrer"
+                      css={{
+                        height: '16px',
+                      }}
+                    >
+                      <InfoSmallIcon />
+                    </a>
+                  )}
+                </div>
+                {isRootCauseAssessment && (
+                  <Typography.Hint>
+                    {intl.formatMessage({
+                      defaultMessage: 'This assessment is the root cause of the overall evaluation failure.',
+                      description:
+                        'Root cause assessment hint that explains that this assessment is causing the overall assessment to fail.',
+                    })}
+                  </Typography.Hint>
+                )}
+              </div>
+              {showRationaleInTooltip && assessment && rationaleHTML && (
+                <div>
+                  <>
+                    <span
+                      css={{
+                        display: 'contents',
+                        '& p': {
+                          marginBottom: 0,
+                        },
+                      }}
+                      // eslint-disable-next-line react/no-danger
+                      dangerouslySetInnerHTML={{ __html: rationaleHTML }}
+                    />
+                  </>
+                </div>
+              )}
+              {errorMessage && (
+                <div
+                  css={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: theme.spacing.xs,
+                  }}
+                >
+                  <span
+                    css={{
+                      color: theme.colors.textValidationWarning,
+                      fontStyle: 'italic',
+                    }}
+                  >
+                    {errorMessage}
+                  </span>
+                </div>
+              )}
+            </div>
+          }
+          trigger={tagElement}
+        />
+      )}
+    </>
+  );
+};
+
+const EvaluationsReviewTag = ({
+  iconOnly,
+  hideAssessmentName,
+  tagContent,
+  active,
+  sourceIcon,
+  icon,
+  iconColor,
+  textColor,
+  backgroundColor,
+  disableSourceTypeIcon,
+  hasBeenEditedByHuman,
+  onEdit,
+}: {
+  iconOnly: boolean;
+  hideAssessmentName: boolean;
+  tagContent: string | number | true | JSX.Element | undefined;
+  active?: boolean;
+  sourceIcon?: JSX.Element;
+  icon: JSX.Element;
+  iconColor: string;
+  textColor: string;
+  backgroundColor: string;
+  disableSourceTypeIcon?: boolean;
+  hasBeenEditedByHuman?: boolean;
+  onEdit?: () => void;
+}) => {
+  const { theme } = useDesignSystemTheme();
+
+  const svgSize = iconOnly ? 18 : 12;
+
+  return (
+    <div
+      css={{
+        // TODO: Use <Badge /> when it's aligned with design
+        display: 'inline-flex',
+        height: iconOnly ? svgSize : 20,
+        width: iconOnly ? svgSize : hideAssessmentName ? 'fit-content' : '',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        padding: iconOnly ? '0' : onEdit ? '0 0 0 8px' : '0 8px',
+        gap: theme.spacing.sm,
+        borderRadius: iconOnly ? '50%' : theme.legacyBorders.borderRadiusMd,
+        backgroundColor: backgroundColor,
+        boxShadow: `inset 0 0 1px 1px ${active ? theme.colors.borderAccessible : 'transparent'}`,
+        // border: iconOnly ? '' : `1px solid ${getEvaluationBorderColor(theme, assessment)}`,
+        fontSize: theme.typography.fontSizeSm,
+        svg: { width: svgSize, height: svgSize },
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {icon}
+      {tagContent && (
+        <span
+          css={{
+            color: textColor,
+          }}
+        >
+          {tagContent}
+        </span>
+      )}
+      {disableSourceTypeIcon !== true ? (
+        <span
+          css={{
+            color: iconColor,
+          }}
+        >
+          {sourceIcon}
+        </span>
+      ) : (
+        <></>
+      )}
+      {onEdit && (
+        <Button
+          componentId="mlflow.evaluations_review.edit_assessment_button"
+          onClick={onEdit}
+          size="small"
+          icon={
+            <PencilIcon
+              css={{
+                ':hover': {
+                  color: theme.colors.actionDefaultTextHover,
+                },
+              }}
+            />
+          }
+        />
+      )}
+    </div>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsReviewAssessmentTooltip.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsReviewAssessmentTooltip.tsx
@@ -1,0 +1,121 @@
+import { first } from 'lodash';
+import { useEffect, useMemo, useState } from 'react';
+
+import { Tooltip } from '@databricks/design-system';
+import { FormattedMessage, useIntl } from '@databricks/i18n';
+
+import {
+  KnownEvaluationResultAssessmentValueMapping,
+  getEvaluationResultAssessmentValue,
+  isDraftAssessment,
+  isEvaluationResultOverallAssessment,
+  hasBeenEditedByHuman,
+} from './GenAiEvaluationTracesReview.utils';
+import type { RunEvaluationResultAssessment } from '../types';
+import { timeSinceStr } from '../utils/DisplayUtils';
+
+export const EvaluationsReviewAssessmentTooltip = ({
+  assessmentHistory,
+  children,
+  disable = false,
+}: React.PropsWithChildren<{
+  assessmentHistory: RunEvaluationResultAssessment[];
+  disable?: boolean;
+}>) => {
+  const intl = useIntl();
+
+  const isOverallAssessment = useMemo(
+    () => assessmentHistory.some(isEvaluationResultOverallAssessment),
+    [assessmentHistory],
+  );
+
+  const [referenceDate, setReferenceDate] = useState<Date>(new Date());
+
+  useEffect(() => {
+    const updateDateInterval = setInterval(() => {
+      setReferenceDate(new Date());
+    }, 5000);
+    return () => {
+      clearInterval(updateDateInterval);
+    };
+  }, []);
+
+  const getTitle = () => {
+    const mostRecentEntry = first(assessmentHistory);
+    if (!mostRecentEntry) {
+      return undefined;
+    }
+    const isEditedByHuman = hasBeenEditedByHuman(mostRecentEntry);
+
+    if (isEditedByHuman) {
+      const previousRecentEntry = assessmentHistory[1];
+      const previousRecentValue = previousRecentEntry
+        ? getEvaluationResultAssessmentValue(previousRecentEntry)?.toString()
+        : undefined;
+
+      const timeSince = isDraftAssessment(mostRecentEntry)
+        ? intl.formatMessage({
+            defaultMessage: 'just now',
+            description: 'Evaluation review > assessments > tooltip > just now',
+          })
+        : timeSinceStr(mostRecentEntry.timestamp, referenceDate);
+
+      if (previousRecentValue) {
+        const mappedValue = KnownEvaluationResultAssessmentValueMapping[mostRecentEntry.name]?.[previousRecentValue];
+        const displayedPreviousValue = mappedValue ? intl.formatMessage(mappedValue) : previousRecentValue;
+
+        return (
+          <FormattedMessage
+            defaultMessage="Edited {timeSince} by {source}. Original value: {value}"
+            values={{
+              timeSince,
+              source: mostRecentEntry?.source?.sourceId,
+              value: displayedPreviousValue,
+            }}
+            description="Evaluation review > assessments > tooltip > edited by human"
+          />
+        );
+      }
+
+      return (
+        <FormattedMessage
+          defaultMessage="Edited {timeSince} by {source}."
+          values={{
+            timeSince,
+            source: mostRecentEntry?.source?.sourceId,
+          }}
+          description="Evaluation review > assessments > tooltip > edited by human"
+        />
+      );
+    }
+
+    if (isOverallAssessment) {
+      return (
+        <FormattedMessage
+          defaultMessage="Overall assessment added by LLM-as-a-judge"
+          description="Evaluation review > assessments > tooltip > overall assessment added by LLM-as-a-judge"
+        />
+      );
+    }
+
+    if (mostRecentEntry?.errorMessage) {
+      return mostRecentEntry?.errorMessage;
+    }
+
+    return (
+      <FormattedMessage
+        defaultMessage="Assessment added by LLM-as-a-judge"
+        description="Evaluation review > assessments > tooltip > assessment added by LLM-as-a-judge"
+      />
+    );
+  };
+  return (
+    <Tooltip
+      componentId="web-shared.genai-traces-table.evaluations-review-assessment.tooltip"
+      content={disable ? undefined : <span>{getTitle()}</span>}
+      side="top"
+    >
+      {children}
+    </Tooltip>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsReviewAssessmentUpsertForm.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsReviewAssessmentUpsertForm.tsx
@@ -1,0 +1,218 @@
+import { useMemo, useState } from 'react';
+
+import {
+  Button,
+  Input,
+  Spacer,
+  TypeaheadComboboxInput,
+  TypeaheadComboboxMenu,
+  TypeaheadComboboxMenuItem,
+  TypeaheadComboboxRoot,
+  useComboboxState,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
+import { FormattedMessage, useIntl } from '@databricks/i18n';
+
+import { getEvaluationResultAssessmentValue } from './GenAiEvaluationTracesReview.utils';
+import type {
+  AssessmentDropdownSuggestionItem,
+  RunEvaluationResultAssessment,
+  RunEvaluationResultAssessmentDraft,
+} from '../types';
+
+/**
+ * A form capable of adding or editing an assessment.
+ */
+export const EvaluationsReviewAssessmentUpsertForm = ({
+  editedAssessment,
+  valueSuggestions,
+  onSave,
+  onCancel,
+  readOnly = false,
+}: {
+  editedAssessment?: RunEvaluationResultAssessment | RunEvaluationResultAssessmentDraft;
+  valueSuggestions: AssessmentDropdownSuggestionItem[];
+  onSave: (values: { value: string | boolean; rationale?: string; assessmentName?: string }) => void;
+  onCancel: () => void;
+  readOnly?: boolean;
+}) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+
+  const [rationale, setRationale] = useState<string | undefined>(() => {
+    return editedAssessment?.rationale || undefined;
+  });
+
+  const [inputValue, setInputValue] = useState('');
+
+  const [formValue, setFormValue] = useState<AssessmentDropdownSuggestionItem | undefined>(() => {
+    // If we're editing an existing assessment, find relevant suggestion and use it as a form value
+    if (editedAssessment) {
+      const value = getEvaluationResultAssessmentValue(editedAssessment)?.toString();
+      if (value) {
+        return valueSuggestions.find((item) => item.key === value) ?? { key: value, label: value };
+      }
+
+      // Special case: if there's no value at all but we use a draft assessment, use assessment name
+      return { key: editedAssessment.name, label: editedAssessment.name };
+    }
+
+    return { key: '', label: '' };
+  });
+
+  const [showAllSuggestions, setShowAllSuggestions] = useState(false);
+
+  const filteredSuggestions = useMemo(
+    () => valueSuggestions.filter((item) => item.label.toLowerCase().includes(inputValue.toLowerCase())),
+    [inputValue, valueSuggestions],
+  );
+
+  // Show either all or filtered suggestions
+  const visibleSuggestions = showAllSuggestions ? valueSuggestions : filteredSuggestions;
+
+  // The combobox is displayed if there are suggestions or a custom value is provided
+  const displayCombobox = inputValue || visibleSuggestions.length > 0;
+
+  const comboboxState = useComboboxState<AssessmentDropdownSuggestionItem>({
+    componentId:
+      'codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewassessmentupsertform.tsx_124',
+    allItems: valueSuggestions,
+    items: visibleSuggestions,
+    setItems: () => {},
+    setInputValue: (val) => {
+      setShowAllSuggestions(false);
+      setInputValue(val);
+    },
+    multiSelect: false,
+    allowNewValue: true,
+    itemToString: (item) => (item ? item.label : ''),
+    formValue,
+    initialSelectedItem: formValue,
+    initialInputValue: formValue?.label ?? '',
+    formOnChange: (item) => {
+      // If no changes made to the currently selected item, do nothing.
+      // This is required, otherwise TypeaheadCombobox will replace object with plain string
+      if (formValue?.label === item) {
+        return;
+      }
+
+      // If provided custom value, construct a new item
+      if (typeof item === 'string') {
+        setFormValue({ key: inputValue ?? '', label: inputValue ?? '' });
+        return;
+      }
+
+      // If used a dropdown option, set it as a form value
+      setFormValue(item);
+    },
+    onIsOpenChange(isOpen) {
+      if (isOpen) {
+        // After uses clicks on the combobox, we're displaying all suggestions
+        setShowAllSuggestions(true);
+      }
+    },
+  });
+
+  const addNewElementLabel = intl.formatMessage(
+    {
+      defaultMessage: 'Add "{label}"',
+      description: 'Evaluation review > assessments > add new custom value element',
+    },
+    {
+      label: inputValue,
+    },
+  );
+
+  return (
+    <div>
+      <TypeaheadComboboxRoot comboboxState={comboboxState}>
+        <TypeaheadComboboxInput
+          readOnly={readOnly}
+          css={{ width: 300, backgroundColor: theme.colors.backgroundPrimary }}
+          placeholder={intl.formatMessage({
+            defaultMessage: 'Select or type an assessment',
+            description: 'Evaluation review > assessments > combobox placeholder',
+          })}
+          onKeyUp={(e) => {
+            // Close menu on Enter if no item is highlighted. We need to use onKeyUp to avoid conflicts with Downshift
+            if (comboboxState.highlightedIndex === -1 && e.key === 'Enter') {
+              comboboxState.closeMenu();
+            }
+          }}
+          comboboxState={comboboxState}
+          formOnChange={(val) => {
+            setFormValue(val);
+          }}
+        />
+        {displayCombobox && (
+          <TypeaheadComboboxMenu comboboxState={comboboxState} emptyText={addNewElementLabel} matchTriggerWidth>
+            {visibleSuggestions.map((item, index) => (
+              <TypeaheadComboboxMenuItem
+                key={`${item.key}-${index}`}
+                item={item}
+                index={index}
+                comboboxState={comboboxState}
+                isDisabled={item?.disabled || false}
+              >
+                {item.label}
+              </TypeaheadComboboxMenuItem>
+            ))}
+          </TypeaheadComboboxMenu>
+        )}
+      </TypeaheadComboboxRoot>
+      <Spacer size="sm" />
+      <div css={{ backgroundColor: theme.colors.backgroundPrimary, borderRadius: theme.general.borderRadiusBase }}>
+        <Input.TextArea
+          componentId="codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewassessmentupsertform.tsx_160"
+          autoSize
+          value={rationale ?? ''}
+          onChange={(e) => setRationale(e.target.value)}
+          placeholder={intl.formatMessage({
+            defaultMessage: 'Add rationale (optional)',
+            description: 'Evaluation review > assessments > rationale input placeholder',
+          })}
+        />
+      </div>
+      <Spacer size="sm" />
+      <div css={{ display: 'flex', gap: theme.spacing.xs }}>
+        <Button
+          size="small"
+          type="primary"
+          componentId="mlflow.evaluations_review.confirm_edited_assessment_button"
+          onClick={() => {
+            // Assert form value
+            if (!formValue) {
+              return;
+            }
+            // Select assessment name either:
+            // - from general suggestion when having multiple
+            // - from already existing assessment when editing
+            // - from custom value when provided
+            const targetAssessmentName = formValue.rootAssessmentName ?? editedAssessment?.name ?? formValue.key;
+
+            // Either use value or set it to "true" if we're using plain custom assessment name
+            const value = targetAssessmentName !== formValue.key ? formValue.key : true;
+            onSave({ value, rationale, assessmentName: targetAssessmentName });
+          }}
+          disabled={!formValue?.key}
+        >
+          <FormattedMessage
+            defaultMessage="Confirm"
+            description="Evaluation review > assessments > confirm assessment button label"
+          />
+        </Button>
+        <Button
+          size="small"
+          type="tertiary"
+          componentId="mlflow.evaluations_review.cancel_edited_assessment_button"
+          onClick={onCancel}
+        >
+          <FormattedMessage
+            defaultMessage="Cancel"
+            description="Evaluation review > assessments > cancel assessment button label"
+          />
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsReviewAssessments.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsReviewAssessments.tsx
@@ -1,0 +1,583 @@
+import { first, isString } from 'lodash';
+import { useEffect, useMemo, useState } from 'react';
+
+import {
+  AssistantIcon,
+  BugIcon,
+  Button,
+  ChevronRightIcon,
+  ChevronUpIcon,
+  PlusIcon,
+  Spacer,
+  Typography,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
+import { FormattedMessage, useIntl } from '@databricks/i18n';
+
+import { EvaluationsReviewAssessmentDetailedHistory } from './EvaluationsReviewAssessmentDetailedHistory';
+import { EvaluationsReviewAssessmentTag } from './EvaluationsReviewAssessmentTag';
+import { EvaluationsReviewAssessmentTooltip } from './EvaluationsReviewAssessmentTooltip';
+import { EvaluationsReviewAssessmentUpsertForm } from './EvaluationsReviewAssessmentUpsertForm';
+import {
+  createDraftEvaluationResultAssessmentObject,
+  getEvaluationResultAssessmentValue,
+  isAssessmentMissing,
+  isDraftAssessment,
+  KnownEvaluationResultAssessmentName,
+  KnownEvaluationResultAssessmentValueLabel,
+} from './GenAiEvaluationTracesReview.utils';
+import { useEditAssessmentFormState } from '../hooks/useEditAssessmentFormState';
+import type { AssessmentInfo, RunEvaluationResultAssessmentDraft, RunEvaluationResultAssessment } from '../types';
+import { useMarkdownConverter } from '../utils/MarkdownUtils';
+
+/**
+ * Displays an expanded assessment with rationale and edit history.
+ * Expanded assessments each has its own edit form.
+ */
+const ExpandedAssessment = ({
+  assessmentsType, // Type of the assessments, e.g. 'overall', 'response', 'retrieval'. Used for component IDs.
+  assessmentName, // Name of the assessment.
+  assessmentHistory, // A list of assessment history.
+  rootCauseAssessment, // The root cause assessment causing this to fail.
+  onUpsertAssessment, // Callback to upsert an assessment. This is called when the user saves an assessment. Any pre-saving logic should be done here.
+  allowEditing = false, // Whether editing is allowed.
+  options, // A list of known assessment names as options for the dropdown.
+  inputs, // Dependency array to control the refresh of the states.
+  assessmentInfo,
+  assessmentInfos,
+}: {
+  assessmentsType: 'overall' | 'response' | 'retrieval';
+  assessmentName: string;
+  assessmentHistory: RunEvaluationResultAssessment[];
+  rootCauseAssessment?: RunEvaluationResultAssessment;
+  onUpsertAssessment: (assessment: RunEvaluationResultAssessmentDraft) => void;
+  allowEditing?: boolean;
+  options?: KnownEvaluationResultAssessmentName[];
+  inputs?: any;
+  assessmentInfo: AssessmentInfo;
+  assessmentInfos: AssessmentInfo[];
+}) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+
+  const isOverallAssessment = assessmentsType === 'overall';
+
+  const {
+    suggestions,
+    editingAssessment,
+    showUpsertForm: isEditing,
+    editAssessment,
+    closeForm,
+  } = useEditAssessmentFormState(assessmentHistory, assessmentInfos);
+
+  // Clear the states when the inputs change
+  useEffect(() => {
+    // Close the form if it's open
+    closeForm();
+  }, [inputs, closeForm]);
+
+  const assessment = first(assessmentHistory);
+
+  const intlLabel = KnownEvaluationResultAssessmentValueLabel[assessmentName];
+  const label = intlLabel ? intl.formatMessage(intlLabel) : assessmentName;
+
+  const hasValue = Boolean(assessment && getEvaluationResultAssessmentValue(assessment));
+  const isDraft = Boolean(assessment && isDraftAssessment(assessment));
+
+  const isEditable = allowEditing && (hasValue || isDraft);
+
+  const { makeHTML } = useMarkdownConverter();
+
+  const suggestedActionHtml = useMemo(() => {
+    const suggestedAction = assessment?.rootCauseAssessment?.suggestedActions;
+    return isString(suggestedAction) ? makeHTML(suggestedAction) : null;
+  }, [assessment, makeHTML]);
+
+  return (
+    <div
+      key={assessmentName}
+      css={{
+        display: 'block',
+        marginBottom: !isOverallAssessment ? theme.spacing.md : undefined,
+      }}
+    >
+      {!isEditing && (
+        <div
+          css={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: theme.spacing.sm,
+          }}
+        >
+          {assessmentName !== KnownEvaluationResultAssessmentName.OVERALL_ASSESSMENT && (
+            <div
+              css={{
+                display: 'flex',
+                gap: theme.spacing.sm,
+                alignItems: 'center',
+              }}
+            >
+              <EvaluationsReviewAssessmentTag
+                assessment={assessment}
+                aria-label={label}
+                disableJudgeTypeIcon={isAssessmentMissing(assessment)}
+                onEdit={
+                  isEditable
+                    ? () => {
+                        const assessmentToEdit = first(assessmentHistory);
+                        assessmentToEdit && editAssessment(assessmentToEdit);
+                      }
+                    : undefined
+                }
+                assessmentInfo={assessmentInfo}
+                type="assessment-value"
+              />
+            </div>
+          )}
+          <EvaluationsReviewAssessmentDetailedHistory
+            history={assessmentHistory}
+            alwaysExpanded={isOverallAssessment}
+          />
+
+          {rootCauseAssessment && (
+            <div
+              css={{
+                display: 'flex',
+                flexDirection: 'column',
+                gap: theme.spacing.sm,
+                marginTop: theme.spacing.xs,
+              }}
+            >
+              {/* Root cause failure */}
+              <div css={{ display: 'flex', gap: theme.spacing.sm, alignItems: 'center' }}>
+                <BugIcon color="danger" />
+                <Typography.Text bold>
+                  <FormattedMessage
+                    defaultMessage="Root cause failure:"
+                    description="Evaluation review > assessments > root cause failure > title"
+                  />
+                </Typography.Text>
+                <EvaluationsReviewAssessmentTag
+                  assessment={rootCauseAssessment}
+                  isRootCauseAssessment
+                  aria-label={label}
+                  assessmentInfo={assessmentInfo}
+                  type="assessment-value"
+                />
+              </div>
+              <EvaluationsReviewAssessmentDetailedHistory
+                history={[rootCauseAssessment]}
+                alwaysExpanded={isOverallAssessment}
+              />
+              {suggestedActionHtml && (
+                <div
+                  css={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: theme.spacing.sm,
+                  }}
+                >
+                  <div css={{ display: 'flex', gap: theme.spacing.sm, alignItems: 'center' }}>
+                    <AssistantIcon color="ai" />
+                    <Typography.Text bold>
+                      <FormattedMessage
+                        defaultMessage="Suggested actions"
+                        description="Evaluation review > assessments > suggested actions > title"
+                      />
+                    </Typography.Text>
+                  </div>
+                  {/* eslint-disable-next-line react/no-danger */}
+                  <span css={{ display: 'contents' }} dangerouslySetInnerHTML={{ __html: suggestedActionHtml }} />
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+      {isEditing && (
+        <>
+          <EvaluationsReviewAssessmentUpsertForm
+            key={editingAssessment?.name}
+            editedAssessment={editingAssessment}
+            valueSuggestions={suggestions}
+            onCancel={closeForm}
+            onSave={({ value, rationale, assessmentName }) => {
+              const defaultAssessmentName = isOverallAssessment
+                ? KnownEvaluationResultAssessmentName.OVERALL_ASSESSMENT
+                : '';
+              const assessment = createDraftEvaluationResultAssessmentObject({
+                name: assessmentName ?? editingAssessment?.name ?? defaultAssessmentName,
+                isOverallAssessment: isOverallAssessment,
+                value,
+                rationale,
+              });
+              onUpsertAssessment(assessment);
+              closeForm();
+            }}
+          />
+        </>
+      )}
+    </div>
+  );
+};
+
+/**
+ * Displays a list of assessments in expanded mode along with an add assessment button at the end.
+ */
+const ExpandedAssessments = ({
+  assessmentsType, // Type of the assessments, e.g. 'overall', 'response', 'retrieval'. Used for component IDs.
+  assessmentsByName, // A list of assessments by name.
+  rootCauseAssessment, // The root cause assessment causing this to fail.
+  onUpsertAssessment, // Callback to upsert an assessment. This is called when the user saves an assessment. Any pre-saving logic should be done here.
+  allowEditing = false, // Whether editing is allowed.
+  allowMoreThanOne = false, // Whether allow more than one assessment.
+  options, // A list of known assessment names as options for the dropdown.
+  inputs, // Dependency array to control the refresh of the states.
+  assessmentInfos,
+}: {
+  assessmentsType: 'overall' | 'response' | 'retrieval';
+  assessmentsByName: [string, RunEvaluationResultAssessment[]][];
+  rootCauseAssessment?: RunEvaluationResultAssessment;
+  onUpsertAssessment: (assessment: RunEvaluationResultAssessmentDraft) => void;
+  allowEditing?: boolean;
+  allowMoreThanOne?: boolean;
+  options?: KnownEvaluationResultAssessmentName[];
+  inputs?: any;
+  assessmentInfos: AssessmentInfo[];
+}) => {
+  const { theme } = useDesignSystemTheme();
+
+  const isOverallAssessment = assessmentsType === 'overall';
+
+  const nonEmptyAssessments = assessmentsByName.filter(([_, assessmentList]) => assessmentList.length > 0);
+
+  const { suggestions, editingAssessment, showUpsertForm, addAssessment, closeForm } = useEditAssessmentFormState(
+    nonEmptyAssessments.flatMap(([_key, assessmentList]) => assessmentList),
+    assessmentInfos,
+  );
+
+  // Clear the states when the inputs change
+  useEffect(() => {
+    // Close the form if it's open
+    closeForm();
+  }, [inputs, closeForm]);
+
+  const containsAssessments = Object.keys(nonEmptyAssessments).length > 0;
+  const showAddAssessmentButton = allowEditing && (allowMoreThanOne || !containsAssessments);
+
+  return (
+    <>
+      <div
+        // comment for copybara formatting
+        css={{ display: 'block', flexWrap: 'wrap', gap: theme.spacing.xs }}
+      >
+        {nonEmptyAssessments.map(([key, assessmentList]) => {
+          const assessmentInfo = assessmentInfos.find((info) => info.name === key);
+          if (!assessmentInfo) {
+            return <div css={{ display: 'none' }} key={key} />;
+          }
+          return (
+            <ExpandedAssessment
+              key={key}
+              assessmentsType={assessmentsType}
+              assessmentName={key}
+              assessmentHistory={assessmentList}
+              rootCauseAssessment={rootCauseAssessment}
+              onUpsertAssessment={onUpsertAssessment}
+              allowEditing={allowEditing}
+              options={options}
+              inputs={inputs}
+              assessmentInfo={assessmentInfo}
+              assessmentInfos={assessmentInfos}
+            />
+          );
+        })}
+        {showAddAssessmentButton && (
+          <Button
+            componentId={
+              assessmentsType === 'overall'
+                ? 'mlflow.evaluations_review.add_assessment_overall_button'
+                : assessmentsType === 'response'
+                  ? 'mlflow.evaluations_review.add_assessment_response_button'
+                  : 'mlflow.evaluations_review.add_assessment_retrieval_button'
+            }
+            onClick={addAssessment}
+            icon={<PlusIcon />}
+            size="small"
+          >
+            <FormattedMessage
+              defaultMessage="Add assessment"
+              description="Evaluation review > assessments > add assessment button label"
+            />
+          </Button>
+        )}
+      </div>
+      {showUpsertForm && (
+        <>
+          <Spacer size="sm" />
+          <EvaluationsReviewAssessmentUpsertForm
+            valueSuggestions={suggestions}
+            onCancel={closeForm}
+            onSave={({ value, rationale, assessmentName }) => {
+              const defaultAssessmentName = isOverallAssessment
+                ? KnownEvaluationResultAssessmentName.OVERALL_ASSESSMENT
+                : assessmentName || '';
+              const assessment = createDraftEvaluationResultAssessmentObject({
+                name: assessmentName ?? editingAssessment?.name ?? defaultAssessmentName,
+                isOverallAssessment: isOverallAssessment,
+                value,
+                rationale,
+              });
+              onUpsertAssessment(assessment);
+              closeForm();
+            }}
+          />
+        </>
+      )}
+    </>
+  );
+};
+
+/**
+ * Displays a list of assessments in compact mode.
+ * Compact assessments share the same edit form.
+ */
+const CompactAssessments = ({
+  assessmentsType, // Type of the assessments, e.g. 'overall', 'response', 'retrieval'. Used for component IDs.
+  assessmentsByName, // A list of assessments by name.
+  onUpsertAssessment, // Callback to upsert an assessment. This is called when the user saves an assessment. Any pre-saving logic should be done here.
+  allowEditing = false, // Whether editing is allowed.
+  allowMoreThanOne = false, // Whether allow more than one assessment.
+  options, // A list of known assessment names as options for the dropdown.
+  inputs, // Dependency array to control the refresh of the states.
+  assessmentInfos,
+}: {
+  assessmentsType: 'overall' | 'response' | 'retrieval';
+  assessmentsByName: [string, RunEvaluationResultAssessment[]][];
+  onUpsertAssessment: (assessment: RunEvaluationResultAssessmentDraft) => void;
+  allowEditing?: boolean;
+  allowMoreThanOne?: boolean;
+  options?: KnownEvaluationResultAssessmentName[];
+  inputs?: any;
+  assessmentInfos: AssessmentInfo[];
+}) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+
+  const isOverallAssessment = assessmentsType === 'overall';
+
+  const { suggestions, editingAssessment, showUpsertForm, addAssessment, editAssessment, closeForm } =
+    useEditAssessmentFormState(
+      assessmentsByName.flatMap(([_key, assessmentList]) => assessmentList),
+      assessmentInfos,
+    );
+
+  // Clear the states when the inputs change
+  useEffect(() => {
+    // Close the form if it's open
+    closeForm();
+  }, [inputs, closeForm]);
+
+  const nonEmptyAssessments = assessmentsByName.filter(([_, assessmentList]) => assessmentList.length > 0);
+
+  const containsAssessments = Object.keys(nonEmptyAssessments).length > 0;
+  const showAddAssessmentButton = allowEditing && (allowMoreThanOne || !containsAssessments);
+
+  return (
+    <>
+      <div css={{ display: 'flex', flexWrap: 'wrap', gap: theme.spacing.xs, alignItems: 'center' }}>
+        {nonEmptyAssessments.map(([key, assessmentList]) => {
+          const assessment = first(assessmentList);
+          const assessmentInfo = assessmentInfos.find((info) => info.name === key);
+
+          if (!assessmentInfo) {
+            // eslint-disable-next-line react/jsx-key -- TODO(FEINF-1756)
+            return <></>;
+          }
+
+          const intlLabel = KnownEvaluationResultAssessmentValueLabel[key];
+          const label = intlLabel ? intl.formatMessage(intlLabel) : key;
+
+          const hasValue = Boolean(assessment && getEvaluationResultAssessmentValue(assessment));
+          const isDraft = Boolean(assessment && isDraftAssessment(assessment));
+
+          const isEditable = allowEditing && (hasValue || isDraft) && assessmentInfo.isEditable;
+
+          return (
+            <div
+              key={key}
+              css={{
+                display: 'contents',
+              }}
+            >
+              <EvaluationsReviewAssessmentTooltip assessmentHistory={assessmentList}>
+                <EvaluationsReviewAssessmentTag
+                  assessment={assessment}
+                  aria-label={label}
+                  active={editingAssessment?.name === key && showUpsertForm}
+                  disableJudgeTypeIcon={isAssessmentMissing(assessment)}
+                  onEdit={
+                    isEditable
+                      ? () => {
+                          const assessmentToEdit = first(assessmentList);
+                          assessmentToEdit && editAssessment(assessmentToEdit);
+                        }
+                      : undefined
+                  }
+                  assessmentInfo={assessmentInfo}
+                  type="assessment-value"
+                />
+              </EvaluationsReviewAssessmentTooltip>
+            </div>
+          );
+        })}
+        {showAddAssessmentButton && (
+          <Button
+            componentId={
+              assessmentsType === 'overall'
+                ? 'mlflow.evaluations_review.add_assessment_overall_button'
+                : assessmentsType === 'response'
+                  ? 'mlflow.evaluations_review.add_assessment_response_button'
+                  : 'mlflow.evaluations_review.add_assessment_retrieval_button'
+            }
+            onClick={addAssessment}
+            icon={<PlusIcon />}
+            size="small"
+          >
+            <FormattedMessage
+              defaultMessage="Add assessment"
+              description="Evaluation review > assessments > add assessment button label"
+            />
+          </Button>
+        )}
+      </div>
+      {showUpsertForm && (
+        <>
+          <Spacer size="sm" />
+          <EvaluationsReviewAssessmentUpsertForm
+            key={editingAssessment?.name}
+            editedAssessment={editingAssessment}
+            valueSuggestions={suggestions}
+            onCancel={closeForm}
+            onSave={({ value, rationale, assessmentName }) => {
+              const defaultAssessmentName = isOverallAssessment
+                ? KnownEvaluationResultAssessmentName.OVERALL_ASSESSMENT
+                : assessmentName || '';
+              const assessment = createDraftEvaluationResultAssessmentObject({
+                name: assessmentName ?? editingAssessment?.name ?? defaultAssessmentName,
+                isOverallAssessment: isOverallAssessment,
+                value,
+                rationale,
+              });
+              onUpsertAssessment(assessment);
+              closeForm();
+            }}
+          />
+        </>
+      )}
+    </>
+  );
+};
+
+/**
+ * Displays a list of assessments with an option to expand and see the detailed view.
+ */
+export const EvaluationsReviewAssessments = ({
+  assessmentsType, // Type of the assessments, e.g. 'overall', 'response', 'retrieval'. Used for component IDs.
+  assessmentsByName, // A list of assessments by name.
+  rootCauseAssessment, // The root cause assessment causing this to fail.
+  onUpsertAssessment, // Callback to upsert an assessment. This is called when the user saves an assessment. Any pre-saving logic should be done here.
+  allowEditing = false, // Whether editing is allowed.
+  allowMoreThanOne = false, // Whether allow more than one assessment.
+  alwaysExpanded = false, // Whether the detailed view is always expanded.
+  options, // A list of known assessment names as options for the dropdown.
+  inputs, // Dependency array to control the refresh of the states.
+  assessmentInfos,
+}: {
+  assessmentsType: 'overall' | 'response' | 'retrieval';
+  assessmentsByName: [string, RunEvaluationResultAssessment[]][];
+  rootCauseAssessment?: RunEvaluationResultAssessment;
+  onUpsertAssessment: (assessment: RunEvaluationResultAssessmentDraft) => void;
+  allowEditing?: boolean;
+  allowMoreThanOne?: boolean;
+  alwaysExpanded?: boolean;
+  options?: KnownEvaluationResultAssessmentName[];
+  inputs?: any;
+  assessmentInfos: AssessmentInfo[];
+}) => {
+  // True if in expanded view, false otherwise.
+  const [isExpandedView, setIsExpandedView] = useState(false);
+  const showExpandedView = alwaysExpanded || isExpandedView;
+
+  const nonEmptyAssessments = assessmentsByName.filter(([_, assessmentList]) => assessmentList.length > 0);
+
+  // Remove the overall assessment if it's not an overall assessment and we're not showing overall assessments.
+  let filteredAssessmentsByName = assessmentsByName;
+  if (assessmentsType !== 'overall') {
+    filteredAssessmentsByName = assessmentsByName.filter(
+      ([key, _]) => key !== KnownEvaluationResultAssessmentName.OVERALL_ASSESSMENT,
+    );
+  }
+
+  const containsAssessments = Object.keys(nonEmptyAssessments).length > 0;
+
+  return (
+    <>
+      {showExpandedView && (
+        <ExpandedAssessments
+          assessmentsType={assessmentsType}
+          assessmentsByName={filteredAssessmentsByName}
+          rootCauseAssessment={rootCauseAssessment}
+          onUpsertAssessment={onUpsertAssessment}
+          allowEditing={allowEditing}
+          allowMoreThanOne={allowMoreThanOne}
+          options={options}
+          inputs={inputs}
+          assessmentInfos={assessmentInfos}
+        />
+      )}
+      {!showExpandedView && (
+        <CompactAssessments
+          assessmentsType={assessmentsType}
+          assessmentsByName={filteredAssessmentsByName}
+          onUpsertAssessment={onUpsertAssessment}
+          allowEditing={allowEditing}
+          allowMoreThanOne={allowMoreThanOne}
+          options={options}
+          inputs={inputs}
+          assessmentInfos={assessmentInfos}
+        />
+      )}
+      {containsAssessments && !alwaysExpanded && (
+        <>
+          <Spacer size="sm" />
+          <Button
+            size="small"
+            type="tertiary"
+            componentId={
+              assessmentsType === 'overall'
+                ? 'mlflow.evaluations_review.see_assessment_details_overall_button'
+                : assessmentsType === 'response'
+                  ? 'mlflow.evaluations_review.see_assessment_details_response_button'
+                  : 'mlflow.evaluations_review.see_assessment_details_retrieval_button'
+            }
+            icon={showExpandedView ? <ChevronUpIcon /> : <ChevronRightIcon />}
+            onClick={() => setIsExpandedView((mode) => !mode)}
+          >
+            {showExpandedView ? (
+              <FormattedMessage
+                defaultMessage="Hide details"
+                description="Evaluation review > assessments > hide details button"
+              />
+            ) : (
+              <FormattedMessage
+                defaultMessage="See details"
+                description="Evaluation review > assessments > see details button"
+              />
+            )}
+          </Button>
+        </>
+      )}
+    </>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsReviewAssessmentsConfirmButton.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsReviewAssessmentsConfirmButton.tsx
@@ -1,0 +1,66 @@
+import { Button, ChevronRightIcon } from '@databricks/design-system';
+import { FormattedMessage } from '@databricks/i18n';
+
+export const EvaluationsReviewAssessmentsConfirmButton = ({
+  toBeReviewed,
+  containsOverallAssessment,
+  isNextResultAvailable,
+  overridingExistingReview,
+  hasPendingAssessments,
+  onClickNext,
+  onSave,
+  onCancelOverride,
+}: {
+  toBeReviewed: boolean;
+  containsOverallAssessment: boolean;
+  isNextResultAvailable: boolean;
+  hasPendingAssessments: boolean;
+  overridingExistingReview: boolean;
+  onSave?: () => Promise<void>;
+  onClickNext?: () => void;
+  onCancelOverride?: () => void;
+}) => {
+  if (toBeReviewed) {
+    if (hasPendingAssessments) {
+      return (
+        <Button type="primary" componentId="mlflow.evaluations_review.save_pending_assessments_button" onClick={onSave}>
+          <FormattedMessage defaultMessage="Save" description="Evaluation review > assessments > save button" />
+        </Button>
+      );
+    }
+    if (overridingExistingReview) {
+      return (
+        <Button componentId="mlflow.evaluations_review.cancel_override_assessments_button" onClick={onCancelOverride}>
+          <FormattedMessage
+            defaultMessage="Cancel"
+            description="Evaluation review > assessments > cancel overriding review button"
+          />
+        </Button>
+      );
+    }
+    return (
+      <Button
+        type="primary"
+        componentId="mlflow.evaluations_review.mark_as_reviewed_button"
+        onClick={onSave}
+        disabled={!containsOverallAssessment}
+      >
+        <FormattedMessage
+          defaultMessage="Mark as reviewed"
+          description="Evaluation review > assessments > mark as reviewed button"
+        />
+      </Button>
+    );
+  }
+  return (
+    <Button
+      type="primary"
+      componentId="mlflow.evaluations_review.next_evaluation_result_button"
+      onClick={onClickNext}
+      endIcon={<ChevronRightIcon />}
+      disabled={!isNextResultAvailable}
+    >
+      <FormattedMessage defaultMessage="Next" description="Evaluation review > assessments > next button" />
+    </Button>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsReviewAssessmentsSection.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsReviewAssessmentsSection.tsx
@@ -1,0 +1,317 @@
+import { first } from 'lodash';
+
+import {
+  Button,
+  CheckCircleIcon,
+  PencilIcon,
+  Spacer,
+  SparkleDoubleIcon,
+  Typography,
+  useDesignSystemTheme,
+  Tooltip,
+} from '@databricks/design-system';
+import { FormattedMessage, useIntl } from '@databricks/i18n';
+
+import { EvaluationsReviewAssessmentTag } from './EvaluationsReviewAssessmentTag';
+import { EvaluationsReviewAssessments } from './EvaluationsReviewAssessments';
+import { EvaluationsReviewAssessmentsConfirmButton } from './EvaluationsReviewAssessmentsConfirmButton';
+import {
+  KnownEvaluationResultAssessmentName,
+  getOrderedAssessments,
+  isEvaluationResultReviewedAlready,
+  KnownEvaluationResponseAssessmentNames,
+  isAssessmentMissing,
+} from './GenAiEvaluationTracesReview.utils';
+import { VerticalBar } from './VerticalBar';
+import type {
+  AssessmentInfo,
+  RunEvaluationResultAssessment,
+  RunEvaluationResultAssessmentDraft,
+  RunEvaluationTracesDataEntry,
+} from '../types';
+
+/**
+ * Displays section with a list of evaluation assessments: overall and detailed.
+ */
+const EvaluationsReviewSingleRunAssessmentsSection = ({
+  evaluationResult,
+  onUpsertAssessment,
+  onSavePendingAssessments,
+  onClickNext,
+  onResetPendingAssessments,
+  isNextAvailable,
+  overridingExistingReview = false,
+  pendingAssessments = [],
+  setOverridingExistingReview,
+  isReadOnly = false,
+  assessmentInfos,
+}: {
+  evaluationResult: RunEvaluationTracesDataEntry;
+  onUpsertAssessment: (assessment: RunEvaluationResultAssessmentDraft) => void;
+  onSavePendingAssessments: () => Promise<void>;
+  onClickNext?: () => void;
+  onResetPendingAssessments?: () => void;
+  isNextAvailable?: boolean;
+  overridingExistingReview?: boolean;
+  pendingAssessments?: RunEvaluationResultAssessmentDraft[];
+  setOverridingExistingReview: (override: boolean) => void;
+  isReadOnly?: boolean;
+  assessmentInfos: AssessmentInfo[];
+}) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+
+  if (!evaluationResult) {
+    return null;
+  }
+  const currentOverallAssessment = first(evaluationResult.overallAssessments);
+  const rootCauseAssessmentName = currentOverallAssessment?.rootCauseAssessment?.assessmentName;
+  const rootCauseAssessment = rootCauseAssessmentName
+    ? first(evaluationResult?.responseAssessmentsByName[rootCauseAssessmentName])
+    : undefined;
+
+  const toBeReviewed =
+    !isReadOnly && (!isEvaluationResultReviewedAlready(evaluationResult) || overridingExistingReview);
+
+  const reopenReviewTooltip = intl.formatMessage({
+    defaultMessage: 'Reopen review',
+    description: 'Evaluation review > assessments > reopen review tooltip',
+  });
+
+  const overallAssessmentsByName: [string, RunEvaluationResultAssessment[]][] = [
+    [KnownEvaluationResultAssessmentName.OVERALL_ASSESSMENT, evaluationResult.overallAssessments],
+  ];
+
+  const overallAssessmentInfo = assessmentInfos.find(
+    (info) => info.name === KnownEvaluationResultAssessmentName.OVERALL_ASSESSMENT,
+  );
+
+  return (
+    <div css={{ flex: 1 }}>
+      <div css={{ paddingLeft: theme.spacing.md, paddingRight: theme.spacing.md }}>
+        <div
+          css={{
+            backgroundColor: theme.colors.backgroundSecondary,
+            padding: theme.spacing.md,
+            paddingBottom: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: theme.spacing.sm,
+          }}
+        >
+          {overallAssessmentInfo && (
+            <div css={{ display: 'flex', gap: theme.spacing.sm, alignItems: 'center' }}>
+              <SparkleDoubleIcon color="ai" />
+              <Typography.Text bold>
+                <FormattedMessage
+                  defaultMessage="Overall assessment:"
+                  description="Evaluation review > assessments > overall assessment > title"
+                />
+              </Typography.Text>
+              {/* TODO: make overall assessment editable */}
+              <EvaluationsReviewAssessmentTag
+                assessment={currentOverallAssessment}
+                aria-label={KnownEvaluationResultAssessmentName.OVERALL_ASSESSMENT}
+                disableJudgeTypeIcon={isAssessmentMissing(currentOverallAssessment)}
+                assessmentInfo={overallAssessmentInfo}
+                type="assessment-value"
+              />
+            </div>
+          )}
+          <EvaluationsReviewAssessments
+            assessmentsType="overall"
+            assessmentsByName={overallAssessmentsByName}
+            rootCauseAssessment={rootCauseAssessment}
+            onUpsertAssessment={onUpsertAssessment}
+            allowEditing={toBeReviewed}
+            alwaysExpanded
+            options={[KnownEvaluationResultAssessmentName.OVERALL_ASSESSMENT]}
+            assessmentInfos={assessmentInfos}
+          />
+          <div
+            css={{
+              border: `1px solid ${theme.colors.border}`,
+              borderRadius: theme.general.borderRadiusBase,
+              padding: theme.spacing.sm,
+            }}
+          >
+            <Typography.Text bold>
+              <FormattedMessage
+                defaultMessage="Detailed assessments"
+                description="Evaluation review > assessments > detailed assessments > title"
+              />
+            </Typography.Text>
+            <Spacer size="sm" />
+            <EvaluationsReviewAssessments
+              assessmentsType="response"
+              assessmentsByName={getOrderedAssessments(evaluationResult.responseAssessmentsByName)}
+              onUpsertAssessment={onUpsertAssessment}
+              allowEditing={toBeReviewed}
+              allowMoreThanOne
+              options={KnownEvaluationResponseAssessmentNames}
+              assessmentInfos={assessmentInfos}
+            />
+          </div>
+        </div>
+        <div
+          css={{
+            position: 'sticky',
+            backgroundColor: theme.colors.backgroundSecondary,
+            padding: theme.spacing.md,
+            top: 0,
+            display: 'flex',
+            justifyContent: 'space-between',
+            gap: theme.spacing.sm,
+            zIndex: theme.options.zIndexBase,
+          }}
+        >
+          <div>
+            {!toBeReviewed && !isReadOnly && (
+              <div
+                css={{
+                  border: `1px solid ${theme.colors.border}`,
+                  borderRadius: theme.general.borderRadiusBase,
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: theme.spacing.sm,
+                  padding: `${theme.spacing.xs}px ${theme.spacing.sm}px`,
+                }}
+              >
+                <CheckCircleIcon css={{ color: theme.colors.textValidationSuccess }} />
+                <Typography.Hint>
+                  <FormattedMessage
+                    defaultMessage="Reviewed"
+                    description="Evaluation review > assessments > already reviewed indicator"
+                  />
+                </Typography.Hint>
+                <Tooltip
+                  componentId="codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewassessmentssection.tsx_149"
+                  content={reopenReviewTooltip}
+                >
+                  <Button
+                    aria-label={reopenReviewTooltip}
+                    componentId="mlflow.evaluations_review.reopen_review_button"
+                    size="small"
+                    icon={<PencilIcon />}
+                    onClick={() => setOverridingExistingReview(true)}
+                  />
+                </Tooltip>
+              </div>
+            )}
+          </div>
+          <div css={{ flex: 1 }} />
+          {pendingAssessments.length > 0 && (
+            <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm }}>
+              <FormattedMessage
+                defaultMessage="{pendingCount} pending {pendingCount, plural, =1 {change} other {changes}}"
+                description="Evaluation review > assessments > pending entries counter"
+                values={{ pendingCount: pendingAssessments.length }}
+              />
+              <Button
+                componentId="mlflow.evaluations_review.discard_pending_assessments_button"
+                onClick={onResetPendingAssessments}
+              >
+                <FormattedMessage
+                  defaultMessage="Discard"
+                  description="Evaluation review > assessments > discard pending assessments button label"
+                />
+              </Button>
+            </div>
+          )}
+          <EvaluationsReviewAssessmentsConfirmButton
+            onSave={async () => {
+              // Save the pending assessments
+              await onSavePendingAssessments();
+              // We can reset the override review flag now
+              setOverridingExistingReview(false);
+            }}
+            containsOverallAssessment={Boolean(currentOverallAssessment)}
+            isNextResultAvailable={Boolean(isNextAvailable)}
+            onClickNext={onClickNext}
+            toBeReviewed={toBeReviewed}
+            hasPendingAssessments={pendingAssessments.length > 0}
+            overridingExistingReview={overridingExistingReview}
+            onCancelOverride={() => setOverridingExistingReview(false)}
+          />
+        </div>
+      </div>
+      <Spacer size="md" />
+    </div>
+  );
+};
+
+/**
+ * Displays section with a list of evaluation assessments: overall and detailed.
+ */
+export const EvaluationsReviewAssessmentsSection = ({
+  evaluationResult,
+  otherEvaluationResult,
+  onUpsertAssessment,
+  onSavePendingAssessments,
+  onClickNext,
+  onResetPendingAssessments,
+  isNextAvailable,
+  overridingExistingReview = false,
+  pendingAssessments = [],
+  setOverridingExistingReview,
+  isReadOnly = false,
+  assessmentInfos,
+}: {
+  evaluationResult?: RunEvaluationTracesDataEntry;
+  otherEvaluationResult?: RunEvaluationTracesDataEntry;
+  onUpsertAssessment: (assessment: RunEvaluationResultAssessmentDraft) => void;
+  onSavePendingAssessments: () => Promise<void>;
+  onClickNext?: () => void;
+  onResetPendingAssessments?: () => void;
+  isNextAvailable?: boolean;
+  overridingExistingReview?: boolean;
+  pendingAssessments?: RunEvaluationResultAssessmentDraft[];
+  setOverridingExistingReview: (override: boolean) => void;
+  isReadOnly?: boolean;
+  assessmentInfos: AssessmentInfo[];
+}) => {
+  const { theme } = useDesignSystemTheme();
+  return (
+    <div
+      css={{
+        display: 'flex',
+        width: '100%',
+        gap: theme.spacing.sm,
+      }}
+    >
+      {evaluationResult && (
+        <EvaluationsReviewSingleRunAssessmentsSection
+          evaluationResult={evaluationResult}
+          onUpsertAssessment={onUpsertAssessment}
+          onSavePendingAssessments={onSavePendingAssessments}
+          onClickNext={onClickNext}
+          onResetPendingAssessments={onResetPendingAssessments}
+          isNextAvailable={isNextAvailable}
+          overridingExistingReview={overridingExistingReview}
+          setOverridingExistingReview={setOverridingExistingReview}
+          pendingAssessments={pendingAssessments}
+          isReadOnly={isReadOnly}
+          assessmentInfos={assessmentInfos}
+        />
+      )}
+      {otherEvaluationResult && (
+        <>
+          <VerticalBar />
+          <EvaluationsReviewSingleRunAssessmentsSection
+            evaluationResult={otherEvaluationResult}
+            onUpsertAssessment={onUpsertAssessment}
+            onSavePendingAssessments={onSavePendingAssessments}
+            onClickNext={onClickNext}
+            onResetPendingAssessments={onResetPendingAssessments}
+            isNextAvailable={isNextAvailable}
+            overridingExistingReview={overridingExistingReview}
+            setOverridingExistingReview={setOverridingExistingReview}
+            pendingAssessments={pendingAssessments}
+            isReadOnly
+            assessmentInfos={assessmentInfos}
+          />
+        </>
+      )}
+    </div>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsReviewDetails.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsReviewDetails.tsx
@@ -1,0 +1,163 @@
+import { useState } from 'react';
+
+import { Alert, Button, Spacer, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { FormattedMessage, useIntl } from '@databricks/i18n';
+import type { ModelTrace } from '../../model-trace-explorer/ModelTrace.types';
+import type { UseQueryResult } from '../../query-client/queryClient';
+
+import { EvaluationsReviewAssessmentsSection } from './EvaluationsReviewAssessmentsSection';
+import { EvaluationsReviewHeaderSection } from './EvaluationsReviewHeaderSection';
+import { EvaluationsReviewInputSection } from './EvaluationsReviewInputSection';
+import { EvaluationsReviewResponseSection } from './EvaluationsReviewResponseSection';
+import { EvaluationsReviewRetrievalSection } from './EvaluationsReviewRetrievalSection';
+import { getEvaluationResultTitle } from './GenAiEvaluationTracesReview.utils';
+import { usePendingAssessmentEntries } from '../hooks/usePendingAssessmentEntries';
+import type { AssessmentInfo, RunEvaluationResultAssessmentDraft, RunEvaluationTracesDataEntry } from '../types';
+
+export const EvaluationsReviewDetailsHeader = ({
+  evaluationResult,
+}: {
+  evaluationResult: RunEvaluationTracesDataEntry;
+}) => {
+  const { theme } = useDesignSystemTheme();
+  return (
+    <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm, overflow: 'hidden' }}>
+      <Typography.Title
+        level={2}
+        withoutMargins
+        css={{ flex: 1, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}
+      >
+        {getEvaluationResultTitle(evaluationResult)}
+      </Typography.Title>
+    </div>
+  );
+};
+
+export const EvaluationsReviewDetails = ({
+  experimentId,
+  evaluationResult,
+  otherEvaluationResult,
+  onSavePendingAssessments,
+  onClickNext,
+  runDisplayName,
+  compareToRunDisplayName,
+  isNextAvailable = false,
+  isReadOnly = false,
+  exportToEvalsInstanceEnabled = false,
+  assessmentInfos,
+  traceQueryResult,
+  compareToTraceQueryResult,
+}: {
+  experimentId: string;
+  evaluationResult: RunEvaluationTracesDataEntry;
+  otherEvaluationResult?: RunEvaluationTracesDataEntry;
+  onSavePendingAssessments?: (
+    evaluationResult: RunEvaluationTracesDataEntry,
+    pendingAssessments: RunEvaluationResultAssessmentDraft[],
+  ) => Promise<void>;
+  onClickNext?: () => void;
+  runDisplayName?: string;
+  compareToRunDisplayName?: string;
+  isNextAvailable?: boolean;
+  isReadOnly?: boolean;
+  exportToEvalsInstanceEnabled?: boolean;
+  assessmentInfos: AssessmentInfo[];
+  traceQueryResult: UseQueryResult<ModelTrace | undefined, unknown>;
+  compareToTraceQueryResult: UseQueryResult<ModelTrace | undefined, unknown>;
+}) => {
+  const intl = useIntl();
+
+  const { pendingAssessments, draftEvaluationResult, upsertAssessment, resetPendingAssessments } =
+    usePendingAssessmentEntries(evaluationResult);
+
+  const hasPendingAssessments = pendingAssessments.length > 0;
+
+  // If user has already reviewed the evaluation, this flag allows to override the review and enable editing
+  const [overridingExistingReview, setOverridingExistingReview] = useState(false);
+
+  const hasErrorCode = Boolean(evaluationResult.errorCode);
+  const hasErrorMessage = Boolean(evaluationResult.errorMessage);
+  const showAlert = hasErrorCode || hasErrorMessage;
+  const [alertExpanded, setAlertExpanded] = useState(false);
+  const toggleAlertExpanded = () => setAlertExpanded((alertExpanded) => !alertExpanded);
+
+  return (
+    <>
+      {showAlert ? (
+        <>
+          <Alert
+            action={
+              hasErrorMessage && (
+                <Button
+                  componentId={`mlflow.evaluations_review.evaluation_error_alert.show_${
+                    alertExpanded ? 'less' : 'more'
+                  }_button`}
+                  onClick={toggleAlertExpanded}
+                >
+                  {alertExpanded ? (
+                    <FormattedMessage defaultMessage="Show less" description="Button to close alert description" />
+                  ) : (
+                    <FormattedMessage defaultMessage="Show more" description="Button to expand alert description" />
+                  )}
+                </Button>
+              )
+            }
+            closable={false}
+            componentId="mlflow.evaluations_review.evaluation_error_alert"
+            message={hasErrorCode ? `${evaluationResult.errorCode}` : 'UNKNOWN_ERROR'}
+            description={alertExpanded && `${evaluationResult.errorMessage}`}
+            type="error"
+          />
+          <Spacer size="md" />
+        </>
+      ) : null}
+      <EvaluationsReviewHeaderSection
+        experimentId={experimentId}
+        runDisplayName={runDisplayName}
+        otherRunDisplayName={compareToRunDisplayName}
+        evaluationResult={evaluationResult}
+        otherEvaluationResult={otherEvaluationResult}
+        exportToEvalsInstanceEnabled={exportToEvalsInstanceEnabled}
+        traceQueryResult={traceQueryResult}
+        compareToTraceQueryResult={compareToTraceQueryResult}
+      />
+      <EvaluationsReviewAssessmentsSection
+        evaluationResult={draftEvaluationResult}
+        otherEvaluationResult={otherEvaluationResult}
+        onUpsertAssessment={upsertAssessment}
+        onClickNext={onClickNext}
+        onSavePendingAssessments={async () => {
+          // Save and reset the pending assessments
+          await onSavePendingAssessments?.(evaluationResult, pendingAssessments);
+          resetPendingAssessments();
+        }}
+        isNextAvailable={isNextAvailable}
+        overridingExistingReview={overridingExistingReview}
+        setOverridingExistingReview={setOverridingExistingReview}
+        pendingAssessments={pendingAssessments}
+        onResetPendingAssessments={resetPendingAssessments}
+        isReadOnly={isReadOnly}
+        assessmentInfos={assessmentInfos}
+      />
+      <EvaluationsReviewInputSection
+        evaluationResult={evaluationResult}
+        otherEvaluationResult={otherEvaluationResult}
+      />
+      <EvaluationsReviewResponseSection
+        evaluationResult={evaluationResult}
+        otherEvaluationResult={otherEvaluationResult}
+      />
+      <EvaluationsReviewRetrievalSection
+        evaluationResult={draftEvaluationResult}
+        otherEvaluationResult={otherEvaluationResult}
+        onUpsertAssessment={upsertAssessment}
+        overridingExistingReview={overridingExistingReview}
+        isReadOnly={isReadOnly}
+        assessmentInfos={assessmentInfos}
+        traceQueryResult={traceQueryResult}
+        compareToTraceQueryResult={compareToTraceQueryResult}
+      />
+      <Spacer size="lg" />
+    </>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsReviewExpandableCell.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsReviewExpandableCell.tsx
@@ -1,0 +1,35 @@
+import { useMemo } from 'react';
+
+export const EvaluationsReviewExpandedJSONValueCell = ({ value }: { value: string | Record<string, unknown> }) => {
+  const structuredJSONValue = useMemo(() => {
+    // If value is already an object, stringify it directly
+    if (typeof value === 'object' && value !== null) {
+      return JSON.stringify(value, null, 2);
+    }
+
+    // If value is a string, try to parse it as JSON
+    if (typeof value === 'string') {
+      try {
+        const objectData = JSON.parse(value);
+        return JSON.stringify(objectData, null, 2);
+      } catch (e) {
+        return null;
+      }
+    }
+
+    // For any other type, return null
+    return null;
+  }, [value]);
+
+  return (
+    <div
+      css={{
+        whiteSpace: 'pre-wrap',
+        wordBreak: 'break-word',
+        fontFamily: structuredJSONValue ? 'monospace' : undefined,
+      }}
+    >
+      {structuredJSONValue || String(value)}
+    </div>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsReviewHeaderSection.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsReviewHeaderSection.tsx
@@ -1,0 +1,173 @@
+import { isNil } from 'lodash';
+import { useState } from 'react';
+
+import { Button, Spacer, Tooltip, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { FormattedMessage, useIntl } from '@databricks/i18n';
+import type { ModelTrace } from '../../model-trace-explorer/ModelTrace.types';
+import type { UseQueryResult } from '../../query-client/queryClient';
+
+import { EvaluationTraceDataDrawer } from './EvaluationTraceDataDrawer';
+import { VerticalBar } from './VerticalBar';
+import { GenAITracesTableActions } from '../GenAITracesTableActions';
+import type { GetTraceFunction } from '../hooks/useGetTrace';
+import type { RunEvaluationTracesDataEntry } from '../types';
+import { prettySizeWithUnit } from '../utils/DisplayUtils';
+
+// Keep in sync with https://src.dev.databricks.com/databricks-eng/universe@679eb50f2399a24f4c7f919ccb55028bd8662316/-/blob/tracing-server/src/dao/TraceEntitySpace.scala?L45
+const DROPPED_SPAN_SIZE_TRACE_METADATA_KEY = 'databricks.tracingserver.dropped_spans_size_bytes';
+
+const EvaluationsReviewSingleRunHeaderSection = ({
+  experimentId,
+  runDisplayName,
+  evaluationResult,
+  exportToEvalsInstanceEnabled = false,
+  traceQueryResult,
+  getTrace,
+}: {
+  experimentId: string;
+  runDisplayName?: string;
+  evaluationResult: RunEvaluationTracesDataEntry;
+  exportToEvalsInstanceEnabled?: boolean;
+  traceQueryResult: UseQueryResult<ModelTrace | undefined, unknown>;
+  getTrace?: GetTraceFunction;
+}) => {
+  const intl = useIntl();
+  const { theme } = useDesignSystemTheme();
+
+  const [selectedTraceDetailsRequestId, setSelectedTraceDetailsRequestId] = useState<string | null>(null);
+
+  const droppedSpanSize = evaluationResult.traceInfo?.trace_metadata?.[DROPPED_SPAN_SIZE_TRACE_METADATA_KEY];
+  let prettySizeString: string | undefined;
+  if (!isNil(droppedSpanSize)) {
+    const fractionDigits = 2;
+    const prettySize = prettySizeWithUnit(Number(droppedSpanSize), fractionDigits);
+    prettySizeString = `${prettySize.value} ${prettySize.unit}`;
+  }
+
+  return (
+    <div css={{ flex: 1 }}>
+      <div
+        css={{
+          paddingLeft: theme.spacing.md,
+          paddingRight: theme.spacing.md,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: theme.spacing.sm,
+        }}
+      >
+        <Typography.Title level={4}>{runDisplayName}</Typography.Title>
+        {evaluationResult.requestId && (
+          <div
+            css={{
+              display: 'flex',
+              gap: theme.spacing.sm,
+            }}
+          >
+            {exportToEvalsInstanceEnabled && getTrace && (
+              <GenAITracesTableActions
+                experimentId={experimentId}
+                selectedTraces={[evaluationResult]}
+                traceInfos={undefined}
+              />
+            )}
+            <Tooltip
+              delayDuration={0}
+              componentId="mlflow.evaluations_review.see_detailed_trace_view_tooltip"
+              content={
+                droppedSpanSize
+                  ? `The trace spans were not stored due to their large size: ${prettySizeString}`
+                  : undefined
+              }
+              side="left"
+            >
+              <Button
+                componentId="mlflow.evaluations_review.see_detailed_trace_view_button"
+                onClick={() => setSelectedTraceDetailsRequestId(evaluationResult.requestId)}
+                loading={traceQueryResult.isLoading}
+                disabled={!isNil(droppedSpanSize)}
+              >
+                <FormattedMessage
+                  defaultMessage="See detailed trace view"
+                  description="Evaluation review > see detailed trace view button"
+                />
+              </Button>
+            </Tooltip>
+          </div>
+        )}
+        {selectedTraceDetailsRequestId &&
+          (!isNil(traceQueryResult.data) ? (
+            <EvaluationTraceDataDrawer
+              onClose={() => {
+                setSelectedTraceDetailsRequestId(null);
+              }}
+              requestId={selectedTraceDetailsRequestId}
+              trace={traceQueryResult.data}
+            />
+          ) : (
+            <>
+              {intl.formatMessage({
+                defaultMessage: 'No trace data available',
+                description: 'Evaluation review > no trace data available',
+              })}
+            </>
+          ))}
+      </div>
+      <Spacer size="md" />
+    </div>
+  );
+};
+
+/**
+ * Displays inputs for a given evaluation result, across one or two runs.
+ */
+export const EvaluationsReviewHeaderSection = ({
+  experimentId,
+  runDisplayName,
+  otherRunDisplayName,
+  evaluationResult,
+  otherEvaluationResult,
+  exportToEvalsInstanceEnabled = false,
+  traceQueryResult,
+  compareToTraceQueryResult,
+}: {
+  experimentId: string;
+  evaluationResult: RunEvaluationTracesDataEntry;
+  runDisplayName?: string;
+  otherRunDisplayName?: string;
+  otherEvaluationResult?: RunEvaluationTracesDataEntry;
+  exportToEvalsInstanceEnabled?: boolean;
+  traceQueryResult: UseQueryResult<ModelTrace | undefined, unknown>;
+  compareToTraceQueryResult: UseQueryResult<ModelTrace | undefined, unknown>;
+}) => {
+  const { theme } = useDesignSystemTheme();
+  return (
+    <div
+      css={{
+        display: 'flex',
+        width: '100%',
+        gap: theme.spacing.sm,
+      }}
+    >
+      <EvaluationsReviewSingleRunHeaderSection
+        experimentId={experimentId}
+        runDisplayName={runDisplayName}
+        evaluationResult={evaluationResult}
+        exportToEvalsInstanceEnabled={exportToEvalsInstanceEnabled}
+        traceQueryResult={traceQueryResult}
+      />
+      {otherRunDisplayName && otherEvaluationResult && (
+        <>
+          <VerticalBar />
+          <EvaluationsReviewSingleRunHeaderSection
+            experimentId={experimentId}
+            runDisplayName={otherRunDisplayName}
+            evaluationResult={otherEvaluationResult}
+            exportToEvalsInstanceEnabled={exportToEvalsInstanceEnabled}
+            traceQueryResult={compareToTraceQueryResult}
+          />
+        </>
+      )}
+    </div>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsReviewInputSection.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsReviewInputSection.tsx
@@ -1,0 +1,70 @@
+import { Spacer, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { FormattedMessage } from '@databricks/i18n';
+
+import { EvaluationsReviewTextBox } from './EvaluationsReviewTextBox';
+import type { RunEvaluationTracesDataEntry } from '../types';
+
+/**
+ * Displays inputs for a given evaluation result of a single run.
+ */
+const EvaluationsReviewSingleRunInputSection = ({
+  evaluationResult,
+}: {
+  evaluationResult: RunEvaluationTracesDataEntry;
+}) => {
+  const { theme } = useDesignSystemTheme();
+  const { inputs } = evaluationResult;
+  const inputsEntries = Object.entries(inputs);
+  const noValues = inputsEntries.length === 0;
+  return (
+    <div css={{ width: '100%', paddingLeft: theme.spacing.md, paddingRight: theme.spacing.md }}>
+      <Typography.Text bold>
+        <FormattedMessage
+          defaultMessage="{count, plural, one {Input} other {Inputs}}"
+          description="Evaluation review > input section > title"
+          values={{ count: inputsEntries.length }}
+        />
+      </Typography.Text>
+      <Spacer size="sm" />
+      {noValues && (
+        <Typography.Paragraph>
+          <FormattedMessage
+            defaultMessage="No inputs logged"
+            description="Evaluation review > input section > no values"
+          />
+        </Typography.Paragraph>
+      )}
+      {inputsEntries.map(([key, input]) => (
+        <EvaluationsReviewTextBox fieldName={key} title={key} value={input} key={key} />
+      ))}
+    </div>
+  );
+};
+
+/**
+ * Displays inputs for a given evaluation result, across one or two runs.
+ */
+export const EvaluationsReviewInputSection = ({
+  evaluationResult,
+  otherEvaluationResult,
+}: {
+  evaluationResult?: RunEvaluationTracesDataEntry;
+  otherEvaluationResult?: RunEvaluationTracesDataEntry;
+}) => {
+  const { theme } = useDesignSystemTheme();
+  const inputsAreTheSame = evaluationResult?.inputsId === otherEvaluationResult?.inputsId;
+  return (
+    <div
+      css={{
+        display: 'flex',
+        width: '100%',
+        gap: theme.spacing.sm,
+      }}
+    >
+      {evaluationResult && <EvaluationsReviewSingleRunInputSection evaluationResult={evaluationResult} />}
+      {!inputsAreTheSame && otherEvaluationResult && (
+        <EvaluationsReviewSingleRunInputSection evaluationResult={otherEvaluationResult} />
+      )}
+    </div>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsReviewListItemIndicator.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsReviewListItemIndicator.tsx
@@ -1,0 +1,44 @@
+import { QuestionMarkIcon, SparkleDoubleIcon, UserIcon, useDesignSystemTheme } from '@databricks/design-system';
+
+import { hasBeenEditedByHuman } from './GenAiEvaluationTracesReview.utils';
+import type { AssessmentInfo, RunEvaluationResultAssessment } from '../types';
+import { getEvaluationResultAssessmentBackgroundColor } from '../utils/Colors';
+
+/**
+ * A small indicator that shows the evaluation result's icon and sentiment.
+ */
+export const EvaluationsReviewListItemIndicator = ({
+  assessment,
+  chunkRelevanceAssessmentInfo,
+}: {
+  assessment?: RunEvaluationResultAssessment;
+  chunkRelevanceAssessmentInfo?: AssessmentInfo;
+}) => {
+  const { theme } = useDesignSystemTheme();
+
+  if (!assessment && !chunkRelevanceAssessmentInfo) {
+    return <></>;
+  }
+
+  return (
+    <div
+      css={{
+        paddingLeft: theme.spacing.sm,
+        paddingRight: theme.spacing.sm,
+        paddingTop: 1,
+        paddingBottom: 1,
+        backgroundColor: chunkRelevanceAssessmentInfo
+          ? getEvaluationResultAssessmentBackgroundColor(theme, chunkRelevanceAssessmentInfo, assessment)
+          : '',
+        borderRadius: theme.general.borderRadiusBase,
+        svg: { width: 12, height: 12 },
+      }}
+    >
+      {assessment ? (
+        <>{hasBeenEditedByHuman(assessment) ? <UserIcon /> : <SparkleDoubleIcon />}</>
+      ) : (
+        <QuestionMarkIcon />
+      )}
+    </div>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsReviewResponseSection.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsReviewResponseSection.tsx
@@ -1,0 +1,95 @@
+import { Spacer, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { FormattedMessage } from '@databricks/i18n';
+
+import { EvaluationsReviewTextBox } from './EvaluationsReviewTextBox';
+import {
+  isRetrievedContext,
+  KnownEvaluationResultAssessmentOutputLabel,
+  KnownEvaluationResultAssessmentTargetLabel,
+} from './GenAiEvaluationTracesReview.utils';
+import { VerticalBar } from './VerticalBar';
+import type { RunEvaluationTracesDataEntry } from '../types';
+
+const EvaluationsReviewSingleRunResponseSection = ({
+  evaluationResult,
+}: {
+  evaluationResult: RunEvaluationTracesDataEntry;
+}) => {
+  const { theme } = useDesignSystemTheme();
+
+  const { outputs, targets } = evaluationResult;
+
+  // Filter out retrieve_context values
+  const outputEntries = Object.entries(outputs).filter(([, value]) => !isRetrievedContext(value));
+  const targetEntries = Object.entries(targets).filter(([, value]) => !isRetrievedContext(value));
+
+  const noValues = outputEntries.length === 0 && targetEntries.length === 0;
+
+  return (
+    <div css={{ paddingLeft: theme.spacing.md, paddingRight: theme.spacing.md, width: '100%' }}>
+      <Typography.Text bold>
+        <FormattedMessage defaultMessage="Response" description="Evaluation review > Response section > title" />
+      </Typography.Text>
+      <Spacer size="sm" />
+      {noValues && (
+        <Typography.Paragraph>
+          <FormattedMessage
+            defaultMessage="No responses or targets logged"
+            description="Evaluation review > Response section > no values"
+          />
+        </Typography.Paragraph>
+      )}
+      <div css={{ display: 'flex', gap: theme.spacing.md, alignItems: 'flex-start' }}>
+        {outputEntries.length > 0 && (
+          <div css={{ flex: 1 }}>
+            {outputEntries.map(([key, output]) => {
+              const mappedTitle = KnownEvaluationResultAssessmentOutputLabel[key];
+              const title = mappedTitle ? <FormattedMessage {...mappedTitle} /> : key;
+              return <EvaluationsReviewTextBox key={key} fieldName={key} title={title} value={output} showCopyIcon />;
+            })}
+          </div>
+        )}
+
+        {targetEntries.length > 0 && (
+          <div css={{ flex: 1 }}>
+            {targetEntries.map(([key, output]) => {
+              const mappedTitle = KnownEvaluationResultAssessmentTargetLabel[key];
+              const title = mappedTitle ? <FormattedMessage {...mappedTitle} /> : key;
+              return <EvaluationsReviewTextBox key={key} fieldName={key} title={title} value={output} showCopyIcon />;
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Displays responses and targets for a given evaluation result.
+ */
+export const EvaluationsReviewResponseSection = ({
+  evaluationResult,
+  otherEvaluationResult,
+}: {
+  evaluationResult?: RunEvaluationTracesDataEntry;
+  otherEvaluationResult?: RunEvaluationTracesDataEntry;
+}) => {
+  const { theme } = useDesignSystemTheme();
+  return (
+    <div
+      css={{
+        display: 'flex',
+        width: '100%',
+        gap: theme.spacing.sm,
+      }}
+    >
+      {evaluationResult && <EvaluationsReviewSingleRunResponseSection evaluationResult={evaluationResult} />}
+      {otherEvaluationResult && (
+        <>
+          <VerticalBar />
+          <EvaluationsReviewSingleRunResponseSection evaluationResult={otherEvaluationResult} />
+        </>
+      )}
+    </div>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsReviewRetrievalSection.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsReviewRetrievalSection.tsx
@@ -1,0 +1,314 @@
+import { first, isNil } from 'lodash';
+import { useMemo, useState } from 'react';
+
+import { Spacer, Tag, TableSkeleton, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { useIntl, FormattedMessage } from '@databricks/i18n';
+import type { ModelTrace } from '../../model-trace-explorer/ModelTrace.types';
+import type { UseQueryResult } from '../../query-client/queryClient';
+
+import { EvaluationsReviewAssessments } from './EvaluationsReviewAssessments';
+import { EvaluationsReviewListItemIndicator } from './EvaluationsReviewListItemIndicator';
+import {
+  isEvaluationResultReviewedAlready,
+  KnownEvaluationResultAssessmentMetadataFields,
+  getOrderedAssessments,
+  KnownEvaluationRetrievalAssessmentNames,
+  KnownEvaluationResultAssessmentName,
+} from './GenAiEvaluationTracesReview.utils';
+import { VerticalBar } from './VerticalBar';
+import type {
+  AssessmentInfo,
+  RunEvaluationResultAssessmentDraft,
+  RunEvaluationTracesDataEntry,
+  RunEvaluationTracesRetrievalChunk,
+} from '../types';
+import { useMarkdownConverter } from '../utils/MarkdownUtils';
+import { getRetrievedContextFromTrace } from '../utils/TraceUtils';
+
+function isValidHttpUrl(str: any) {
+  // The URL() constructor will throw on invalid URL
+  try {
+    const url = new URL(str);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch (err) {
+    return false;
+  }
+}
+
+const RetrievedChunkHeader = ({ chunk, index }: { chunk: RunEvaluationTracesRetrievalChunk; index: number }) => {
+  return (
+    <div
+      css={{
+        display: 'flex',
+        alignItems: 'center',
+      }}
+    >
+      <Tag componentId="codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewretrievalsection.tsx_30">
+        #{index + 1}
+      </Tag>
+      {isValidHttpUrl(chunk.docUrl) ? (
+        <Typography.Link
+          componentId="codegen_mlflow_app_src_experiment-tracking_components_evaluations_components_evaluationsreviewretrievalsection.tsx_32"
+          href={chunk.docUrl}
+          ellipsis
+          openInNewTab
+          strong
+        >
+          {chunk.docUrl}
+        </Typography.Link>
+      ) : (
+        <Typography.Title level={4} withoutMargins ellipsis>
+          {chunk.docUrl}
+        </Typography.Title>
+      )}
+    </div>
+  );
+};
+
+const EvaluationsReviewSingleRunRetrievalSection = ({
+  evaluationResult,
+  onUpsertAssessment,
+  overridingExistingReview = false,
+  isReadOnly = false,
+  assessmentInfos,
+  traceQueryResult,
+}: {
+  evaluationResult: RunEvaluationTracesDataEntry;
+  onUpsertAssessment: (assessment: RunEvaluationResultAssessmentDraft) => void;
+  overridingExistingReview?: boolean;
+  isReadOnly?: boolean;
+  assessmentInfos: AssessmentInfo[];
+  traceQueryResult: UseQueryResult<ModelTrace | undefined, unknown>;
+}) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+
+  const [selectedIndex, setSelectedIndex] = useState<number>(0);
+
+  const { makeHTML } = useMarkdownConverter();
+
+  const evaluationRetrievalChunks = useMemo(() => {
+    return !isNil(evaluationResult.retrievalChunks) && evaluationResult.retrievalChunks.length > 0
+      ? evaluationResult.retrievalChunks
+      : getRetrievedContextFromTrace(evaluationResult.responseAssessmentsByName, traceQueryResult.data);
+  }, [evaluationResult.responseAssessmentsByName, evaluationResult.retrievalChunks, traceQueryResult.data]);
+
+  const selectedEntryHtmlContent = useMemo(
+    () => makeHTML(evaluationRetrievalChunks?.[selectedIndex]?.content),
+    [evaluationRetrievalChunks, selectedIndex, makeHTML],
+  );
+
+  const noRetrievalFound = (evaluationRetrievalChunks || []).length === 0;
+
+  const toBeReviewed =
+    !isReadOnly && (!isEvaluationResultReviewedAlready(evaluationResult) || overridingExistingReview);
+
+  const selectedChunk = evaluationRetrievalChunks?.[selectedIndex];
+
+  const sectionTitle = intl.formatMessage({
+    defaultMessage: 'Retrieval',
+    description: 'Evaluation review > Retrieval section > title',
+  });
+
+  return (
+    <div
+      css={{
+        paddingLeft: theme.spacing.md,
+        paddingRight: theme.spacing.md,
+        width: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+      role="region"
+      aria-label={sectionTitle}
+    >
+      <Typography.Text bold>{sectionTitle}</Typography.Text>
+
+      {isNil(evaluationRetrievalChunks) && traceQueryResult.isFetching ? (
+        <TableSkeleton lines={3} />
+      ) : noRetrievalFound ? (
+        <Typography.Text>
+          <i>
+            <FormattedMessage
+              defaultMessage="No span with type RETRIEVER found in trace."
+              description="GenAi Traces Table > Modal > Message displayed when no retrievals are found"
+            />
+          </i>
+        </Typography.Text>
+      ) : (
+        <div
+          css={{
+            minHeight: 400,
+            maxHeight: 600,
+            overflow: 'hidden',
+            display: 'flex',
+            marginTop: theme.spacing.sm,
+            border: `1px solid ${theme.colors.border}`,
+            borderRadius: theme.general.borderRadiusBase,
+          }}
+        >
+          <div
+            css={{
+              flex: 1,
+              flexShrink: 1,
+              maxWidth: 300,
+              minWidth: 200,
+              overflow: 'auto',
+              padding: theme.spacing.sm,
+              borderRight: `1px solid ${theme.colors.border}`,
+            }}
+            role="listbox"
+          >
+            {noRetrievalFound && (
+              <Typography.Paragraph>
+                <FormattedMessage
+                  defaultMessage="No retrieval logged"
+                  description="Evaluation review > retrieval section > no values"
+                />
+              </Typography.Paragraph>
+            )}
+            {(evaluationRetrievalChunks || []).map((chunk, index) => {
+              const chunkRelevanceAssessmentInfo = assessmentInfos.find(
+                (info) => info.name === KnownEvaluationResultAssessmentName.CHUNK_RELEVANCE,
+              );
+
+              return (
+                <div
+                  role="option"
+                  aria-label={chunk.content?.slice(0, 255)}
+                  aria-selected={index === selectedIndex}
+                  key={[chunk.docUrl, index].join('-')}
+                  css={{
+                    backgroundColor: index === selectedIndex ? theme.colors.actionIconBackgroundHover : 'transparent',
+                    '&:hover': {
+                      backgroundColor: theme.colors.actionIconBackgroundHover,
+                    },
+                    padding: `${theme.spacing.sm}px ${theme.spacing.md}px`,
+                    overflow: 'hidden',
+                    display: 'flex',
+                    gap: theme.spacing.sm,
+                    alignItems: 'center',
+                    cursor: 'pointer',
+                    width: '100%',
+                  }}
+                  onClick={() => {
+                    setSelectedIndex(index);
+                  }}
+                >
+                  {/* TODO: Find a better way to determine which retrieval assessment to use for the indicator */}
+                  <EvaluationsReviewListItemIndicator
+                    chunkRelevanceAssessmentInfo={chunkRelevanceAssessmentInfo}
+                    assessment={first(
+                      chunk?.retrievalAssessmentsByName?.[KnownEvaluationResultAssessmentName.CHUNK_RELEVANCE],
+                    )}
+                  />
+                  <Typography.Text ellipsis css={{ flex: 1, lineHeight: theme.typography.lineHeightLg }}>
+                    {chunk.content}
+                  </Typography.Text>
+                </div>
+              );
+            })}
+          </div>
+
+          {selectedChunk && (
+            <div css={{ flex: 2, display: 'flex', flexDirection: 'column', width: 0 }}>
+              <div
+                css={{
+                  padding: theme.spacing.md,
+                  borderBottom: `1px solid ${theme.colors.border}`,
+                }}
+              >
+                <RetrievedChunkHeader chunk={selectedChunk} index={selectedIndex} />
+                <Spacer size="md" />
+                <EvaluationsReviewAssessments
+                  assessmentsType="retrieval"
+                  assessmentsByName={getOrderedAssessments(selectedChunk.retrievalAssessmentsByName || {})}
+                  onUpsertAssessment={(assessment: RunEvaluationResultAssessmentDraft) => {
+                    if (!assessment.metadata) {
+                      assessment.metadata = {};
+                    }
+                    // Set the chunk index to the selected index
+                    assessment.metadata[KnownEvaluationResultAssessmentMetadataFields.CHUNK_INDEX] = selectedIndex;
+                    onUpsertAssessment(assessment);
+                  }}
+                  allowEditing={toBeReviewed}
+                  allowMoreThanOne
+                  options={KnownEvaluationRetrievalAssessmentNames}
+                  inputs={[selectedIndex]}
+                  assessmentInfos={assessmentInfos}
+                />
+              </div>
+              <div css={{ padding: theme.spacing.md, overflow: 'auto' }}>
+                <Typography.Paragraph>
+                  <span
+                    css={{ display: 'contents' }}
+                    // eslint-disable-next-line react/no-danger
+                    dangerouslySetInnerHTML={{ __html: selectedEntryHtmlContent ?? '' }}
+                  />
+                </Typography.Paragraph>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+/**
+ * Displays RAG retrieval results for a given evaluation result.
+ */
+export const EvaluationsReviewRetrievalSection = ({
+  evaluationResult,
+  otherEvaluationResult,
+  onUpsertAssessment,
+  overridingExistingReview = false,
+  isReadOnly = false,
+  assessmentInfos,
+  traceQueryResult,
+  compareToTraceQueryResult,
+}: {
+  evaluationResult?: RunEvaluationTracesDataEntry;
+  otherEvaluationResult?: RunEvaluationTracesDataEntry;
+  onUpsertAssessment: (assessment: RunEvaluationResultAssessmentDraft) => void;
+  overridingExistingReview?: boolean;
+  isReadOnly?: boolean;
+  assessmentInfos: AssessmentInfo[];
+  traceQueryResult: UseQueryResult<ModelTrace | undefined, unknown>;
+  compareToTraceQueryResult: UseQueryResult<ModelTrace | undefined, unknown>;
+}) => {
+  const { theme } = useDesignSystemTheme();
+  return (
+    <div
+      css={{
+        display: 'flex',
+        width: '100%',
+        gap: theme.spacing.sm,
+      }}
+    >
+      {evaluationResult && (
+        <EvaluationsReviewSingleRunRetrievalSection
+          evaluationResult={evaluationResult}
+          onUpsertAssessment={onUpsertAssessment}
+          overridingExistingReview={overridingExistingReview}
+          isReadOnly={isReadOnly}
+          assessmentInfos={assessmentInfos}
+          traceQueryResult={traceQueryResult}
+        />
+      )}
+      {otherEvaluationResult && (
+        <>
+          <VerticalBar />
+          <EvaluationsReviewSingleRunRetrievalSection
+            evaluationResult={otherEvaluationResult}
+            onUpsertAssessment={onUpsertAssessment}
+            overridingExistingReview={overridingExistingReview}
+            isReadOnly={isReadOnly}
+            assessmentInfos={assessmentInfos}
+            traceQueryResult={compareToTraceQueryResult}
+          />
+        </>
+      )}
+    </div>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsReviewTextBox.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/components/EvaluationsReviewTextBox.tsx
@@ -1,0 +1,75 @@
+import { isString } from 'lodash';
+import React, { useMemo } from 'react';
+
+import { Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { CopyActionButton } from '../../copy/CopyActionButton';
+
+import { EvaluationsReviewExpandedJSONValueCell } from './EvaluationsReviewExpandableCell';
+import { EXPECTED_FACTS_FIELD_NAME, stringifyValue } from './GenAiEvaluationTracesReview.utils';
+import { useMarkdownConverter } from '../utils/MarkdownUtils';
+
+export const EvaluationsReviewTextBox = ({
+  fieldName,
+  title,
+  value,
+  showCopyIcon,
+}: {
+  fieldName: string;
+  title: React.ReactNode;
+  value: any;
+  showCopyIcon?: boolean;
+}) => {
+  const { theme } = useDesignSystemTheme();
+
+  const { makeHTML } = useMarkdownConverter();
+
+  const htmlContent = useMemo(() => {
+    return isString(value) ? makeHTML(value) : null;
+  }, [value, makeHTML]);
+
+  const jsonContent = useMemo(() => {
+    return isString(value) ? null : stringifyValue(value);
+  }, [value]);
+
+  return (
+    <div
+      css={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: theme.spacing.sm,
+        flex: 1,
+        border: `1px solid ${theme.colors.border}`,
+        padding: theme.spacing.md,
+        borderRadius: theme.general.borderRadiusBase,
+        marginBottom: theme.spacing.md,
+      }}
+    >
+      <div css={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <Typography.Text bold>{title}</Typography.Text>
+        {showCopyIcon && (
+          <CopyActionButton copyText={stringifyValue(value)} componentId="mlflow.evaluations_review.textbox.copy" />
+        )}
+      </div>
+      <Typography.Paragraph
+        css={{
+          marginBottom: '0 !important',
+        }}
+      >
+        {isString(value) ? (
+          // eslint-disable-next-line react/no-danger
+          <span css={{ display: 'contents' }} dangerouslySetInnerHTML={{ __html: htmlContent ?? '' }} />
+        ) : fieldName === EXPECTED_FACTS_FIELD_NAME && Array.isArray(value) ? (
+          <ul>
+            {value.map((fact, index) => (
+              <li key={index}>
+                <EvaluationsReviewExpandedJSONValueCell key={index} value={fact} />
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <EvaluationsReviewExpandedJSONValueCell value={jsonContent} />
+        )}
+      </Typography.Paragraph>
+    </div>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/components/GenAITraceComparisonModal.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/components/GenAITraceComparisonModal.tsx
@@ -1,0 +1,78 @@
+import { compact } from 'lodash';
+import { useContext, useMemo } from 'react';
+
+import { Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { FormattedMessage } from '@databricks/i18n';
+import { CompareModelTraceExplorer } from '../../model-trace-explorer/CompareModelTraceExplorer';
+import { ModelTraceExplorerSkeleton } from '../../model-trace-explorer/ModelTraceExplorerSkeleton';
+import { useGetTracesById } from '../../model-trace-explorer/hooks/useGetTracesById';
+import { GenAITracesTableContext } from '../GenAITracesTableContext';
+
+// prettier-ignore
+export const GenAITraceComparisonModal = ({
+  traceIds,
+  onClose,
+}: {
+  traceIds: string[];
+  onClose?: () => void;
+}) => {
+  const { theme } = useDesignSystemTheme();
+  const { DrawerComponent } = useContext(GenAITracesTableContext);
+
+  const queryParams = undefined;
+  const { data: fetchedTraces, isLoading } = useGetTracesById(traceIds, queryParams);
+
+  const modelTraces = useMemo(() => compact(fetchedTraces), [fetchedTraces]);
+
+  return (
+    <DrawerComponent.Root
+      open
+      modal
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose?.();
+        }
+      }}
+    >
+      <DrawerComponent.Content
+        componentId="mlflow.evaluations_review.modal"
+        width="90vw"
+        title={
+          <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm }}>
+            <Typography.Title level={2} withoutMargins>
+              <FormattedMessage
+                defaultMessage="Comparing {count} traces"
+                description="Comparing traces title"
+                values={{ count: traceIds.length }}
+              />
+            </Typography.Title>
+          </div>
+        }
+        expandContentToFullHeight
+        css={[
+          {
+            // Disable drawer's scroll to allow inner content to handle scrolling
+            '&>div': {
+              overflow: 'hidden',
+            },
+            '&>div:first-of-type': {
+              paddingLeft: theme.spacing.md,
+            },
+          },
+        ]}
+      >
+        {isLoading || !modelTraces || modelTraces.length === 0 ? (
+          <ModelTraceExplorerSkeleton />
+        ) : (
+          <CompareModelTraceExplorer
+            modelTraces={modelTraces}
+            css={{
+              marginLeft: -theme.spacing.lg,
+              marginRight: -theme.spacing.lg,
+            }}
+          />
+        )}
+      </DrawerComponent.Content>
+    </DrawerComponent.Root>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/components/GenAiDeleteTraceModal.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/components/GenAiDeleteTraceModal.tsx
@@ -1,0 +1,88 @@
+import React, { useState } from 'react';
+
+import { Modal, Typography } from '@databricks/design-system';
+import { FormattedMessage, useIntl } from '@databricks/i18n';
+
+import type { RunEvaluationTracesDataEntry } from '../types';
+
+export const GenAiDeleteTraceModal = ({
+  experimentIds,
+  visible,
+  selectedTraces,
+  handleClose,
+  deleteTraces,
+}: {
+  experimentIds: string[];
+  visible: boolean;
+  selectedTraces: RunEvaluationTracesDataEntry[];
+  handleClose: () => void;
+  deleteTraces: (experimentId: string, traceIds: string[]) => Promise<void>;
+}) => {
+  const intl = useIntl();
+  const [errorMessage, setErrorMessage] = useState<string>('');
+  const [isLoading, setIsLoading] = useState(false);
+  const tracesToDelete = selectedTraces.map((trace) => trace.evaluationId);
+
+  const submitDeleteTraces = async () => {
+    try {
+      await deleteTraces(experimentIds[0] ?? '', tracesToDelete);
+      handleClose();
+    } catch (e: any) {
+      setErrorMessage(
+        intl.formatMessage({
+          defaultMessage: 'An error occurred while attempting to delete traces. Please refresh the page and try again.',
+          description: 'Experiment page > traces view controls > Delete traces modal > Error message',
+        }),
+      );
+    }
+    setIsLoading(false);
+  };
+
+  const handleOk = () => {
+    submitDeleteTraces();
+    setIsLoading(true);
+  };
+
+  return (
+    <Modal
+      componentId="eval-tab.delete_traces-modal"
+      title={
+        <FormattedMessage
+          defaultMessage="{count, plural, one {Delete Trace} other {Delete Traces}}"
+          description="Experiment page > traces view controls > Delete traces modal > Title"
+          values={{ count: tracesToDelete.length }}
+        />
+      }
+      visible={visible}
+      onCancel={handleClose}
+      okText={
+        <FormattedMessage
+          defaultMessage="Delete {count, plural, one { # trace } other { # traces }}"
+          description="Experiment page > traces view controls > Delete traces modal > Delete button"
+          values={{ count: tracesToDelete.length }}
+        />
+      }
+      onOk={handleOk}
+      okButtonProps={{ loading: isLoading, danger: true }}
+    >
+      {errorMessage && <Typography.Paragraph color="error">{errorMessage}</Typography.Paragraph>}
+      <Typography.Paragraph>
+        <Typography.Text bold>
+          <FormattedMessage
+            defaultMessage="{count, plural, one { # trace } other { # traces }} will be deleted."
+            description="Experiment page > traces view controls > Delete traces modal > Confirmation message title"
+            values={{
+              count: tracesToDelete.length,
+            }}
+          />
+        </Typography.Text>
+      </Typography.Paragraph>
+      <Typography.Paragraph>
+        <FormattedMessage
+          defaultMessage="Deleted traces cannot be restored. Are you sure you want to proceed?"
+          description="Experiment page > traces view controls > Delete traces modal > Confirmation message"
+        />
+      </Typography.Paragraph>
+    </Modal>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/components/GenAiEvaluationBadge.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/components/GenAiEvaluationBadge.tsx
@@ -1,0 +1,38 @@
+import { useDesignSystemTheme } from '@databricks/design-system';
+
+export const GenAiEvaluationBadge = ({
+  backgroundColor,
+  icon,
+  children,
+}:
+  | {
+      backgroundColor?: string;
+      icon?: React.ReactNode;
+      children: React.ReactNode;
+    }
+  | {
+      backgroundColor?: string;
+      icon: React.ReactNode;
+      children?: null;
+    }) => {
+  const { theme } = useDesignSystemTheme();
+  return (
+    <div
+      css={{
+        display: 'flex',
+        flexDirection: 'row',
+        justifyContent: 'center',
+        alignItems: 'center',
+        padding: '4px 8px',
+        gap: theme.spacing.xs,
+        borderRadius: theme.borders.borderRadiusMd,
+        color: theme.colors.textSecondary,
+        backgroundColor: backgroundColor || theme.colors.backgroundSecondary,
+        fontSize: theme.typography.fontSizeSm,
+      }}
+    >
+      {icon ? icon : null}
+      {children ? <span>{children}</span> : null}
+    </div>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/components/GenAiEvaluationTracesReview.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/components/GenAiEvaluationTracesReview.tsx
@@ -1,0 +1,131 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+import { Spinner, useDesignSystemTheme } from '@databricks/design-system';
+import type { ModelTrace } from '../../model-trace-explorer/ModelTrace.types';
+import type { UseQueryResult } from '../../query-client/queryClient';
+
+import { EvaluationsReviewDetails } from './EvaluationsReviewDetails';
+import {
+  copyAiOverallAssessmentAsHumanAssessment,
+  shouldRepeatExistingOriginalOverallAiAssessment,
+} from './GenAiEvaluationTracesReview.utils';
+import type { AssessmentInfo, RunEvaluationTracesDataEntry, SaveAssessmentsQuery } from '../types';
+import { RUN_EVALUATIONS_SINGLE_ITEM_REVIEW_UI_PAGE_ID } from '../utils/EvaluationLogging';
+
+export const GenAiEvaluationTracesReview = ({
+  experimentId,
+  evaluation,
+  otherEvaluation,
+  className,
+  runUuid,
+  isReadOnly = false,
+  selectNextEval,
+  isNextAvailable,
+  runDisplayName,
+  compareToRunDisplayName,
+  exportToEvalsInstanceEnabled = false,
+  assessmentInfos,
+  traceQueryResult,
+  compareToTraceQueryResult,
+  saveAssessmentsQuery,
+}: {
+  experimentId: string;
+  evaluation: RunEvaluationTracesDataEntry;
+  otherEvaluation?: RunEvaluationTracesDataEntry;
+  className?: string;
+  runUuid?: string;
+  isReadOnly?: boolean;
+  selectNextEval: () => void;
+  isNextAvailable: boolean;
+  runDisplayName?: string;
+  compareToRunDisplayName?: string;
+  exportToEvalsInstanceEnabled?: boolean;
+  assessmentInfos: AssessmentInfo[];
+  traceQueryResult: UseQueryResult<ModelTrace | undefined, unknown>;
+  compareToTraceQueryResult: UseQueryResult<ModelTrace | undefined, unknown>;
+  saveAssessmentsQuery?: SaveAssessmentsQuery;
+}) => {
+  const { theme } = useDesignSystemTheme();
+
+  const handleSavePendingAssessments = useCallback(
+    async (evaluation, pendingAssessments) => {
+      if (!evaluation || isReadOnly || !runUuid || !saveAssessmentsQuery) {
+        return;
+      }
+
+      // Prepare the list of assessments to be sent to the backend.
+      const assessmentsToSave = pendingAssessments.slice();
+
+      // Even if user did not provide any explicit overall assessment, we still should be able to mark the evaluation as reviewed.
+      // We check if there are no user provided overall assessments and if the last overall assessment was AI generated.
+      const shouldRepeatOverallAiAssessment = shouldRepeatExistingOriginalOverallAiAssessment(
+        evaluation,
+        pendingAssessments,
+      );
+
+      // If we should repeat the AI generated overall assessment, we need to copy and add it to the list of assessments to save.
+      if (shouldRepeatOverallAiAssessment) {
+        const repeatedOverallAssessment = copyAiOverallAssessmentAsHumanAssessment(evaluation);
+
+        repeatedOverallAssessment && assessmentsToSave.unshift(repeatedOverallAssessment);
+      }
+
+      return saveAssessmentsQuery.savePendingAssessments(runUuid, evaluation.evaluationId, assessmentsToSave);
+    },
+    [runUuid, isReadOnly, saveAssessmentsQuery],
+  );
+
+  // Scroll right side panel to the top when switching between evaluations
+  const reviewDetailsRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    reviewDetailsRef.current?.scrollTo(0, 0);
+  }, [evaluation.evaluationId]);
+
+  return (
+    <div
+      // comment for copybara formatting
+      css={{ display: 'flex', position: 'relative', overflow: 'scroll' }}
+      className={className}
+    >
+      <div
+        css={{
+          flex: 1,
+          overflow: 'auto',
+        }}
+        ref={reviewDetailsRef}
+      >
+        <EvaluationsReviewDetails
+          experimentId={experimentId}
+          key={evaluation.evaluationId}
+          evaluationResult={evaluation}
+          otherEvaluationResult={otherEvaluation}
+          onSavePendingAssessments={handleSavePendingAssessments}
+          onClickNext={selectNextEval}
+          isNextAvailable={isNextAvailable}
+          isReadOnly={isReadOnly || !runUuid}
+          runDisplayName={runDisplayName}
+          compareToRunDisplayName={compareToRunDisplayName}
+          exportToEvalsInstanceEnabled={exportToEvalsInstanceEnabled}
+          assessmentInfos={assessmentInfos}
+          traceQueryResult={traceQueryResult}
+          compareToTraceQueryResult={compareToTraceQueryResult}
+        />
+      </div>
+      {saveAssessmentsQuery?.isSaving && (
+        <div
+          css={{
+            inset: 0,
+            position: 'absolute',
+            backgroundColor: theme.colors.overlayOverlay,
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            zIndex: theme.options.zIndexBase + 1,
+          }}
+        >
+          <Spinner size="large" inheritColor css={{ color: theme.colors.backgroundPrimary }} />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/components/GenAiEvaluationTracesReview.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/components/GenAiEvaluationTracesReview.utils.tsx
@@ -1,0 +1,991 @@
+import { isNil, isNumber, isPlainObject, orderBy } from 'lodash';
+
+import type { ThemeType } from '@databricks/design-system';
+import { CheckCircleIcon, WarningIcon, XCircleIcon } from '@databricks/design-system';
+import type { MessageDescriptor, IntlShape } from '@databricks/i18n';
+import { defineMessage } from '@databricks/i18n';
+import { getUser } from '../../global-settings/getUser';
+import { normalizeConversation } from '../../model-trace-explorer/ModelTraceExplorer.utils';
+
+import type {
+  AssessmentInfo,
+  AssessmentValueType,
+  RunEvaluationResultAssessment,
+  RunEvaluationResultAssessmentDraft,
+  RunEvaluationTracesDataEntry,
+} from '../types';
+import { getEvaluationResultAssessmentBackgroundColor, getEvaluationResultIconColor } from '../utils/Colors';
+
+const ERROR_VALUE = 'Error';
+
+export const INPUT_REQUEST_KEY = 'request';
+
+const COMMON_MESSAGE_FORMATS = ['openai', 'langchain', 'anthropic'] as const;
+
+/**
+ * Attempts to extract the last user message content from various chat formats.
+ * Returns undefined if the input cannot be parsed as a chat format.
+ */
+export const tryExtractUserMessageContent = (input: unknown): string | undefined => {
+  // This prevents raw/truncated strings from being incorrectly treated as user messages
+  if (isNil(input) || typeof input !== 'object') {
+    return undefined;
+  }
+
+  try {
+    for (const format of COMMON_MESSAGE_FORMATS) {
+      const messages = normalizeConversation(input, format);
+      if (messages && messages.length > 0) {
+        const lastUserMessage = [...messages].reverse().find((msg) => msg.role === 'user');
+        if (lastUserMessage?.content) {
+          return lastUserMessage.content;
+        }
+      }
+    }
+  } catch {
+    // JSON may be truncated or malformed, silently fail
+  }
+
+  return undefined;
+};
+
+const INPUT_MESSAGES_KEY = 'messages';
+
+export enum KnownEvaluationResultAssessmentName {
+  OVERALL_ASSESSMENT = 'overall_assessment',
+  SAFETY = 'safety',
+  GROUNDEDNESS = 'groundedness',
+  RETRIEVAL_GROUNDEDNESS = 'retrieval_groundedness', // Updated name for groundedness
+  CORRECTNESS = 'correctness',
+  RELEVANCE_TO_QUERY = 'relevance_to_query',
+  CHUNK_RELEVANCE = 'chunk_relevance',
+  RETRIEVAL_RELEVANCE = 'retrieval_relevance', // Updated name for chunk relevance
+  CONTEXT_SUFFICIENCY = 'context_sufficiency',
+  RETRIEVAL_SUFFICIENCY = 'retrieval_sufficiency', // Updated name for context sufficiency
+  GUIDELINE_ADHERENCE = 'guideline_adherence',
+  GUIDELINES = 'guidelines', // Updated name for guideline adherence
+  GLOBAL_GUIDELINE_ADHERENCE = 'global_guideline_adherence',
+  CONVERSATIONAL_GUIDELINES = 'conversational_guidelines',
+}
+
+export const DEFAULT_ASSESSMENTS_SORT_ORDER: string[] = [
+  KnownEvaluationResultAssessmentName.OVERALL_ASSESSMENT,
+  // Correctness runs with GT, relevancy to query runs without it.
+  KnownEvaluationResultAssessmentName.CORRECTNESS,
+  KnownEvaluationResultAssessmentName.GLOBAL_GUIDELINE_ADHERENCE,
+  KnownEvaluationResultAssessmentName.GUIDELINE_ADHERENCE,
+  KnownEvaluationResultAssessmentName.GUIDELINES,
+  KnownEvaluationResultAssessmentName.CONVERSATIONAL_GUIDELINES,
+  KnownEvaluationResultAssessmentName.RELEVANCE_TO_QUERY,
+  KnownEvaluationResultAssessmentName.CONTEXT_SUFFICIENCY,
+  KnownEvaluationResultAssessmentName.RETRIEVAL_SUFFICIENCY,
+  KnownEvaluationResultAssessmentName.CHUNK_RELEVANCE,
+  KnownEvaluationResultAssessmentName.RETRIEVAL_RELEVANCE,
+  KnownEvaluationResultAssessmentName.GROUNDEDNESS,
+  KnownEvaluationResultAssessmentName.RETRIEVAL_GROUNDEDNESS, // Updated name for groundedness
+  KnownEvaluationResultAssessmentName.SAFETY,
+];
+
+export const getJudgeMetricsLink = (asessmentDocLink?: AssessmentLearnMoreLink) => {
+  // return OSS docs link
+  return 'https://mlflow.org/docs/latest/genai/eval-monitor/scorers/';
+};
+
+export interface AssessmentLearnMoreLink {
+  basePath: string;
+  hash?: string;
+}
+
+/**
+ * These will be converted to the links per-cloud:
+ * https://learn.microsoft.com/en-us/azure/databricks/generative-ai/agent-evaluation/${hash}`
+ * https://docs.databricks.com/en/generative-ai/agent-evaluation/${page}.html#${hash}
+ */
+// eslint-disable-next-line @databricks/no-const-object-record-string -- TODO(FEINF-2058)
+export const ASSESSMENTS_DOC_LINKS: Record<string, AssessmentLearnMoreLink> = {
+  [KnownEvaluationResultAssessmentName.OVERALL_ASSESSMENT]: {
+    // TODO(nsthorat): Update this link to the overall deep link once it's available.
+    basePath: '/generative-ai/agent-evaluation/llm-judge-metrics',
+    hash: 'how-quality-is-assessed-by-llm-judges',
+  },
+  [KnownEvaluationResultAssessmentName.CORRECTNESS]: {
+    basePath: '/generative-ai/agent-evaluation/llm-judge-reference',
+    hash: 'correctness',
+  },
+  [KnownEvaluationResultAssessmentName.GROUNDEDNESS]: {
+    basePath: '/generative-ai/agent-evaluation/llm-judge-reference',
+    hash: 'groundedness',
+  },
+  [KnownEvaluationResultAssessmentName.RETRIEVAL_GROUNDEDNESS]: {
+    basePath: '/generative-ai/agent-evaluation/llm-judge-reference',
+    hash: 'groundedness',
+  },
+  [KnownEvaluationResultAssessmentName.RELEVANCE_TO_QUERY]: {
+    basePath: '/generative-ai/agent-evaluation/llm-judge-reference',
+    hash: 'answer-relevance',
+  },
+  [KnownEvaluationResultAssessmentName.SAFETY]: {
+    basePath: '/generative-ai/agent-evaluation/llm-judge-reference',
+    hash: 'safety',
+  },
+  [KnownEvaluationResultAssessmentName.CHUNK_RELEVANCE]: {
+    basePath: '/generative-ai/agent-evaluation/llm-judge-reference',
+    hash: 'chunk-relevance-precision',
+  },
+  [KnownEvaluationResultAssessmentName.RETRIEVAL_RELEVANCE]: {
+    basePath: '/generative-ai/agent-evaluation/llm-judge-reference',
+    hash: 'chunk-relevance-precision',
+  },
+  [KnownEvaluationResultAssessmentName.CONTEXT_SUFFICIENCY]: {
+    basePath: '/generative-ai/agent-evaluation/llm-judge-reference',
+    hash: 'context-sufficiency',
+  },
+  [KnownEvaluationResultAssessmentName.RETRIEVAL_SUFFICIENCY]: {
+    basePath: '/generative-ai/agent-evaluation/llm-judge-reference',
+    hash: 'context-sufficiency',
+  },
+  [KnownEvaluationResultAssessmentName.GUIDELINE_ADHERENCE]: {
+    basePath: '/generative-ai/agent-evaluation/llm-judge-reference',
+    hash: 'guideline-adherence',
+  },
+  [KnownEvaluationResultAssessmentName.GUIDELINES]: {
+    basePath: '/generative-ai/agent-evaluation/llm-judge-reference',
+    hash: 'guideline-adherence',
+  },
+  [KnownEvaluationResultAssessmentName.CONVERSATIONAL_GUIDELINES]: {
+    basePath: '/generative-ai/agent-evaluation/llm-judge-reference',
+    hash: 'conversational-guidelines',
+  },
+};
+
+export enum KnownEvaluationResultAssessmentStringValue {
+  YES = 'yes',
+  NO = 'no',
+  UNKNOWN = 'unknown',
+}
+
+export function getAssessmentValueLabel(
+  intl: IntlShape,
+  theme: ThemeType,
+  assessmentInfo: AssessmentInfo,
+  value: AssessmentValueType,
+): { content: string; icon?: JSX.Element } {
+  // Handle error value first, before checking dtype
+  if (value === ERROR_VALUE) {
+    return {
+      content: intl.formatMessage({
+        defaultMessage: 'Error',
+        description: 'Error assessment label for filter dropdown',
+      }),
+    };
+  }
+  if (assessmentInfo.dtype === 'pass-fail') {
+    if (value === KnownEvaluationResultAssessmentStringValue.YES) {
+      return {
+        content: intl.formatMessage({
+          defaultMessage: 'Pass',
+          description: 'Passing assessment label',
+        }),
+        icon: (
+          <span
+            css={{
+              color: `${getEvaluationResultIconColor(theme, assessmentInfo, {
+                stringValue: KnownEvaluationResultAssessmentStringValue.YES,
+              })} !important`,
+              svg: {
+                width: '12px',
+                height: '12px',
+              },
+            }}
+          >
+            <CheckCircleIcon
+              css={{
+                backgroundColor: getEvaluationResultAssessmentBackgroundColor(theme, assessmentInfo, {
+                  stringValue: KnownEvaluationResultAssessmentStringValue.YES,
+                }),
+                borderRadius: '50%',
+              }}
+            />
+          </span>
+        ),
+      };
+    } else if (value === KnownEvaluationResultAssessmentStringValue.NO) {
+      return {
+        content: intl.formatMessage({
+          defaultMessage: 'Fail',
+          description: 'Failing assessment label',
+        }),
+        icon: (
+          <span
+            css={{
+              color: `${getEvaluationResultIconColor(theme, assessmentInfo, {
+                stringValue: KnownEvaluationResultAssessmentStringValue.NO,
+              })} !important`,
+              svg: {
+                width: '12px',
+                height: '12px',
+              },
+            }}
+          >
+            <XCircleIcon
+              css={{
+                backgroundColor: getEvaluationResultAssessmentBackgroundColor(theme, assessmentInfo, {
+                  stringValue: KnownEvaluationResultAssessmentStringValue.NO,
+                }),
+                borderRadius: '50%',
+              }}
+            />
+          </span>
+        ),
+      };
+    } else {
+      return {
+        content: intl.formatMessage({
+          defaultMessage: 'Missing',
+          description: 'Missing assessment label',
+        }),
+        icon: (
+          <span
+            css={{
+              color: `${getEvaluationResultIconColor(theme, assessmentInfo, {
+                stringValue: KnownEvaluationResultAssessmentStringValue.UNKNOWN,
+              })} !important`,
+              svg: {
+                width: '12px',
+                height: '12px',
+              },
+            }}
+          >
+            <WarningIcon
+              css={{
+                backgroundColor: getEvaluationResultAssessmentBackgroundColor(theme, assessmentInfo, {
+                  stringValue: KnownEvaluationResultAssessmentStringValue.UNKNOWN,
+                }),
+                borderRadius: '50%',
+              }}
+            />
+          </span>
+        ),
+      };
+    }
+  } else if (assessmentInfo.dtype === 'boolean') {
+    if (value === true) {
+      return {
+        content: intl.formatMessage({
+          defaultMessage: 'True',
+          description: 'True assessment label',
+        }),
+      };
+    } else if (value === false) {
+      return {
+        content: intl.formatMessage({
+          defaultMessage: 'False',
+          description: 'False assessment label',
+        }),
+      };
+    } else {
+      return {
+        content: intl.formatMessage({
+          defaultMessage: 'null',
+          description: 'null assessment label',
+        }),
+      };
+    }
+  }
+  return {
+    content: `${value}`,
+  };
+}
+
+export enum KnownEvaluationResultAssessmentMetadataFields {
+  IS_OVERALL_ASSESSMENT = 'is_overall_assessment',
+  CHUNK_INDEX = 'chunk_index',
+  IS_COPIED_FROM_AI = 'is_copied_from_ai',
+}
+
+// eslint-disable-next-line @databricks/no-const-object-record-string -- TODO(FEINF-2058)
+export const KnownEvaluationResultAssessmentOutputLabel: Record<string, MessageDescriptor> = {
+  response: defineMessage({
+    defaultMessage: 'Model output',
+    description: 'Evaluation review > Response section > model output > title',
+  }),
+};
+
+export const EXPECTED_FACTS_FIELD_NAME = 'expected_facts';
+
+// eslint-disable-next-line @databricks/no-const-object-record-string -- TODO(FEINF-2058)
+export const KnownEvaluationResultAssessmentTargetLabel: Record<string, MessageDescriptor> = {
+  expected_response: defineMessage({
+    defaultMessage: 'Expected output',
+    description: 'Evaluation review > Response section > expected output > title',
+  }),
+  [EXPECTED_FACTS_FIELD_NAME]: defineMessage({
+    defaultMessage: 'Expected facts',
+    description: 'Evaluation review > Response section > expected facts > title',
+  }),
+};
+
+// eslint-disable-next-line @databricks/no-const-object-record-string -- TODO(FEINF-2058)
+export const KnownEvaluationResultAssessmentValueLabel: Record<string, MessageDescriptor> = {
+  [KnownEvaluationResultAssessmentName.OVERALL_ASSESSMENT]: defineMessage({
+    defaultMessage: 'Overall',
+    description: 'Evaluation results > known type of evaluation result assessment > overall assessment.',
+  }),
+  [KnownEvaluationResultAssessmentName.CORRECTNESS]: defineMessage({
+    defaultMessage: 'Correctness',
+    description:
+      'Evaluation results > known type of evaluation result assessment > correctness assessment. Used to indicate if the result is correct in context of LLMs evaluation. Label displayed if user provided custom value, e.g. "Correctness: mostly yes, have gaps"',
+  }),
+  [KnownEvaluationResultAssessmentName.GROUNDEDNESS]: defineMessage({
+    defaultMessage: 'Groundedness',
+    description:
+      'Evaluation results > known type of evaluation result assessment > groundedness assessment. Used to indicate if the result is grounded in context of LLMs evaluation. Label displayed if user provided custom value, e.g. "Groundedness: moderately grounded"',
+  }),
+  [KnownEvaluationResultAssessmentName.RETRIEVAL_GROUNDEDNESS]: defineMessage({
+    defaultMessage: 'Retrieval groundedness',
+    description:
+      'Evaluation results > known type of evaluation result assessment > retrieval groundedness assessment. Used to indicate if the result is grounded in context of LLMs evaluation. Label displayed if user provided custom value, e.g. "Retrieval groundedness: moderately grounded"',
+  }),
+  [KnownEvaluationResultAssessmentName.CONTEXT_SUFFICIENCY]: defineMessage({
+    defaultMessage: 'Context sufficiency',
+    description:
+      'Evaluation results > known type of evaluation result assessment > context sufficiency assessment. Used to indicate if the retrieved context is sufficient to generate the expected response. Label displayed if user provided custom value, e.g. "Context Sufficiency: mostly sufficient"',
+  }),
+  [KnownEvaluationResultAssessmentName.RETRIEVAL_SUFFICIENCY]: defineMessage({
+    defaultMessage: 'Retrieval sufficiency',
+    description:
+      'Evaluation results > known type of evaluation result assessment > retrieval sufficiency assessment. Used to indicate if the retrieved context is sufficient to generate the expected response. Label displayed if user provided custom value, e.g. "Retrieval sufficiency: mostly sufficient"',
+  }),
+  [KnownEvaluationResultAssessmentName.RELEVANCE_TO_QUERY]: defineMessage({
+    defaultMessage: 'Relevance',
+    description:
+      'Evaluation results > known type of evaluation result assessment > relevance assessment. Used to indicate if the result is relevant to query in context of LLMs evaluation. Label displayed if user provided custom value, e.g. "Relevance: moderate"',
+  }),
+  [KnownEvaluationResultAssessmentName.SAFETY]: defineMessage({
+    defaultMessage: 'Safety',
+    description:
+      'Evaluation results > known type of evaluation result assessment > safety assessment. Used to indicate if the result is safe in context of LLMs evaluation. Label displayed if user provided custom value, e.g. "Safety: moderate"',
+  }),
+  [KnownEvaluationResultAssessmentName.CHUNK_RELEVANCE]: defineMessage({
+    defaultMessage: 'Chunk relevance',
+    description:
+      'Evaluation results > known type of evaluation result assessment > chunk relevance assessment. Used to indicate if the result is relevant to source data chunk in context of LLMs evaluation. Label displayed if user provided custom value, e.g. "Chunk relevance: moderate"',
+  }),
+  [KnownEvaluationResultAssessmentName.RETRIEVAL_RELEVANCE]: defineMessage({
+    defaultMessage: 'Retrieval relevance',
+    description:
+      'Evaluation results > known type of evaluation result assessment > retrieval relevance assessment. Used to indicate if the result is relevant to source data chunk in context of LLMs evaluation. Label displayed if user provided custom value, e.g. "Retrieval relevance: moderate"',
+  }),
+  [KnownEvaluationResultAssessmentName.GUIDELINE_ADHERENCE]: defineMessage({
+    defaultMessage: 'Guideline adherence',
+    description:
+      'Evaluation results > known type of evaluation result assessment > guideline adherence assessment. Used to indicate if the result adheres to the guidelines in context of LLMs evaluation. Label displayed if user provided custom value, e.g. "Guideline adherence: moderate"',
+  }),
+  [KnownEvaluationResultAssessmentName.GUIDELINES]: defineMessage({
+    defaultMessage: 'Guidelines',
+    description:
+      'Evaluation results > known type of evaluation result assessment > guidelines assessment. Used to indicate if the result adheres to the guidelines in context of LLMs evaluation. Label displayed if user provided custom value, e.g. "Guidelines: moderate"',
+  }),
+  [KnownEvaluationResultAssessmentName.GLOBAL_GUIDELINE_ADHERENCE]: defineMessage({
+    defaultMessage: 'Global guideline adherence',
+    description:
+      'Evaluation results > known type of evaluation result assessment > global guideline adherence assessment. Used to indicate if the result adheres to the global guidelines in context of LLMs evaluation. Label displayed if user provided custom value, e.g. "Global guideline adherence: moderate"',
+  }),
+  [KnownEvaluationResultAssessmentName.CONVERSATIONAL_GUIDELINES]: defineMessage({
+    defaultMessage: 'Conversational guidelines',
+    description:
+      'Evaluation results > known type of evaluation result assessment > conversational guidelines assessment. Used to indicate if the assistant adheres to the guidelines throughout a conversation.',
+  }),
+};
+
+// eslint-disable-next-line @databricks/no-const-object-record-string -- TODO(FEINF-2058)
+export const KnownEvaluationResultAssessmentValueMissingTooltip: Record<string, MessageDescriptor> = {
+  [KnownEvaluationResultAssessmentName.CORRECTNESS]: defineMessage({
+    defaultMessage:
+      'Correctness assessment is missing. This is likely because you have not provided an expected response (ground truth) or grading notes.',
+    description:
+      'Evaluation results > known type of evaluation result assessment > correctness assessment. Used to indicate if the result is correct in context of LLMs evaluation. Label displayed if user provided custom value, e.g. "Correctness: mostly yes, have gaps"',
+  }),
+  [KnownEvaluationResultAssessmentName.GROUNDEDNESS]: defineMessage({
+    defaultMessage:
+      'Groundedness assessment is missing. This is likely because your agent is not returning retrieved_context.',
+    description:
+      'Evaluation results > known type of evaluation result assessment > groundedness assessment. Used to indicate if the result is grounded in context of LLMs evaluation. Label displayed if user provided custom value, e.g. "Groundedness: moderately grounded"',
+  }),
+  [KnownEvaluationResultAssessmentName.RETRIEVAL_GROUNDEDNESS]: defineMessage({
+    defaultMessage:
+      'Retrieval Groundedness assessment is missing. This is likely because your agent is not returning retrieved_context.',
+    description:
+      'Evaluation results > known type of evaluation result assessment > retrieval groundedness assessment. Used to indicate if the result is grounded in context of LLMs evaluation. Label displayed if user provided custom value, e.g. "Retrieval Groundedness: moderately grounded"',
+  }),
+  [KnownEvaluationResultAssessmentName.CONTEXT_SUFFICIENCY]: defineMessage({
+    defaultMessage:
+      'Context sufficiency assessment is missing. This is likely because your agent is not returning retrieved_context.',
+    description:
+      'Evaluation results > known type of evaluation result assessment > context sufficiency assessment. Used to indicate if the retrieved context is sufficient to generate the expected response. Label displayed if user provided custom value, e.g. "Context Sufficiency: mostly sufficient"',
+  }),
+  [KnownEvaluationResultAssessmentName.RETRIEVAL_SUFFICIENCY]: defineMessage({
+    defaultMessage:
+      'Retrieval sufficiency assessment is missing. This is likely because your agent is not returning retrieved_context.',
+    description:
+      'Evaluation results > known type of evaluation result assessment > retrieval sufficiency assessment. Used to indicate if the retrieved context is sufficient to generate the expected response. Label displayed if user provided custom value, e.g. "Retrieval sufficiency: mostly sufficient"',
+  }),
+};
+
+// eslint-disable-next-line @databricks/no-const-object-record-string -- TODO(FEINF-2058)
+export const KnownEvaluationResultAssessmentValueDescription: Record<string, MessageDescriptor> = {
+  [KnownEvaluationResultAssessmentName.OVERALL_ASSESSMENT]: defineMessage({
+    defaultMessage: 'The overall assessment passes when all of the judges pass.',
+    description:
+      'Evaluation results > known type of evaluation result assessment > overall assessment > description of overall assessment',
+  }),
+  [KnownEvaluationResultAssessmentName.CORRECTNESS]: defineMessage({
+    defaultMessage:
+      "The correctness LLM judge gives a binary evaluation and written rationale on whether the agent's generated response is factually accurate and semantically similar to the provided ground-truth response or grading notes.",
+    description:
+      'Evaluation results > known type of evaluation result assessment > description of correctness assessment.',
+  }),
+  [KnownEvaluationResultAssessmentName.GROUNDEDNESS]: defineMessage({
+    defaultMessage:
+      "The groundedness LLM judge returns a binary evaluation and written rationale on whether the generated response is factually consistent with the agent's retrieved context.",
+    description: 'Evaluation results > known type of evaluation result assessment > description of groundedness judge.',
+  }),
+  [KnownEvaluationResultAssessmentName.RETRIEVAL_GROUNDEDNESS]: defineMessage({
+    defaultMessage:
+      "The retrieval groundedness LLM judge returns a binary evaluation and written rationale on whether the generated response is factually consistent with the agent's retrieved context.",
+    description:
+      'Evaluation results > known type of evaluation result assessment > description of retrieval groundedness judge.',
+  }),
+  [KnownEvaluationResultAssessmentName.RELEVANCE_TO_QUERY]: defineMessage({
+    defaultMessage:
+      'The relevance_to_query LLM judge determines whether the response is relevant to the input request.',
+    description: 'Evaluation results > known type of evaluation result assessment > description of relevance judge.',
+  }),
+  [KnownEvaluationResultAssessmentName.SAFETY]: defineMessage({
+    defaultMessage:
+      'The safety LLM judge returns a binary rating and a written rationale on whether the generated response has harmful or toxic content.',
+    description: 'Evaluation results > known type of evaluation result assessment > description of safety judge.',
+  }),
+  [KnownEvaluationResultAssessmentName.CHUNK_RELEVANCE]: defineMessage({
+    defaultMessage:
+      'The chunk-relevance-precision LLM judge determines whether the chunks returned by the retriever are relevant to the input request. Precision is calculated as the number of relevant chunks returned divided by the total number of chunks returned. For example, if the retriever returns four chunks, and the LLM judge determines that three of the four returned documents are relevant to the request, then llm_judged/chunk_relevance/precision is 0.75.',
+    description: 'Evaluation results > known type of evaluation result assessment > chunk relevance judge.',
+  }),
+  [KnownEvaluationResultAssessmentName.RETRIEVAL_RELEVANCE]: defineMessage({
+    defaultMessage:
+      'The retrieval-relevance LLM judge determines whether the chunks returned by the retriever are relevant to the input request. Precision is calculated as the number of relevant chunks returned divided by the total number of chunks returned. For example, if the retriever returns four chunks, and the LLM judge determines that three of the four returned documents are relevant to the request, then llm_judged/chunk_relevance/precision is 0.75.',
+    description: 'Evaluation results > known type of evaluation result assessment > retrieval relevance judge.',
+  }),
+  [KnownEvaluationResultAssessmentName.CONTEXT_SUFFICIENCY]: defineMessage({
+    defaultMessage:
+      'The context sufficiency LLM judge determines whether the retrieved context is sufficient to generate the expected response.',
+    description: 'Evaluation results > known type of evaluation result assessment > context sufficiency judge.',
+  }),
+  [KnownEvaluationResultAssessmentName.RETRIEVAL_SUFFICIENCY]: defineMessage({
+    defaultMessage:
+      'The retrieval sufficiency LLM judge determines whether the retrieved context is sufficient to generate the expected response.',
+    description: 'Evaluation results > known type of evaluation result assessment > retrieval sufficiency judge.',
+  }),
+  [KnownEvaluationResultAssessmentName.GUIDELINE_ADHERENCE]: defineMessage({
+    defaultMessage:
+      'The guideline adherence LLM judge determines whether the response adheres to the guidelines provided.',
+    description: 'Evaluation results > known type of evaluation result assessment > guideline adherence judge.',
+  }),
+  [KnownEvaluationResultAssessmentName.GUIDELINES]: defineMessage({
+    defaultMessage:
+      'The guidelines LLM judge determines whether the response adheres to the guidelines provided. All responses must adhere to guidelines.',
+    description: 'Evaluation results > known type of evaluation result assessment > guidelines judge.',
+  }),
+  [KnownEvaluationResultAssessmentName.GLOBAL_GUIDELINE_ADHERENCE]: defineMessage({
+    defaultMessage:
+      'The global guideline adherence LLM judge determines whether the response adheres to the global guidelines provided. All responses must adhere to global guidelines.',
+    description: 'Evaluation results > known type of evaluation result assessment > global guideline adherence judge.',
+  }),
+  [KnownEvaluationResultAssessmentName.CONVERSATIONAL_GUIDELINES]: defineMessage({
+    defaultMessage:
+      "The conversational guidelines LLM judge evaluates whether the assistant's responses throughout a conversation comply with the provided guidelines.",
+    description: 'Evaluation results > known type of evaluation result assessment > conversational guidelines judge.',
+  }),
+};
+
+// eslint-disable-next-line @databricks/no-const-object-record-string -- TODO(FEINF-2058)
+export const KnownEvaluationResultAssessmentValueMapping: Record<string, Record<string, MessageDescriptor>> = {
+  [KnownEvaluationResultAssessmentName.OVERALL_ASSESSMENT]: {
+    [KnownEvaluationResultAssessmentStringValue.YES]: defineMessage({
+      defaultMessage: 'Pass',
+      description:
+        'Evaluation results > overall assessment > pass value label. Displayed if evaluation result is overall considered as approved by LLM judge or human.',
+    }),
+    [KnownEvaluationResultAssessmentStringValue.NO]: defineMessage({
+      defaultMessage: 'Fail',
+      description:
+        'Evaluation results > overall assessment > fail value label. Displayed if evaluation result is overall considered as disapproved by LLM judge or human.',
+    }),
+  },
+  [KnownEvaluationResultAssessmentName.CHUNK_RELEVANCE]: {
+    [KnownEvaluationResultAssessmentStringValue.YES]: defineMessage({
+      defaultMessage: 'Relevant',
+      description:
+        'Evaluation results > chunk relevancy assessment > positive value label. Displayed if evaluation result is considered as relevant to the query.',
+    }),
+    [KnownEvaluationResultAssessmentStringValue.NO]: defineMessage({
+      defaultMessage: 'Irrelevant',
+      description:
+        'Evaluation results > chunk relevancy assessment > negative value label. Displayed if evaluation result is considered as irrelevant to the query.',
+    }),
+  },
+  [KnownEvaluationResultAssessmentName.RETRIEVAL_RELEVANCE]: {
+    [KnownEvaluationResultAssessmentStringValue.YES]: defineMessage({
+      defaultMessage: 'Relevant',
+      description:
+        'Evaluation results > retrieval relevancy assessment > positive value label. Displayed if evaluation result is considered as relevant to the query.',
+    }),
+    [KnownEvaluationResultAssessmentStringValue.NO]: defineMessage({
+      defaultMessage: 'Irrelevant',
+      description:
+        'Evaluation results > retrieval relevancy assessment > negative value label. Displayed if evaluation result is considered as irrelevant to the query.',
+    }),
+  },
+  [KnownEvaluationResultAssessmentName.CONTEXT_SUFFICIENCY]: {
+    [KnownEvaluationResultAssessmentStringValue.YES]: defineMessage({
+      defaultMessage: 'Context sufficient',
+      description:
+        'Evaluation results > context sufficiency assessment > positive value label. Displayed if retrieved context is sufficient to generate the expected response.',
+    }),
+    [KnownEvaluationResultAssessmentStringValue.NO]: defineMessage({
+      defaultMessage: 'Context insufficient',
+      description:
+        'Evaluation results > context sufficiency assessment > negative value label. Displayed if retrieved context is insufficient to generate the expected response.',
+    }),
+  },
+  [KnownEvaluationResultAssessmentName.RETRIEVAL_SUFFICIENCY]: {
+    [KnownEvaluationResultAssessmentStringValue.YES]: defineMessage({
+      defaultMessage: 'Sufficient',
+      description:
+        'Evaluation results > retrieval sufficiency assessment > positive value label. Displayed if retrieved context is sufficient to generate the expected response.',
+    }),
+    [KnownEvaluationResultAssessmentStringValue.NO]: defineMessage({
+      defaultMessage: 'Insufficient',
+      description:
+        'Evaluation results > retrieval sufficiency assessment > negative value label. Displayed if retrieved context is insufficient to generate the expected response.',
+    }),
+  },
+  [KnownEvaluationResultAssessmentName.RELEVANCE_TO_QUERY]: {
+    [KnownEvaluationResultAssessmentStringValue.YES]: defineMessage({
+      defaultMessage: 'Relevant',
+      description:
+        'Evaluation results > relevancy assessment > positive value label. Displayed if evaluation result is considered as irrelevant to the query.',
+    }),
+    [KnownEvaluationResultAssessmentStringValue.NO]: defineMessage({
+      defaultMessage: 'Irrelevant',
+      description:
+        'Evaluation results > relevancy assessment > negative value label. Displayed if evaluation result is considered as irrelevant to the query.',
+    }),
+  },
+  [KnownEvaluationResultAssessmentName.GROUNDEDNESS]: {
+    [KnownEvaluationResultAssessmentStringValue.YES]: defineMessage({
+      defaultMessage: 'Grounded',
+      description:
+        'Evaluation results > grounded assessment > positive value label. Displayed if evaluation result is considered as grounded.',
+    }),
+    [KnownEvaluationResultAssessmentStringValue.NO]: defineMessage({
+      defaultMessage: 'Not grounded',
+      description:
+        'Evaluation results > grounded assessment > negative value label. Displayed if evaluation result is considered as not grounded.',
+    }),
+  },
+  [KnownEvaluationResultAssessmentName.RETRIEVAL_GROUNDEDNESS]: {
+    [KnownEvaluationResultAssessmentStringValue.YES]: defineMessage({
+      defaultMessage: 'Grounded',
+      description:
+        'Evaluation results > retrieval grounded assessment > positive value label. Displayed if evaluation result is considered as grounded.',
+    }),
+    [KnownEvaluationResultAssessmentStringValue.NO]: defineMessage({
+      defaultMessage: 'Not grounded',
+      description:
+        'Evaluation results > retrieval grounded assessment > negative value label. Displayed if evaluation result is considered as not grounded.',
+    }),
+  },
+  [KnownEvaluationResultAssessmentName.CORRECTNESS]: {
+    [KnownEvaluationResultAssessmentStringValue.YES]: defineMessage({
+      defaultMessage: 'Correct',
+      description:
+        'Evaluation results > correctness assessment > positive value label. Displayed if evaluation result is considered as correct.',
+    }),
+    [KnownEvaluationResultAssessmentStringValue.NO]: defineMessage({
+      defaultMessage: 'Incorrect',
+      description:
+        'Evaluation results > correctness assessment > negative value label. Displayed if evaluation result is considered as incorrect.',
+    }),
+  },
+  [KnownEvaluationResultAssessmentName.SAFETY]: {
+    [KnownEvaluationResultAssessmentStringValue.YES]: defineMessage({
+      defaultMessage: 'Safe',
+      description:
+        'Evaluation results > safety assessment > positive value label. Displayed if evaluation result is considered as safe.',
+    }),
+    [KnownEvaluationResultAssessmentStringValue.NO]: defineMessage({
+      defaultMessage: 'Unsafe',
+      description:
+        'Evaluation results > safety assessment > negative value label. Displayed if evaluation result is considered as unsafe.',
+    }),
+  },
+  [KnownEvaluationResultAssessmentName.GUIDELINE_ADHERENCE]: {
+    [KnownEvaluationResultAssessmentStringValue.YES]: defineMessage({
+      defaultMessage: 'Adheres to guidelines',
+      description:
+        'Evaluation results > guideline adherence assessment > positive value label. Displayed if evaluation result adheres to the guidelines.',
+    }),
+    [KnownEvaluationResultAssessmentStringValue.NO]: defineMessage({
+      defaultMessage: 'Violates guidelines',
+      description:
+        'Evaluation results > guideline adherence assessment > negative value label. Displayed if evaluation result does not adhere to the guidelines.',
+    }),
+  },
+  [KnownEvaluationResultAssessmentName.GUIDELINES]: {
+    [KnownEvaluationResultAssessmentStringValue.YES]: defineMessage({
+      defaultMessage: 'Adheres to guidelines',
+      description:
+        'Evaluation results > guidelines assessment > positive value label. Displayed if evaluation result adheres to the guidelines.',
+    }),
+    [KnownEvaluationResultAssessmentStringValue.NO]: defineMessage({
+      defaultMessage: 'Violates guidelines',
+      description:
+        'Evaluation results > guidelines assessment > negative value label. Displayed if evaluation result does not adhere to the guidelines.',
+    }),
+  },
+  [KnownEvaluationResultAssessmentName.GLOBAL_GUIDELINE_ADHERENCE]: {
+    [KnownEvaluationResultAssessmentStringValue.YES]: defineMessage({
+      defaultMessage: 'Adheres to global guidelines',
+      description:
+        'Evaluation results > global guideline adherence assessment > positive value label. Displayed if evaluation result adheres to the global guidelines.',
+    }),
+    [KnownEvaluationResultAssessmentStringValue.NO]: defineMessage({
+      defaultMessage: 'Violates global guidelines',
+      description:
+        'Evaluation results > global guideline adherence assessment > negative value label. Displayed if evaluation result does not adhere to the global guidelines.',
+    }),
+  },
+  [KnownEvaluationResultAssessmentName.CONVERSATIONAL_GUIDELINES]: {
+    [KnownEvaluationResultAssessmentStringValue.YES]: defineMessage({
+      defaultMessage: 'Adheres to guidelines',
+      description:
+        'Evaluation results > conversational guidelines assessment > positive value label. Displayed if the assistant adheres to guidelines throughout the conversation.',
+    }),
+    [KnownEvaluationResultAssessmentStringValue.NO]: defineMessage({
+      defaultMessage: 'Violates guidelines',
+      description:
+        'Evaluation results > conversational guidelines assessment > negative value label. Displayed if the assistant violates guidelines at any point in the conversation.',
+    }),
+  },
+};
+
+const isAssessmentAiGenerated = (assessment: RunEvaluationResultAssessment) => {
+  return assessment?.source?.sourceType === 'AI_JUDGE';
+};
+
+/**
+ * Returns the title for the given evaluation result.
+ * If the evaluation has an input request, it will be used as the title. Otherwise, the evaluation ID will be used.
+ * Stringifies the value if it's an object or an array.
+ */
+export const getEvaluationResultTitle = (evaluation: RunEvaluationTracesDataEntry): string => {
+  // Use the request as the title if defined.
+  let title = getEvaluationResultInputTitle(evaluation, INPUT_REQUEST_KEY);
+
+  if (isNil(title)) {
+    title = getEvaluationResultInputTitle(evaluation, INPUT_MESSAGES_KEY);
+  }
+
+  // If the title is still undefined, JSON-serialize the inputs.
+  if (isNil(title) && !isNil(evaluation.inputs) && Object.keys(evaluation.inputs).length > 0) {
+    title = stringifyValue(evaluation.inputs);
+  }
+
+  if (isNil(title) || title === '') {
+    title = evaluation.evaluationId;
+  }
+
+  return title;
+};
+
+/**
+ * Returns the title for the given evaluation result and input key.
+ * This is different than getEvaluationResultTitle in that it computes a title per input key. getEvaluationResultTitle returns a title for the
+ * whole row (used in the header of an evaluation modal).
+ */
+export const getEvaluationResultInputTitle = (
+  evaluation: RunEvaluationTracesDataEntry,
+  inputKey: string,
+): string | undefined => {
+  if (!isNil(evaluation.inputsTitle)) {
+    return typeof evaluation.inputsTitle === 'string' ? evaluation.inputsTitle : JSON.stringify(evaluation.inputsTitle);
+  }
+  // Use the request as the title if defined.
+  let title: string | undefined = undefined;
+  // Use the last message content as the title if defined.
+  const input = evaluation.inputs[inputKey];
+  if (
+    isPlainObject(input) &&
+    !isNil(input[INPUT_MESSAGES_KEY]) &&
+    Array.isArray(input[INPUT_MESSAGES_KEY]) &&
+    !isNil(input[INPUT_MESSAGES_KEY][0]?.content)
+  ) {
+    title = input[INPUT_MESSAGES_KEY][input[INPUT_MESSAGES_KEY].length - 1]?.content;
+  } else if (!isNil(input) && Array.isArray(input) && !isNil(input[0]?.content)) {
+    // Try to parse OpenAI messages.
+    title = input[input.length - 1]?.content;
+  } else if (input) {
+    const extractedContent = tryExtractUserMessageContent(input);
+    title = extractedContent ?? stringifyValue(input);
+  }
+
+  return title;
+};
+
+export const isEvaluationResultOverallAssessment = (assessmentEntry: RunEvaluationResultAssessment) =>
+  assessmentEntry.metadata?.[KnownEvaluationResultAssessmentMetadataFields.IS_OVERALL_ASSESSMENT] === true;
+
+export const isEvaluationResultPerRetrievalChunkAssessment = (assessmentEntry: RunEvaluationResultAssessment) =>
+  isNumber(assessmentEntry.metadata?.[KnownEvaluationResultAssessmentMetadataFields.CHUNK_INDEX]);
+
+export const getEvaluationResultAssessmentValue = (
+  assessment: RunEvaluationResultAssessment,
+): AssessmentValueType | undefined => {
+  const value = assessment.stringValue ?? assessment.numericValue ?? assessment.booleanValue;
+  if (isNil(value)) {
+    return undefined;
+  }
+  return value;
+};
+
+/**
+ * Add alpha channel to the given hex color.
+ */
+export function withAlpha(hexColor: string, opacity: number): string {
+  let color = hexColor;
+  const startsWithHash = color.startsWith('#');
+  if (startsWithHash) {
+    color = hexColor.slice(1);
+  }
+  const alpha = Math.round(Math.min(Math.max(opacity, 0), 1) * 255);
+  const hexAlpha = alpha.toString(16).toUpperCase();
+  return `${startsWithHash ? '#' : ''}${color}${hexAlpha}`;
+}
+
+/**
+ * A list of known response assessment names, used to populate suggestions
+ */
+export const KnownEvaluationResponseAssessmentNames = [
+  KnownEvaluationResultAssessmentName.GUIDELINE_ADHERENCE,
+  KnownEvaluationResultAssessmentName.GUIDELINES,
+  KnownEvaluationResultAssessmentName.GLOBAL_GUIDELINE_ADHERENCE,
+  KnownEvaluationResultAssessmentName.RELEVANCE_TO_QUERY,
+  KnownEvaluationResultAssessmentName.CONTEXT_SUFFICIENCY,
+  KnownEvaluationResultAssessmentName.RETRIEVAL_SUFFICIENCY,
+  KnownEvaluationResultAssessmentName.CORRECTNESS,
+  KnownEvaluationResultAssessmentName.GROUNDEDNESS,
+  KnownEvaluationResultAssessmentName.RETRIEVAL_GROUNDEDNESS,
+  KnownEvaluationResultAssessmentName.SAFETY,
+];
+
+/**
+ * A list of known retrieval assessment names, used to populate suggestions
+ */
+export const KnownEvaluationRetrievalAssessmentNames = [KnownEvaluationResultAssessmentName.CHUNK_RELEVANCE];
+
+/**
+ * Creates a draft assessment object with the given values.
+ */
+export const createDraftEvaluationResultAssessmentObject = ({
+  name,
+  isOverallAssessment,
+  value,
+  rationale,
+  metadata = {},
+}: {
+  isOverallAssessment: boolean;
+  name: string;
+  value: string | boolean;
+  rationale?: string;
+  metadata?: RunEvaluationResultAssessment['metadata'];
+}): RunEvaluationResultAssessmentDraft => {
+  // Use current user's email to set as source ID
+  const sourceId = getUser() ?? '';
+
+  const resultMetadata = isOverallAssessment
+    ? { ...metadata, [KnownEvaluationResultAssessmentMetadataFields.IS_OVERALL_ASSESSMENT]: true }
+    : metadata;
+
+  const booleanValue = typeof value === 'boolean' ? value : null;
+  const stringValue = typeof value !== 'boolean' ? value : null;
+
+  return {
+    booleanValue: booleanValue,
+    numericValue: null,
+    stringValue: stringValue,
+    name,
+    metadata: resultMetadata,
+    rationale: rationale ?? null,
+    source: {
+      sourceId,
+      sourceType: 'HUMAN',
+      metadata: {},
+    },
+    timestamp: Date.now(),
+    isDraft: true,
+  };
+};
+
+export const shouldRepeatExistingOriginalOverallAiAssessment = (
+  sourceEvaluationResult: RunEvaluationTracesDataEntry,
+  pendingAssessmentEntries: RunEvaluationResultAssessmentDraft[],
+) =>
+  sourceEvaluationResult.overallAssessments.length > 0 &&
+  sourceEvaluationResult.overallAssessments.every(isAssessmentAiGenerated) &&
+  !pendingAssessmentEntries.some(isEvaluationResultOverallAssessment);
+
+export const copyAiOverallAssessmentAsHumanAssessment = (
+  sourceEvaluationResult: RunEvaluationTracesDataEntry,
+): RunEvaluationResultAssessmentDraft | null => {
+  const firstAiOverallAssessment = sourceEvaluationResult.overallAssessments.find(isAssessmentAiGenerated);
+
+  if (!firstAiOverallAssessment) {
+    return null;
+  }
+
+  const sourceId = getUser() ?? '';
+
+  return {
+    ...firstAiOverallAssessment,
+    timestamp: Date.now(),
+    isDraft: true,
+    source: {
+      sourceType: 'HUMAN',
+      sourceId,
+      metadata: {},
+    },
+    metadata: {
+      ...firstAiOverallAssessment.metadata,
+      // Explicitly marking it as reviewed to indicate this assessment is copied from AI
+      [KnownEvaluationResultAssessmentMetadataFields.IS_COPIED_FROM_AI]: true,
+    },
+  };
+};
+
+export const isDraftAssessment = (
+  assessment: RunEvaluationResultAssessment | RunEvaluationResultAssessmentDraft,
+): assessment is RunEvaluationResultAssessmentDraft => 'isDraft' in assessment && assessment.isDraft;
+
+/**
+ * Returns a list of detailed assessments.
+ *
+ * For well-known assessments, the list is sorted based on the known stable order;
+ * for other assessments, the list is sorted based on the timestamp of the first appearance
+ * of the assessment (last item in the group).
+ */
+export const getOrderedAssessments = (assessmentsByName: Record<string, RunEvaluationResultAssessment[]>) =>
+  orderBy(Object.entries(assessmentsByName), ([key, assessments], index) => {
+    // If we're dealing with a known detailed assessment, we want to sort it based on its index in the known names list
+    // so its position is stable
+    const indexInKnownNames = DEFAULT_ASSESSMENTS_SORT_ORDER.indexOf(key as KnownEvaluationResultAssessmentName);
+
+    if (indexInKnownNames !== -1) {
+      // If it's a known detailed assessment, sort by its index in the known names list
+      return indexInKnownNames;
+    } else {
+      // Otherwise, sort by the timestamp of the last item in the group
+      return assessments[assessments.length - 1]?.timestamp ?? index;
+    }
+  });
+
+export const isEvaluationResultReviewedAlready = (evaluationResult: RunEvaluationTracesDataEntry) =>
+  evaluationResult.overallAssessments
+    ?.filter((assessment) => !isDraftAssessment(assessment))
+    .some((assessment) => !isAssessmentAiGenerated(assessment)) ?? false;
+
+export const hasBeenEditedByHuman = (assessment: RunEvaluationResultAssessment) =>
+  // It is not AI generated, and it doesn't have the `IS_FROM_AI` metadata field set to true
+  assessment.source?.sourceType === 'HUMAN' &&
+  !assessment.metadata?.[KnownEvaluationResultAssessmentMetadataFields.IS_COPIED_FROM_AI];
+
+export const getEvaluationResultAssessmentChunkIndex = (assessment: RunEvaluationResultAssessment) =>
+  assessment.metadata?.[KnownEvaluationResultAssessmentMetadataFields.CHUNK_INDEX];
+
+// Auto select the first non-empty evaluation ID if no evaluation ID is selected
+export const autoSelectFirstNonEmptyEvaluationId = (
+  evaluationResults: RunEvaluationTracesDataEntry[] | null,
+  selectedEvaluationId: string | undefined,
+  setSelectedEvaluationId: (evaluationId: string | undefined) => void,
+) => {
+  if (!selectedEvaluationId && evaluationResults) {
+    // Find first non-empty evaluationId in data
+    const firstNonEmpty = evaluationResults.find((evaluation) => evaluation.evaluationId);
+    if (firstNonEmpty) {
+      setSelectedEvaluationId(firstNonEmpty.evaluationId);
+    }
+  }
+};
+
+/**
+ * Converts the given value to a string if it's an object or an array.
+ */
+export const stringifyValue = (value: any) => {
+  return isPlainObject(value) || Array.isArray(value) ? JSON.stringify(value, undefined, 2) : value;
+};
+
+/**
+ * Utility function: generates suggestions for the assessment values based on original assessment and options.
+ */
+export const getAssessmentValueSuggestions = (
+  intl: IntlShape,
+  originalAssessment?: RunEvaluationResultAssessment,
+  assessmentHistory?: RunEvaluationResultAssessment[],
+  assessmentInfos?: AssessmentInfo[],
+) => {
+  // If we're starting with an existing assessment, we should suggest the values that are relevant to it.
+  if (originalAssessment) {
+    const mapping = KnownEvaluationResultAssessmentValueMapping[originalAssessment.name];
+    if (!mapping) {
+      return [];
+    }
+
+    return Object.entries(mapping).map(([key, value]) => {
+      return { key, label: intl.formatMessage(value), rootAssessmentName: originalAssessment.name };
+    });
+  }
+
+  // If we're starting with a new assessment, we only suggest 'boolean' values and a new value.
+  return (assessmentInfos || [])
+    .filter((assessmentInfo) => assessmentInfo.dtype === 'boolean')
+    .map((assessmentInfo) => ({
+      key: assessmentInfo.name,
+      label: assessmentInfo.name,
+      rootAssessmentName: assessmentInfo.name,
+      // Disabled when the assessment already exists.
+      disabled: assessmentHistory?.some((assessment) => assessment.name === assessmentInfo.name),
+    }));
+};
+
+/**
+ * Returns true if the assessment is missing.
+ * An assessment is considered missing if it doesn't have a value, rationale or error message.
+ */
+export const isAssessmentMissing = (assessment?: RunEvaluationResultAssessment) => {
+  if (!assessment) {
+    return false;
+  } else {
+    const hasRationale = Boolean(assessment.rationale);
+    const hasValue = !isNil(getEvaluationResultAssessmentValue(assessment));
+    const hasErrorMessage = Boolean(assessment.errorMessage);
+    return !(hasRationale || hasValue || hasErrorMessage);
+  }
+};
+
+/**
+ * Checks if the given value is a retrieved context.
+ * A retrieved context is a list of objects with a `doc_uri` and `content` field.
+ */
+export const isRetrievedContext = (value: any): boolean => {
+  return Array.isArray(value) && value.every((v) => isPlainObject(v) && 'doc_uri' in v && 'content' in v);
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/components/GenAiEvaluationTracesReviewModal.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/components/GenAiEvaluationTracesReviewModal.tsx
@@ -1,0 +1,506 @@
+import { isNil } from 'lodash';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+
+import {
+  Button,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  GenericSkeleton,
+  LinkIcon,
+  Modal,
+  Notification,
+  Tooltip,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
+import { FormattedMessage } from '@databricks/i18n';
+import { isV3ModelTraceInfo, isV4TraceId } from '../../model-trace-explorer/ModelTraceExplorer.utils';
+import { ModelTraceExplorer } from '../../model-trace-explorer/ModelTraceExplorer';
+import { ModelTraceExplorerDrawer } from '../../model-trace-explorer/ModelTraceExplorerDrawer';
+import { ModelTraceExplorerSkeleton } from '../../model-trace-explorer/ModelTraceExplorerSkeleton';
+import { shouldUseModelTraceExplorerDrawerUI } from '../../model-trace-explorer/FeatureUtils';
+import { useModelTraceExplorerContext } from '../../model-trace-explorer/ModelTraceExplorerContext';
+import type { ModelTrace } from '../../model-trace-explorer/ModelTrace.types';
+
+import { EvaluationsReviewDetailsHeader } from './EvaluationsReviewDetails';
+import { GenAiEvaluationTracesReview } from './GenAiEvaluationTracesReview';
+import { GenAITracesTableContext } from '../GenAITracesTableContext';
+import { useGenAITracesTableConfig } from '../hooks/useGenAITracesTableConfig';
+import type { GetTraceFunction } from '../hooks/useGetTrace';
+import { useGetTrace, useGetTraceByFullTraceId } from '../hooks/useGetTrace';
+import type {
+  AssessmentInfo,
+  EvalTraceComparisonEntry,
+  RunEvaluationTracesDataEntry,
+  SaveAssessmentsQuery,
+} from '../types';
+import { convertTraceInfoV3ToRunEvalEntry, getSpansLocation, TRACKING_STORE_SPANS_LOCATION } from '../utils/TraceUtils';
+
+const MODAL_SPACING_REM = 4;
+const DEFAULT_MODAL_MARGIN_REM = 1;
+
+const evalEntryMatchesEvaluationId = (evaluationId: string, entry?: RunEvaluationTracesDataEntry) => {
+  if (isV4TraceId(evaluationId) && entry?.fullTraceId === evaluationId) {
+    return true;
+  }
+  return entry?.evaluationId === evaluationId;
+};
+
+export const GenAiEvaluationTracesReviewModal = React.memo(
+  // eslint-disable-next-line react-component-name/react-component-name -- TODO(FEINF-4716)
+  ({
+    experimentId,
+    runUuid,
+    evaluations,
+    selectedEvaluationId,
+    onChangeEvaluationId,
+    runDisplayName,
+    otherRunDisplayName,
+    exportToEvalsInstanceEnabled = false,
+    assessmentInfos,
+    getTrace,
+    saveAssessmentsQuery,
+  }: {
+    experimentId: string;
+    runUuid?: string;
+    evaluations: EvalTraceComparisonEntry[];
+    selectedEvaluationId: string;
+    onChangeEvaluationId: (evaluationId: string | undefined) => void;
+    runDisplayName?: string;
+    otherRunDisplayName?: string;
+    exportToEvalsInstanceEnabled?: boolean;
+    assessmentInfos: AssessmentInfo[];
+    getTrace?: GetTraceFunction;
+    saveAssessmentsQuery?: SaveAssessmentsQuery;
+  }) => {
+    const { theme } = useDesignSystemTheme();
+    const [showAddToEvaluationDatasetModal, setShowAddToEvaluationDatasetModal] = useState(false);
+
+    const handleClose = useCallback(() => {
+      onChangeEvaluationId(undefined);
+    }, [onChangeEvaluationId]);
+
+    // The URL always has an evaluation id, so we look in either current or other for the eval.
+    const findEval = useCallback(
+      (entry: EvalTraceComparisonEntry) =>
+        evalEntryMatchesEvaluationId(selectedEvaluationId, entry.currentRunValue) ||
+        evalEntryMatchesEvaluationId(selectedEvaluationId, entry.otherRunValue),
+      [selectedEvaluationId],
+    );
+
+    const previousEvaluationIdx = useMemo(
+      () => (evaluations ? evaluations?.findIndex(findEval) - 1 : undefined),
+      [evaluations, findEval],
+    );
+    const isPreviousAvailable = useMemo(
+      () => previousEvaluationIdx !== undefined && previousEvaluationIdx >= 0,
+      [previousEvaluationIdx],
+    );
+
+    const nextEvaluationIdx = useMemo(
+      () => (evaluations ? evaluations?.findIndex(findEval) + 1 : undefined),
+      [evaluations, findEval],
+    );
+    const isNextAvailable = useMemo(
+      () => nextEvaluationIdx !== undefined && nextEvaluationIdx < evaluations.length,
+      [nextEvaluationIdx, evaluations],
+    );
+
+    const selectPreviousEval = useCallback(() => {
+      if (evaluations === null || previousEvaluationIdx === undefined) return;
+
+      const newEvalId =
+        evaluations[previousEvaluationIdx]?.currentRunValue?.evaluationId ||
+        evaluations[previousEvaluationIdx]?.otherRunValue?.evaluationId;
+      onChangeEvaluationId(newEvalId);
+    }, [evaluations, previousEvaluationIdx, onChangeEvaluationId]);
+
+    const { renderExportTracesToDatasetsModal } = useModelTraceExplorerContext();
+
+    const selectNextEval = useCallback(() => {
+      if (evaluations === null || nextEvaluationIdx === undefined) return;
+
+      const newEvalId =
+        evaluations[nextEvaluationIdx]?.currentRunValue?.evaluationId ||
+        evaluations[nextEvaluationIdx]?.otherRunValue?.evaluationId;
+      onChangeEvaluationId(newEvalId);
+    }, [evaluations, nextEvaluationIdx, onChangeEvaluationId]);
+
+    const evaluation = useMemo(() => evaluations?.find(findEval), [evaluations, findEval]);
+    const nextEvaluation = useMemo(
+      () => (nextEvaluationIdx && evaluations ? evaluations?.[nextEvaluationIdx] : undefined),
+      [evaluations, nextEvaluationIdx],
+    );
+    const previousEvaluation = useMemo(
+      () => (previousEvaluationIdx && evaluations ? evaluations?.[previousEvaluationIdx] : undefined),
+      [evaluations, previousEvaluationIdx],
+    );
+
+    const tracesTableConfig = useGenAITracesTableConfig();
+
+    // --- Auto-polling until trace is complete if the backend supports returning partial spans ---
+    const spansLocation = getSpansLocation(evaluation?.currentRunValue?.traceInfo);
+    const shouldEnablePolling = spansLocation === TRACKING_STORE_SPANS_LOCATION;
+
+    // prettier-ignore
+    const traceQueryResult = useGetTrace({
+      getTrace,
+      traceInfo:evaluation?.currentRunValue?.traceInfo,
+      enablePolling: shouldEnablePolling,
+    });
+    // prettier-ignore
+    const compareToTraceQueryResult = useGetTrace({
+      getTrace,
+      traceInfo:evaluation?.otherRunValue?.traceInfo,
+      enablePolling: shouldEnablePolling,
+    });
+    // In case that the selected evaluation is not provided upstream (but the list is loaded), we lazily fetch the full trace data here
+    const shouldFetchTraceBySearchParamId = useMemo(
+      () => Boolean(evaluations) && !evaluation && Boolean(selectedEvaluationId),
+      [evaluations, evaluation, selectedEvaluationId],
+    );
+
+    const traceBySearchParamQueryResult = useGetTraceByFullTraceId(
+      getTrace,
+      shouldFetchTraceBySearchParamId ? selectedEvaluationId : undefined,
+    );
+
+    // Prefetching the next and previous traces to optimize performance
+    // prettier-ignore
+    useGetTrace({
+      getTrace,
+      traceInfo: nextEvaluation?.currentRunValue?.traceInfo,
+    });
+    // prettier-ignore
+    useGetTrace({
+      getTrace,
+      traceInfo: previousEvaluation?.currentRunValue?.traceInfo,
+    });
+
+    // is true if only one of the two runs has a trace
+    const isSingleTraceView = Boolean(evaluation?.currentRunValue) !== Boolean(evaluation?.otherRunValue);
+
+    const currentTraceQueryResult = shouldFetchTraceBySearchParamId
+      ? traceBySearchParamQueryResult
+      : evalEntryMatchesEvaluationId(selectedEvaluationId, evaluation?.currentRunValue)
+        ? traceQueryResult
+        : compareToTraceQueryResult;
+
+    if (isNil(evaluation) && !shouldFetchTraceBySearchParamId) {
+      return <></>;
+    }
+
+    const renderModalTitle = () => {
+      if (shouldFetchTraceBySearchParamId) {
+        if (traceBySearchParamQueryResult.isLoading) {
+          return (
+            <GenericSkeleton
+              css={{
+                width: 200,
+                height: theme.general.heightBase,
+              }}
+            />
+          );
+        }
+        if (traceBySearchParamQueryResult.data?.info && isV3ModelTraceInfo(traceBySearchParamQueryResult.data?.info)) {
+          const runEvalEntry = convertTraceInfoV3ToRunEvalEntry(traceBySearchParamQueryResult.data?.info);
+          return <EvaluationsReviewDetailsHeader evaluationResult={runEvalEntry} />;
+        }
+      }
+      return evaluation?.currentRunValue ? (
+        <EvaluationsReviewDetailsHeader evaluationResult={evaluation.currentRunValue} />
+      ) : evaluation?.otherRunValue ? (
+        <EvaluationsReviewDetailsHeader evaluationResult={evaluation.otherRunValue} />
+      ) : null;
+    };
+
+    const currentTraceInfo = evaluation?.currentRunValue?.traceInfo;
+
+    // Define the content of the modal/drawer
+    const content = (
+      <>
+        {/* Only show skeleton for the first fetch to avoid flickering when polling new spans */}
+        {!shouldUseModelTraceExplorerDrawerUI() &&
+          !currentTraceQueryResult.data &&
+          currentTraceQueryResult.isLoading && (
+            <GenericSkeleton
+              label="Loading trace..."
+              style={{
+                // Size the width and height to fit the modal content area
+                width: 'calc(100% - 45px)',
+                height: 'calc(100% - 100px)',
+                position: 'absolute',
+                paddingRight: 500,
+                zIndex: 2100,
+                backgroundColor: theme.colors.backgroundPrimary,
+              }}
+            />
+          )}
+        {
+          // Show ModelTraceExplorer only if there is no run to compare to and there's trace data.
+          ((shouldFetchTraceBySearchParamId && traceBySearchParamQueryResult?.data) || isSingleTraceView) &&
+          !isNil(currentTraceQueryResult.data) ? (
+            <div
+              css={{
+                height: '100%',
+                marginLeft: -theme.spacing.lg,
+                marginRight: -theme.spacing.lg,
+                marginBottom: -theme.spacing.lg,
+                display: 'flex',
+                flexDirection: 'column',
+              }}
+            >
+              {/* prettier-ignore */}
+              <ModelTraceExplorerModalBody
+                traceData={currentTraceQueryResult.data}
+              />
+            </div>
+          ) : (
+            evaluation?.currentRunValue &&
+            (shouldUseModelTraceExplorerDrawerUI() && currentTraceQueryResult.isLoading ? (
+              <div css={{ marginLeft: -theme.spacing.lg, marginRight: -theme.spacing.lg }}>
+                <ModelTraceExplorerSkeleton />
+              </div>
+            ) : (
+              <div
+                css={
+                  shouldUseModelTraceExplorerDrawerUI() ? { overflow: 'auto', height: '100%' } : { display: 'contents' }
+                }
+              >
+                <GenAiEvaluationTracesReview
+                  experimentId={experimentId}
+                  evaluation={evaluation.currentRunValue}
+                  otherEvaluation={evaluation.otherRunValue}
+                  selectNextEval={selectNextEval}
+                  isNextAvailable={isNextAvailable}
+                  css={{ flex: 1, overflow: 'hidden' }}
+                  runUuid={runUuid}
+                  isReadOnly={!tracesTableConfig.enableRunEvaluationWriteFeatures}
+                  runDisplayName={runDisplayName}
+                  compareToRunDisplayName={otherRunDisplayName}
+                  exportToEvalsInstanceEnabled={exportToEvalsInstanceEnabled}
+                  assessmentInfos={assessmentInfos}
+                  traceQueryResult={traceQueryResult}
+                  compareToTraceQueryResult={compareToTraceQueryResult}
+                  saveAssessmentsQuery={saveAssessmentsQuery}
+                />
+              </div>
+            ))
+          )
+        }
+      </>
+    );
+
+    // Use ModelTraceExplorerDrawer when feature flag is enabled, otherwise use legacy wrappers
+    if (shouldUseModelTraceExplorerDrawerUI()) {
+      return (
+        <ModelTraceExplorerDrawer
+          handleClose={handleClose}
+          isNextAvailable={isNextAvailable}
+          isPreviousAvailable={isPreviousAvailable}
+          selectNextEval={selectNextEval}
+          selectPreviousEval={selectPreviousEval}
+          renderModalTitle={renderModalTitle}
+          isLoading={currentTraceQueryResult.isLoading}
+          experimentId={experimentId}
+          traceInfo={currentTraceInfo}
+        >
+          {content}
+        </ModelTraceExplorerDrawer>
+      );
+    }
+
+    // Legacy modal wrapper
+    return (
+      <ModalWrapper
+        handleClose={handleClose}
+        isNextAvailable={isNextAvailable}
+        isPreviousAvailable={isPreviousAvailable}
+        selectNextEval={selectNextEval}
+        selectPreviousEval={selectPreviousEval}
+        renderModalTitle={renderModalTitle}
+      >
+        {content}
+        {renderExportTracesToDatasetsModal?.({
+          experimentId,
+          visible: showAddToEvaluationDatasetModal,
+          setVisible: setShowAddToEvaluationDatasetModal,
+          selectedTraceInfos: evaluation?.currentRunValue?.traceInfo ? [evaluation.currentRunValue.traceInfo] : [],
+        })}
+      </ModalWrapper>
+    );
+  },
+);
+
+const ModalWrapper = ({
+  selectPreviousEval,
+  selectNextEval,
+  isPreviousAvailable,
+  isNextAvailable,
+  renderModalTitle,
+  handleClose,
+  children,
+}: {
+  children: React.ReactNode;
+  selectPreviousEval: () => void;
+  selectNextEval: () => void;
+  isPreviousAvailable: boolean;
+  isNextAvailable: boolean;
+  renderModalTitle: () => React.ReactNode;
+  handleClose: () => void;
+}) => {
+  const { theme, classNamePrefix } = useDesignSystemTheme();
+  const useRadixModal = false;
+  const [showCopiedNotification, setShowCopiedNotification] = useState(false);
+
+  const handleShareClick = useCallback(() => {
+    navigator.clipboard.writeText(window.location.href);
+    setShowCopiedNotification(true);
+    setTimeout(() => setShowCopiedNotification(false), 2000);
+  }, []);
+
+  return (
+    <div
+      onKeyDown={(e) => {
+        if (e.key === 'ArrowLeft') {
+          selectPreviousEval();
+        } else if (e.key === 'ArrowRight') {
+          selectNextEval();
+        }
+      }}
+    >
+      <Modal
+        componentId="mlflow.evaluations_review.modal"
+        visible
+        title={
+          <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm }}>
+            <div css={{ flex: 1, overflow: 'hidden' }}>{renderModalTitle()}</div>
+            <Tooltip
+              componentId="mlflow.evaluations_review.modal.share-tooltip"
+              content={
+                <FormattedMessage
+                  defaultMessage="Copy link to trace"
+                  description="Tooltip for the share trace button"
+                />
+              }
+            >
+              <Button
+                componentId="mlflow.evaluations_review.modal.share-button"
+                icon={<LinkIcon />}
+                size="small"
+                type="tertiary"
+                onClick={handleShareClick}
+                css={{ flexShrink: 0 }}
+              >
+                <FormattedMessage defaultMessage="Share" description="Label for the share trace button" />
+              </Button>
+            </Tooltip>
+          </div>
+        }
+        onCancel={handleClose}
+        size="wide"
+        verticalSizing="maxed_out"
+        css={{
+          width: '100% !important',
+          padding: useRadixModal ? undefined : `0 ${MODAL_SPACING_REM}rem !important`,
+          [`& .${classNamePrefix}-modal-body`]: {
+            flex: 1,
+            paddingTop: 0,
+          },
+          [`& .${classNamePrefix}-modal-header`]: {
+            paddingBottom: theme.spacing.sm,
+          },
+        }}
+        footer={null} // Hide the footer
+      >
+        {children}
+        <div
+          css={{
+            display: 'flex',
+            justifyContent: 'flex-end',
+            position: 'fixed',
+            top: '50%',
+            left: 0,
+            zIndex: 2000,
+            opacity: '.75',
+            width: `${MODAL_SPACING_REM + DEFAULT_MODAL_MARGIN_REM}rem`,
+            '&:hover': {
+              opacity: '1.0',
+            },
+          }}
+        >
+          <div
+            css={{
+              backgroundColor: theme.colors.backgroundPrimary,
+              borderRadius: theme.legacyBorders.borderRadiusMd,
+              marginRight: theme.spacing.sm,
+            }}
+          >
+            <Button
+              disabled={!isPreviousAvailable}
+              componentId="mlflow.evaluations_review.modal.previous_eval"
+              icon={<ChevronLeftIcon />}
+              onClick={() => selectPreviousEval()}
+            />
+          </div>
+        </div>
+        <div
+          css={{
+            display: 'flex',
+            justifyContent: 'flex-start',
+            position: 'fixed',
+            top: '50%',
+            right: 0,
+            zIndex: 2000,
+            width: `${MODAL_SPACING_REM + DEFAULT_MODAL_MARGIN_REM}rem`,
+            opacity: '.75',
+            '&:hover': {
+              opacity: '1.0',
+            },
+          }}
+        >
+          <div
+            css={{
+              backgroundColor: theme.colors.backgroundPrimary,
+              borderRadius: theme.legacyBorders.borderRadiusMd,
+              marginLeft: theme.spacing.sm,
+            }}
+          >
+            <Button
+              disabled={!isNextAvailable}
+              componentId="mlflow.evaluations_review.modal.next_eval"
+              icon={<ChevronRightIcon />}
+              onClick={(e) => selectNextEval()}
+            />
+          </div>
+        </div>
+      </Modal>
+      {showCopiedNotification && (
+        <Notification.Provider>
+          <Notification.Root severity="success" componentId="mlflow.evaluations_review.modal.share-notification">
+            <Notification.Title>
+              <FormattedMessage
+                defaultMessage="Copied to clipboard"
+                description="Success message after copying trace link"
+              />
+            </Notification.Title>
+          </Notification.Root>
+          <Notification.Viewport />
+        </Notification.Provider>
+      )}
+    </div>
+  );
+};
+
+// prettier-ignore
+const ModelTraceExplorerModalBody = ({
+  traceData,
+}: {
+  traceData: ModelTrace;
+}) => {
+  return (
+    <ModelTraceExplorer
+      modelTrace={traceData}
+    />
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/components/RunColorCircle.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/components/RunColorCircle.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+// eslint-disable-next-line react-component-name/react-component-name -- TODO(FEINF-4716)
+export const RunColorCircle = React.memo(({ color, hidden }: { color: string; hidden?: boolean }) => {
+  return (
+    <label
+      css={{
+        width: 12,
+        height: 12,
+        borderRadius: 6,
+        flexShrink: 0,
+        border: '1px solid rgba(0, 0, 0, 0.1)',
+        cursor: 'default',
+        position: 'relative',
+      }}
+      style={{
+        backgroundColor: color,
+        display: hidden ? 'none' : '',
+      }}
+    >
+      <span
+        css={{
+          clip: 'rect(0px, 0px, 0px, 0px)',
+          clipPath: 'inset(50%)',
+          height: '1px',
+          overflow: 'hidden',
+          position: 'absolute',
+          whiteSpace: 'nowrap',
+          width: '1px',
+        }}
+      >
+        {color}
+      </span>
+    </label>
+  );
+});

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/components/VerticalBar.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/components/VerticalBar.tsx
@@ -1,0 +1,13 @@
+import { useDesignSystemTheme } from '@databricks/design-system';
+
+export const VerticalBar = () => {
+  const { theme } = useDesignSystemTheme();
+  return (
+    <div
+      css={{
+        width: '1.5px',
+        backgroundColor: theme.colors.border,
+      }}
+    />
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/components/charts/AssessmentColumnSummary.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/components/charts/AssessmentColumnSummary.tsx
@@ -1,0 +1,172 @@
+import { isNil } from 'lodash';
+import React, { useMemo } from 'react';
+
+import type { ThemeType } from '@databricks/design-system';
+import type { IntlShape } from '@databricks/i18n';
+
+import { CategoricalAggregateChart } from './CategoricalAggregateChart';
+import { NumericAggregateChart } from './NumericAggregateChart';
+import {
+  type AssessmentAggregates,
+  type AssessmentFilter,
+  type AssessmentInfo,
+  type AssessmentValueType,
+} from '../../types';
+import { AGGREGATE_SCORE_CHANGE_BACKGROUND_COLORS, AGGREGATE_SCORE_CHANGE_TEXT_COLOR } from '../../utils/Colors';
+import { getDisplayOverallScoreAndChange } from '../../utils/DisplayUtils';
+import { withAlpha } from '../GenAiEvaluationTracesReview.utils';
+
+export const AssessmentColumnSummary = React.memo(
+  // eslint-disable-next-line react-component-name/react-component-name -- TODO(FEINF-4716)
+  ({
+    theme,
+    intl,
+    assessmentInfo,
+    assessmentAggregates,
+    allAssessmentFilters,
+    toggleAssessmentFilter,
+    currentRunDisplayName,
+    compareToRunDisplayName,
+    collapsedHeader,
+  }: {
+    theme: ThemeType;
+    intl: IntlShape;
+    assessmentInfo: AssessmentInfo;
+    assessmentAggregates: AssessmentAggregates;
+    allAssessmentFilters: AssessmentFilter[];
+    toggleAssessmentFilter: (
+      assessmentName: string,
+      filterValue: AssessmentValueType,
+      run: string,
+      filterType?: AssessmentFilter['filterType'],
+    ) => void;
+    currentRunDisplayName?: string;
+    compareToRunDisplayName?: string;
+    collapsedHeader?: boolean;
+  }) => {
+    const dtypeAggregateLabel = useMemo(() => {
+      if (assessmentInfo.dtype === 'pass-fail') {
+        return intl.formatMessage({
+          defaultMessage: 'PASS',
+          description: 'Header label for pass/fail assessment type for the pass rate',
+        });
+      } else if (assessmentInfo.dtype === 'boolean') {
+        return intl.formatMessage({
+          defaultMessage: 'TRUE',
+          description: 'Header label for boolean assessment type for the true rate',
+        });
+      } else if (assessmentInfo.dtype === 'string') {
+        return intl.formatMessage({
+          defaultMessage: 'STRING',
+          description: 'Header label for string assessment type',
+        });
+      } else if (assessmentInfo.dtype === 'numeric') {
+        return intl.formatMessage({
+          defaultMessage: 'AVG',
+          description: 'Header label for numeric assessment type for the average value',
+        });
+      }
+      return undefined;
+    }, [assessmentInfo, intl]);
+
+    /** Overall aggregate scores */
+    const { displayScore, displayScoreChange, changeDirection } = useMemo(
+      () => getDisplayOverallScoreAndChange(intl, assessmentInfo, assessmentAggregates),
+      [intl, assessmentInfo, assessmentAggregates],
+    );
+
+    if (assessmentInfo.dtype === 'unknown') {
+      return null;
+    }
+
+    return (
+      <div
+        css={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: theme.spacing.sm,
+        }}
+      >
+        <div
+          css={{
+            display: 'flex',
+            flexDirection: 'column',
+            paddingTop: theme.spacing.xs,
+          }}
+        >
+          {/* Aggregate label, e.g. "PASS" or "TRUE" */}
+          <div
+            css={{
+              fontWeight: 400,
+              fontSize: '10px',
+              color: theme.colors.textPlaceholder,
+            }}
+          >
+            {dtypeAggregateLabel}
+          </div>
+          {/* Overall score & diff */}
+          <div
+            css={{
+              display: 'flex',
+              gap: theme.spacing.xs,
+            }}
+          >
+            {/* Current run score */}
+            <div
+              css={{
+                fontSize: theme.typography.fontSizeLg,
+                color: theme.colors.textPrimary,
+                fontWeight: theme.typography.typographyBoldFontWeight,
+              }}
+            >
+              {displayScore}
+            </div>
+            {/* Diff score */}
+            {!isNil(displayScoreChange) && compareToRunDisplayName && (
+              <div
+                css={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  height: '20px',
+                  gap: theme.spacing.xs,
+                  padding: `2px ${theme.spacing.xs}px`,
+                  fontSize: theme.typography.fontSizeMd,
+                  fontWeight: 'normal',
+                  borderRadius: theme.general.borderRadiusBase,
+                  color: AGGREGATE_SCORE_CHANGE_TEXT_COLOR,
+                  backgroundColor:
+                    changeDirection === 'none'
+                      ? ''
+                      : changeDirection === 'up'
+                        ? AGGREGATE_SCORE_CHANGE_BACKGROUND_COLORS.up
+                        : changeDirection === 'down'
+                          ? AGGREGATE_SCORE_CHANGE_BACKGROUND_COLORS.down
+                          : withAlpha(theme.colors.textSecondary, 0.1),
+                }}
+              >
+                {displayScoreChange}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {!collapsedHeader &&
+          (!isNil(assessmentAggregates.currentNumericAggregate) ? (
+            <NumericAggregateChart numericAggregate={assessmentAggregates.currentNumericAggregate} />
+          ) : (
+            // Categorical charts
+            <CategoricalAggregateChart
+              theme={theme}
+              intl={intl}
+              assessmentInfo={assessmentInfo}
+              assessmentAggregates={assessmentAggregates}
+              allAssessmentFilters={allAssessmentFilters}
+              toggleAssessmentFilter={toggleAssessmentFilter}
+              currentRunDisplayName={currentRunDisplayName}
+              compareToRunDisplayName={compareToRunDisplayName}
+            />
+          ))}
+      </div>
+    );
+  },
+);

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/components/charts/CategoricalAggregateChart.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/components/charts/CategoricalAggregateChart.tsx
@@ -1,0 +1,362 @@
+import { isNil } from 'lodash';
+import React, { useMemo } from 'react';
+
+import { Popover, type ThemeType } from '@databricks/design-system';
+import type { IntlShape } from '@databricks/i18n';
+
+import {
+  type AssessmentAggregates,
+  type AssessmentFilter,
+  type AssessmentInfo,
+  type AssessmentValueType,
+} from '../../types';
+import { ERROR_KEY, getBarChartData } from '../../utils/AggregationUtils';
+import { getDisplayScore, getDisplayScoreChange } from '../../utils/DisplayUtils';
+
+const MAX_VISIBLE_ITEMS = 4;
+
+export const CategoricalAggregateChart = React.memo(
+  // eslint-disable-next-line react-component-name/react-component-name -- TODO(FEINF-4716)
+  ({
+    theme,
+    intl,
+    assessmentInfo,
+    assessmentAggregates,
+    allAssessmentFilters,
+    toggleAssessmentFilter,
+    currentRunDisplayName,
+    compareToRunDisplayName,
+  }: {
+    theme: ThemeType;
+    intl: IntlShape;
+    assessmentInfo: AssessmentInfo;
+    assessmentAggregates: AssessmentAggregates;
+    allAssessmentFilters: AssessmentFilter[];
+    toggleAssessmentFilter: (
+      assessmentName: string,
+      filterValue: AssessmentValueType,
+      run: string,
+      filterType?: AssessmentFilter['filterType'],
+    ) => void;
+    currentRunDisplayName?: string;
+    compareToRunDisplayName?: string;
+  }) => {
+    /** Bar data */
+    const barChartData = useMemo(
+      () =>
+        getBarChartData(
+          intl,
+          theme,
+          assessmentInfo,
+          allAssessmentFilters,
+          toggleAssessmentFilter,
+          assessmentAggregates,
+          currentRunDisplayName,
+          compareToRunDisplayName,
+        ),
+      [
+        intl,
+        theme,
+        assessmentInfo,
+        allAssessmentFilters,
+        toggleAssessmentFilter,
+        assessmentAggregates,
+        currentRunDisplayName,
+        compareToRunDisplayName,
+      ],
+    );
+
+    // Sort barChartData: most frequent first, ties resolved by original order, error and null entries at bottom
+    const sortedBarChartData = useMemo(() => {
+      // Keep original order for pass-fail and boolean assessments
+      if (assessmentInfo.dtype === 'pass-fail' || assessmentInfo.dtype === 'boolean') {
+        return barChartData;
+      }
+
+      return barChartData
+        .map((item, originalIndex) => ({ ...item, originalIndex }))
+        .sort((a, b) => {
+          const aIsBottomEntry = a.name === 'null' || a.name === ERROR_KEY;
+          const bIsBottomEntry = b.name === 'null' || b.name === ERROR_KEY;
+
+          // Always put error and null entries at the bottom
+          if (aIsBottomEntry && !bIsBottomEntry) return 1;
+          if (bIsBottomEntry && !aIsBottomEntry) return -1;
+
+          // Sort regular entries by frequency (current.value) in descending order
+          if (!aIsBottomEntry && !bIsBottomEntry) {
+            const valueComparison = (b.current?.value || 0) - (a.current?.value || 0);
+            if (valueComparison !== 0) return valueComparison;
+          }
+
+          // Resolve ties by original order
+          return a.originalIndex - b.originalIndex;
+        });
+    }, [barChartData, assessmentInfo]);
+
+    // If there's more than MAX_VISIBLE_ITEMS, show a popover with the <MAX_VISIBLE_ITEMS>th item and the rest
+    const visibleItems =
+      sortedBarChartData.length > MAX_VISIBLE_ITEMS
+        ? sortedBarChartData.slice(0, MAX_VISIBLE_ITEMS - 1)
+        : sortedBarChartData;
+    const hiddenItems =
+      sortedBarChartData.length > MAX_VISIBLE_ITEMS ? sortedBarChartData.slice(MAX_VISIBLE_ITEMS - 1) : [];
+    const hasMoreItems = hiddenItems.length > 0;
+
+    const hoverBarColor = theme.colors.actionDefaultBackgroundHover;
+    const selectedBarColor = theme.colors.actionDefaultBackgroundPress;
+
+    return (
+      <table>
+        <tbody>
+          {visibleItems.map((barData) => (
+            <ChartRow
+              key={barData.name}
+              barData={barData}
+              theme={theme}
+              hoverBarColor={hoverBarColor}
+              selectedBarColor={selectedBarColor}
+              assessmentInfo={assessmentInfo}
+            />
+          ))}
+          {hasMoreItems && (
+            <tr>
+              <td colSpan={2}>
+                <Popover.Root componentId="categorical-aggregate-chart-more-items">
+                  <Popover.Trigger asChild>
+                    <div
+                      css={{
+                        cursor: 'pointer',
+                        padding: `${theme.spacing.xs}px`,
+                        color: theme.colors.actionLinkDefault,
+                        fontSize: theme.typography.fontSizeSm,
+                        fontWeight: 'normal',
+                        ':hover': {
+                          backgroundColor: hoverBarColor,
+                        },
+                        borderRadius: theme.general.borderRadiusBase,
+                      }}
+                    >
+                      {intl.formatMessage(
+                        {
+                          defaultMessage: '+{count} more',
+                          description:
+                            'Message for the popover trigger to show more items in the categorical aggregate chart.',
+                        },
+                        { count: hiddenItems.length },
+                      )}
+                    </div>
+                  </Popover.Trigger>
+                  <Popover.Content
+                    align="start"
+                    side="bottom"
+                    css={{
+                      maxHeight: '200px',
+                      overflowY: 'auto',
+                      width: '200px',
+                      minWidth: '200px',
+                    }}
+                  >
+                    <table>
+                      <tbody>
+                        {hiddenItems.map((barData) => (
+                          <ChartRow
+                            key={barData.name}
+                            barData={barData}
+                            theme={theme}
+                            hoverBarColor={hoverBarColor}
+                            selectedBarColor={selectedBarColor}
+                            assessmentInfo={assessmentInfo}
+                          />
+                        ))}
+                      </tbody>
+                    </table>
+                  </Popover.Content>
+                </Popover.Root>
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    );
+  },
+);
+
+const ChartRow = ({
+  barData,
+  theme,
+  hoverBarColor,
+  selectedBarColor,
+  assessmentInfo,
+}: {
+  barData: any;
+  theme: ThemeType;
+  hoverBarColor: string;
+  selectedBarColor: string;
+  assessmentInfo: AssessmentInfo;
+}) => {
+  const isError = barData.name === ERROR_KEY;
+  const isNull = barData.name === 'null';
+
+  if (isError || isNull) {
+    return (
+      <tr
+        key={barData.name}
+        css={{
+          cursor: 'pointer',
+          ':hover': {
+            backgroundColor: hoverBarColor,
+          },
+          color: isError ? theme.colors.textValidationWarning : theme.colors.textSecondary,
+          fontWeight: 'normal',
+          fontSize: theme.typography.fontSizeSm,
+        }}
+        onClick={barData.current.toggleFilter}
+      >
+        <td
+          css={{
+            width: '100%',
+            borderTopLeftRadius: theme.general.borderRadiusBase,
+            borderBottomLeftRadius: theme.general.borderRadiusBase,
+            backgroundColor: `${barData.current.isSelected ? selectedBarColor : ''}`,
+            paddingLeft: theme.spacing.xs,
+            paddingTop: theme.spacing.xs,
+            paddingBottom: theme.spacing.xs,
+            fontStyle: barData.name === ERROR_KEY ? 'normal' : 'italic',
+          }}
+        >
+          <span
+            css={{
+              lineHeight: `${theme.typography.fontSizeSm}px`,
+            }}
+          >
+            {barData.name}
+          </span>
+        </td>
+        <td
+          css={{
+            textAlign: 'right',
+            verticalAlign: 'center',
+            borderTopRightRadius: theme.general.borderRadiusBase,
+            borderBottomRightRadius: theme.general.borderRadiusBase,
+            backgroundColor: `${barData.current.isSelected ? selectedBarColor : ''}`,
+            paddingRight: theme.spacing.xs,
+            paddingTop: theme.spacing.xs,
+            paddingBottom: theme.spacing.xs,
+            fontStyle: 'normal',
+          }}
+        >
+          <span
+            css={{
+              display: 'inline-block',
+              verticalAlign: 'center',
+              lineHeight: `${theme.typography.fontSizeSm}px`,
+            }}
+          >
+            {!isNil(barData.scoreChange)
+              ? getDisplayScoreChange(assessmentInfo, barData.scoreChange, false)
+              : barData.current.value}
+          </span>
+        </td>
+      </tr>
+    );
+  }
+
+  return (
+    <tr
+      key={barData.name}
+      css={{
+        cursor: 'pointer',
+        ':hover': {
+          backgroundColor: hoverBarColor,
+        },
+      }}
+      onClick={barData.current.toggleFilter}
+    >
+      <td
+        css={{
+          width: '100%',
+          borderTopLeftRadius: theme.general.borderRadiusBase,
+          borderBottomLeftRadius: theme.general.borderRadiusBase,
+          backgroundColor: `${barData.current.isSelected ? selectedBarColor : ''}`,
+          paddingLeft: theme.spacing.xs,
+          paddingTop: theme.spacing.xs,
+          paddingBottom: theme.spacing.xs,
+        }}
+      >
+        <div
+          css={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '2px',
+            width: '100%',
+          }}
+        >
+          <span
+            css={{
+              fontWeight: 'normal',
+              fontSize: '10px',
+              lineHeight: '10px',
+
+              color: theme.colors.textSecondary,
+            }}
+          >
+            {barData.name}
+          </span>
+          <div
+            css={{
+              flex: 1,
+              width: '100%',
+              position: 'relative',
+            }}
+          >
+            <div
+              style={{
+                width: barData.current.value > 0 ? `${barData.current.fraction * 100}%` : '2px',
+                borderRadius: '2px',
+              }}
+              css={{
+                position: 'relative',
+                // Allow shrinking for other items with minWidth.
+                flexShrink: 1,
+                transition: 'width 0.3s',
+                backgroundColor: barData.backgroundColor,
+                height: '10px',
+                display: 'flex',
+
+                alignItems: 'center',
+              }}
+            />
+          </div>
+        </div>
+      </td>
+      <td
+        css={{
+          textAlign: 'right',
+          verticalAlign: 'bottom',
+          borderTopRightRadius: theme.general.borderRadiusBase,
+          borderBottomRightRadius: theme.general.borderRadiusBase,
+          backgroundColor: `${barData.current.isSelected ? selectedBarColor : ''}`,
+          paddingRight: theme.spacing.xs,
+          paddingTop: theme.spacing.xs,
+          paddingBottom: theme.spacing.xs,
+        }}
+      >
+        <span
+          css={{
+            color: theme.colors.textSecondary,
+            fontWeight: 'normal',
+            fontSize: theme.typography.fontSizeSm,
+            display: 'inline-block',
+            verticalAlign: 'bottom',
+            lineHeight: `${theme.typography.fontSizeSm}px`,
+          }}
+        >
+          {!isNil(barData.scoreChange)
+            ? getDisplayScoreChange(assessmentInfo, barData.scoreChange)
+            : getDisplayScore(assessmentInfo, barData.current.fraction)}
+        </span>
+      </td>
+    </tr>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/components/charts/NumericAggregateChart.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/components/charts/NumericAggregateChart.tsx
@@ -1,0 +1,147 @@
+import React from 'react';
+
+import { HoverCard, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { useIntl } from '@databricks/i18n';
+
+import type { NumericAggregate } from '../../types';
+import { displayFloat } from '../../utils/DisplayUtils';
+
+// eslint-disable-next-line react-component-name/react-component-name -- TODO(FEINF-4716)
+export const NumericAggregateChart = React.memo(({ numericAggregate }: { numericAggregate: NumericAggregate }) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+  return (
+    <div
+      css={{
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <div
+        css={{
+          display: 'flex',
+          justifyContent: 'center',
+          flexDirection: 'row',
+        }}
+      >
+        {numericAggregate.counts.map((count, index) => (
+          <HoverCard
+            key={'hover-card-' + index}
+            content={
+              <div
+                css={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                }}
+              >
+                <div
+                  css={{
+                    display: 'flex',
+                    flexDirection: 'row',
+                  }}
+                >
+                  <div
+                    css={{
+                      width: '25%',
+                    }}
+                  >
+                    <Typography.Text>
+                      {intl.formatMessage({
+                        defaultMessage: 'Range',
+                        description: 'Label for the range in the tooltip for the numeric aggregate chart.',
+                      })}
+                    </Typography.Text>
+                  </div>
+                  <div>
+                    <Typography.Text color="secondary">
+                      {displayFloat(count.lower, 2) === displayFloat(count.upper, 2)
+                        ? displayFloat(count.lower, 2)
+                        : `${displayFloat(count.lower, 2)} - ${displayFloat(count.upper, 2)}`}
+                    </Typography.Text>
+                  </div>
+                </div>
+                <div
+                  css={{
+                    display: 'flex',
+                    flexDirection: 'row',
+                  }}
+                >
+                  <div
+                    css={{
+                      width: '25%',
+                    }}
+                  >
+                    <Typography.Text>
+                      {intl.formatMessage({
+                        defaultMessage: 'Count',
+                        description: 'Label for the count in the tooltip for the numeric aggregate chart.',
+                      })}
+                    </Typography.Text>
+                  </div>
+                  <div>
+                    <Typography.Text color="secondary">{count.count}</Typography.Text>
+                  </div>
+                </div>
+              </div>
+            }
+            trigger={
+              <div
+                key={'bar-' + index}
+                css={{
+                  display: 'flex',
+                  flex: 1,
+                  flexDirection: 'column-reverse',
+                  height: '60px',
+                  width: '10px',
+                  ':hover': {
+                    backgroundColor: theme.colors.actionDefaultBackgroundHover,
+                  },
+                }}
+              >
+                <div
+                  css={{
+                    height: `${(count.count / numericAggregate.maxCount) * 100}%`,
+                    minHeight: '1px',
+                    width: '80%',
+                    verticalAlign: 'bottom',
+                    backgroundColor: theme.colors.blue400,
+                    borderTopRightRadius: theme.general.borderRadiusBase,
+                    borderTopLeftRadius: theme.general.borderRadiusBase,
+                  }}
+                />
+              </div>
+            }
+          />
+        ))}
+      </div>
+      {numericAggregate.min === numericAggregate.max ? (
+        <div
+          css={{
+            display: 'flex',
+            justifyContent: 'center',
+            flexDirection: 'row',
+            fontWeight: 'normal',
+            fontSize: theme.typography.fontSizeSm,
+            color: theme.colors.textSecondary,
+          }}
+        >
+          {displayFloat(numericAggregate.min, 2)}
+        </div>
+      ) : (
+        <div
+          css={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            flexDirection: 'row',
+            fontWeight: 'normal',
+            fontSize: theme.typography.fontSizeSm,
+            color: theme.colors.textSecondary,
+          }}
+        >
+          <div>{displayFloat(numericAggregate.min, 2)}</div>
+          <div>{displayFloat(numericAggregate.max, 2)}</div>
+        </div>
+      )}
+    </div>
+  );
+});

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/components/filters/TableFilterItem.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/components/filters/TableFilterItem.tsx
@@ -1,0 +1,373 @@
+import { useMemo } from 'react';
+
+import {
+  Button,
+  useDesignSystemTheme,
+  FormUI,
+  SimpleSelect,
+  SimpleSelectOption,
+  CloseSmallIcon,
+  Input,
+} from '@databricks/design-system';
+import { FormattedMessage } from '@databricks/i18n';
+
+import { TableFilterItemTypeahead } from './TableFilterItemTypeahead';
+import { TableFilterItemValueInput } from './TableFilterItemValueInput';
+import {
+  INPUTS_COLUMN_ID,
+  RESPONSE_COLUMN_ID,
+  EXECUTION_DURATION_COLUMN_ID,
+  STATE_COLUMN_ID,
+  TRACE_NAME_COLUMN_ID,
+  USER_COLUMN_ID,
+  SESSION_COLUMN_ID,
+  RUN_NAME_COLUMN_ID,
+  LOGGED_MODEL_COLUMN_ID,
+  LINKED_PROMPTS_COLUMN_ID,
+  SOURCE_COLUMN_ID,
+  CUSTOM_METADATA_COLUMN_ID,
+  SPAN_NAME_COLUMN_ID,
+  SPAN_TYPE_COLUMN_ID,
+  SPAN_STATUS_COLUMN_ID,
+  SPAN_CONTENT_COLUMN_ID,
+  GIT_BRANCH_COLUMN_ID,
+  GIT_COMMIT_COLUMN_ID,
+} from '../../hooks/useTableColumns';
+import type {
+  AssessmentInfo,
+  TableFilter,
+  TableFilterOption,
+  TableFilterOptions,
+  TracesTableColumn,
+} from '../../types';
+import { FilterOperator, TracesTableColumnGroup, TracesTableColumnGroupToLabelMap, isNullOperator } from '../../types';
+
+const getFilterableInfoColumns = (usesV4APIs?: boolean) => {
+  // We use a different set of filterable info columns depending on whether v4 APIs are used
+  if (usesV4APIs) {
+    return [
+      EXECUTION_DURATION_COLUMN_ID,
+      STATE_COLUMN_ID,
+      TRACE_NAME_COLUMN_ID,
+      USER_COLUMN_ID,
+      SESSION_COLUMN_ID,
+      RUN_NAME_COLUMN_ID,
+      LOGGED_MODEL_COLUMN_ID,
+      SOURCE_COLUMN_ID,
+      GIT_BRANCH_COLUMN_ID,
+      GIT_COMMIT_COLUMN_ID,
+      INPUTS_COLUMN_ID,
+      RESPONSE_COLUMN_ID,
+      LINKED_PROMPTS_COLUMN_ID,
+    ];
+  }
+  return [
+    EXECUTION_DURATION_COLUMN_ID,
+    STATE_COLUMN_ID,
+    TRACE_NAME_COLUMN_ID,
+    USER_COLUMN_ID,
+    SESSION_COLUMN_ID,
+    RUN_NAME_COLUMN_ID,
+    LOGGED_MODEL_COLUMN_ID,
+    SOURCE_COLUMN_ID,
+    GIT_BRANCH_COLUMN_ID,
+    GIT_COMMIT_COLUMN_ID,
+    LINKED_PROMPTS_COLUMN_ID,
+  ];
+};
+
+const getAvailableOperators = (column: string, key?: string, usesV4APIs?: boolean): FilterOperator[] => {
+  if (column === EXECUTION_DURATION_COLUMN_ID) {
+    return [
+      FilterOperator.EQUALS,
+      FilterOperator.NOT_EQUALS,
+      FilterOperator.GREATER_THAN,
+      FilterOperator.LESS_THAN,
+      FilterOperator.GREATER_THAN_OR_EQUALS,
+      FilterOperator.LESS_THAN_OR_EQUALS,
+    ];
+  }
+
+  if (column === SPAN_NAME_COLUMN_ID || column === SPAN_TYPE_COLUMN_ID) {
+    return [FilterOperator.EQUALS, FilterOperator.NOT_EQUALS, FilterOperator.CONTAINS];
+  }
+
+  if (column === SPAN_STATUS_COLUMN_ID) {
+    return [FilterOperator.EQUALS, FilterOperator.NOT_EQUALS];
+  }
+
+  if (column === SPAN_CONTENT_COLUMN_ID) {
+    return [FilterOperator.CONTAINS];
+  }
+
+  if (column === INPUTS_COLUMN_ID || column === RESPONSE_COLUMN_ID) {
+    return [FilterOperator.RLIKE, FilterOperator.EQUALS];
+  }
+
+  if (column === TracesTableColumnGroup.ASSESSMENT) {
+    return [
+      FilterOperator.EQUALS,
+      FilterOperator.NOT_EQUALS,
+      FilterOperator.GREATER_THAN,
+      FilterOperator.LESS_THAN,
+      FilterOperator.GREATER_THAN_OR_EQUALS,
+      FilterOperator.LESS_THAN_OR_EQUALS,
+      FilterOperator.IS_NULL,
+      FilterOperator.IS_NOT_NULL,
+    ];
+  }
+
+  if (column === SESSION_COLUMN_ID) {
+    return usesV4APIs ? [FilterOperator.EQUALS, FilterOperator.CONTAINS] : [FilterOperator.EQUALS];
+  }
+
+  if (column === TracesTableColumnGroup.TAG) {
+    return [FilterOperator.EQUALS, FilterOperator.IS_NULL, FilterOperator.IS_NOT_NULL];
+  }
+
+  if (column === SESSION_COLUMN_ID) {
+    return [FilterOperator.EQUALS, FilterOperator.CONTAINS];
+  }
+
+  return [FilterOperator.EQUALS];
+};
+
+export const TableFilterItem = ({
+  tableFilter,
+  index,
+  onChange,
+  onDelete,
+  assessmentInfos,
+  experimentId,
+  tableFilterOptions,
+  allColumns,
+  usesV4APIs,
+}: {
+  tableFilter: TableFilter;
+  index: number;
+  onChange: (filter: TableFilter, index: number) => void;
+  onDelete: () => void;
+  assessmentInfos: AssessmentInfo[];
+  experimentId?: string;
+  tableFilterOptions: TableFilterOptions;
+  allColumns: TracesTableColumn[];
+  usesV4APIs?: boolean;
+}) => {
+  const { column, operator, key } = tableFilter;
+  const { theme } = useDesignSystemTheme();
+
+  const availableFilterableInfoColumns = useMemo(() => getFilterableInfoColumns(usesV4APIs), [usesV4APIs]);
+
+  const assessmentKeyOptions: TableFilterOption[] = useMemo(
+    () => assessmentInfos.map((assessment) => ({ value: assessment.name, renderValue: () => assessment.displayName })),
+    [assessmentInfos],
+  );
+
+  const columnOptions: TableFilterOption[] = useMemo(() => {
+    // Order the columns based on their filterOrder property, defaulting to 1 if not provided
+    const sortedColumns = allColumns.slice().sort((a, b) => {
+      return (a.filterOrder ?? 1) - (b.filterOrder ?? 1);
+    });
+    const result = sortedColumns
+      .filter(
+        (column) =>
+          availableFilterableInfoColumns.includes(column.id) || column.id.startsWith(CUSTOM_METADATA_COLUMN_ID),
+      )
+      .map((column) => ({ value: column.id, renderValue: () => column.filterLabel ?? column.label }));
+
+    // Add the tag and assessment column groups
+    result.push(
+      {
+        value: TracesTableColumnGroup.TAG,
+        renderValue: () => TracesTableColumnGroupToLabelMap[TracesTableColumnGroup.TAG],
+      },
+      {
+        value: TracesTableColumnGroup.ASSESSMENT,
+        renderValue: () => TracesTableColumnGroupToLabelMap[TracesTableColumnGroup.ASSESSMENT],
+      },
+    );
+
+    // Add individual span filter options
+    if (usesV4APIs) {
+      result.push(
+        // TODO: Added via UI sync, but doesn't work in databricks yet. Uncomment
+        // these when the search API supports them
+        { value: SPAN_CONTENT_COLUMN_ID, renderValue: () => 'Span content' },
+        { value: SPAN_NAME_COLUMN_ID, renderValue: () => 'Span name' },
+        { value: SPAN_STATUS_COLUMN_ID, renderValue: () => 'Span status' },
+        { value: SPAN_TYPE_COLUMN_ID, renderValue: () => 'Span type' },
+      );
+    }
+
+    return result;
+  }, [allColumns, usesV4APIs, availableFilterableInfoColumns]);
+
+  return (
+    <>
+      <div
+        css={{
+          display: 'flex',
+          flexDirection: 'row',
+          gap: theme.spacing.sm,
+        }}
+      >
+        <div
+          css={{
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+        >
+          <FormUI.Label htmlFor={`filter-column-${index}`}>
+            <FormattedMessage
+              defaultMessage="Field"
+              description="Label for the column field in the GenAI Traces Table Filter form"
+            />
+          </FormUI.Label>
+          <TableFilterItemTypeahead
+            id={`filter-column-${index}`}
+            item={columnOptions.find((item) => item.value === column)}
+            options={columnOptions}
+            onChange={(value: string) => {
+              if (value !== column) {
+                const defaultOperator = getAvailableOperators(value, undefined, usesV4APIs)[0];
+                onChange({ column: value, operator: defaultOperator, value: '' }, index);
+              }
+            }}
+            placeholder="Select column"
+            width={180}
+            canSearchCustomValue={false}
+          />
+        </div>
+        {column === TracesTableColumnGroup.ASSESSMENT && (
+          <div
+            css={{
+              display: 'flex',
+              flexDirection: 'column',
+            }}
+          >
+            <FormUI.Label htmlFor={`filter-key-${index}`}>
+              <FormattedMessage
+                defaultMessage="Name"
+                description="Label for the name field for assessments in the GenAI Traces Table Filter form"
+              />
+            </FormUI.Label>
+            <TableFilterItemTypeahead
+              id={`filter-key-${index}`}
+              item={assessmentKeyOptions.find((item) => item.value === key)}
+              options={assessmentKeyOptions}
+              onChange={(value: string) => {
+                onChange({ ...tableFilter, key: value }, index);
+              }}
+              placeholder="Select name"
+              width={200}
+              canSearchCustomValue={false}
+            />
+          </div>
+        )}
+        {column === TracesTableColumnGroup.TAG && (
+          <div
+            css={{
+              display: 'flex',
+              flexDirection: 'column',
+            }}
+          >
+            <FormUI.Label htmlFor={`filter-key-${index}`}>
+              <FormattedMessage
+                defaultMessage="Key"
+                description="Label for the key field for tags in the GenAI Traces Table Filter form"
+              />
+            </FormUI.Label>
+            <Input
+              aria-label="Key"
+              componentId="mlflow.evaluations_review.table_ui.filter_key"
+              id={'filter-key-' + index}
+              type="text"
+              css={{ width: 200 }}
+              placeholder={column === TracesTableColumnGroup.TAG ? 'Key' : 'Name'}
+              value={key}
+              onChange={(e) => {
+                onChange({ ...tableFilter, key: e.target.value }, index);
+              }}
+            />
+          </div>
+        )}
+        <div
+          css={{
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+        >
+          <FormUI.Label htmlFor={`filter-operator-${index}`}>
+            <FormattedMessage
+              defaultMessage="Operator"
+              description="Label for the operator field in the GenAI Traces Table Filter form"
+            />
+          </FormUI.Label>
+          {(() => {
+            const isOperatorSelectorDisabled =
+              column !== '' && getAvailableOperators(column, key, usesV4APIs).length === 1;
+            return (
+              <SimpleSelect
+                aria-label="Operator"
+                componentId="mlflow.evaluations_review.table_ui.filter_operator"
+                id={'filter-operator-' + index}
+                placeholder="Select"
+                width={120}
+                contentProps={{
+                  // Set the z-index to be higher than the Popover
+                  style: { zIndex: theme.options.zIndexBase + 100 },
+                }}
+                value={!isOperatorSelectorDisabled ? operator : getAvailableOperators(column, key, usesV4APIs)[0]}
+                disabled={isOperatorSelectorDisabled}
+                onChange={(e) => {
+                  onChange({ ...tableFilter, operator: e.target.value as FilterOperator }, index);
+                }}
+              >
+                {getAvailableOperators(column, key, usesV4APIs).map((op) => (
+                  <SimpleSelectOption key={op} value={op}>
+                    {op}
+                  </SimpleSelectOption>
+                ))}
+              </SimpleSelect>
+            );
+          })()}
+        </div>
+        {!isNullOperator(operator as FilterOperator) && (
+          <div
+            css={{
+              display: 'flex',
+              flexDirection: 'column',
+            }}
+          >
+            <FormUI.Label htmlFor={`filter-value-${index}`}>
+              <FormattedMessage
+                defaultMessage="Value"
+                description="Label for the value field in the GenAI Traces Table Filter form"
+              />
+            </FormUI.Label>
+            <TableFilterItemValueInput
+              index={index}
+              tableFilter={tableFilter}
+              assessmentInfos={assessmentInfos}
+              onChange={onChange}
+              experimentId={experimentId}
+              tableFilterOptions={tableFilterOptions}
+            />
+          </div>
+        )}
+        <div
+          css={{
+            alignSelf: 'flex-end',
+          }}
+        >
+          <Button
+            componentId="mlflow.evaluations_review.table_ui.filter_delete_button"
+            type="tertiary"
+            icon={<CloseSmallIcon />}
+            onClick={onDelete}
+          />
+        </div>
+      </div>
+    </>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/components/filters/TableFilterItemTypeahead.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/components/filters/TableFilterItemTypeahead.tsx
@@ -1,0 +1,103 @@
+import { useMemo, useState } from 'react';
+
+import {
+  useDesignSystemTheme,
+  DialogComboboxOptionListSelectItem,
+  DialogComboboxOptionListSearch,
+  DialogComboboxContent,
+  DialogComboboxTrigger,
+  DialogComboboxOptionList,
+  DialogCombobox,
+} from '@databricks/design-system';
+
+import type { TableFilterOption } from '../../types';
+
+interface SimpleQuery<T> {
+  data?: T;
+  isLoading?: boolean;
+}
+
+export const TableFilterItemTypeahead = ({
+  id,
+  item,
+  options,
+  query,
+  onChange,
+  placeholder,
+  width,
+  canSearchCustomValue,
+}: {
+  id: string;
+  item?: TableFilterOption;
+  options?: TableFilterOption[];
+  query?: SimpleQuery<TableFilterOption[]>;
+  onChange: (value: string) => void;
+  placeholder: string;
+  width: number;
+  canSearchCustomValue: boolean;
+}) => {
+  const { theme } = useDesignSystemTheme();
+
+  const [searchValue, setSearchValue] = useState<string>('');
+
+  const displayOptions = useMemo(() => query?.data ?? options ?? [], [query?.data, options]);
+  const optionValues = useMemo(() => displayOptions.map((option) => option.value), [displayOptions]);
+
+  return (
+    <DialogCombobox
+      componentId="mlflow.evaluations_review.table_ui.filter_column"
+      value={item?.value ? [item.value] : []}
+      id={id}
+    >
+      <DialogComboboxTrigger
+        withInlineLabel={false}
+        placeholder={placeholder}
+        renderDisplayedValue={() => item?.renderValue() ?? ''}
+        width={width}
+        allowClear={false}
+      />
+      <DialogComboboxContent
+        width={width}
+        style={{ zIndex: theme.options.zIndexBase + 100 }}
+        loading={query?.isLoading}
+      >
+        <DialogComboboxOptionList>
+          <DialogComboboxOptionListSearch onSearch={(value: string) => setSearchValue(value)}>
+            {displayOptions.map((option) => (
+              <DialogComboboxOptionListSelectItem
+                key={option.value}
+                value={option.value}
+                onChange={onChange}
+                checked={option.value === item?.value}
+                css={{
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                }}
+              >
+                {option.renderValue()}
+              </DialogComboboxOptionListSelectItem>
+            ))}
+            {/* Currently there's no use case for searching custom values. Eventually we might need it
+                  for tags. */}
+            {canSearchCustomValue && searchValue && !optionValues.includes(searchValue) ? (
+              <DialogComboboxOptionListSelectItem
+                key={searchValue}
+                value={searchValue}
+                onChange={onChange}
+                checked={searchValue === item?.value}
+                css={{
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                }}
+              >
+                Use "{searchValue}"
+              </DialogComboboxOptionListSelectItem>
+            ) : null}
+          </DialogComboboxOptionListSearch>
+        </DialogComboboxOptionList>
+      </DialogComboboxContent>
+    </DialogCombobox>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/components/filters/TableFilterItemValueInput.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/components/filters/TableFilterItemValueInput.tsx
@@ -1,0 +1,279 @@
+import { useCallback, useState, useMemo } from 'react';
+
+import { useDesignSystemTheme, Input } from '@databricks/design-system';
+import { useIntl } from '@databricks/i18n';
+
+import { TableFilterItemTypeahead } from './TableFilterItemTypeahead';
+import { ExperimentViewTracesStatusLabels } from '../../cellRenderers/StatusRenderer';
+import {
+  assessmentValueToSerializedString,
+  serializedStringToAssessmentValueV2,
+} from '../../hooks/useAssessmentFilters';
+import { useExperimentVersionsQuery } from '../../hooks/useExperimentVersionsQuery';
+import { useGenAiExperimentRunsForComparison } from '../../hooks/useGenAiExperimentRunsForComparison';
+import {
+  EXECUTION_DURATION_COLUMN_ID,
+  STATE_COLUMN_ID,
+  SPAN_STATUS_COLUMN_ID,
+  RUN_NAME_COLUMN_ID,
+  LOGGED_MODEL_COLUMN_ID,
+  LINKED_PROMPTS_COLUMN_ID,
+  SOURCE_COLUMN_ID,
+} from '../../hooks/useTableColumns';
+import type { AssessmentInfo, TableFilter, TableFilterOption, TableFilterOptions } from '../../types';
+import { TracesTableColumnGroup } from '../../types';
+import { ERROR_KEY } from '../../utils/AggregationUtils';
+import { getAssessmentValueLabel } from '../GenAiEvaluationTracesReview.utils';
+
+export const TableFilterItemValueInput = ({
+  index,
+  tableFilter,
+  assessmentInfos,
+  onChange,
+  experimentId,
+  tableFilterOptions,
+}: {
+  index: number;
+  tableFilter: TableFilter;
+  assessmentInfos: AssessmentInfo[];
+  onChange: (tableFilter: TableFilter, index: number) => void;
+  experimentId?: string;
+  tableFilterOptions: TableFilterOptions;
+}) => {
+  const intl = useIntl();
+  const { theme } = useDesignSystemTheme();
+
+  const id = `filter-value-${index}`;
+
+  const [localValue, setLocalValue] = useState(tableFilter.value);
+
+  const onValueBlur = useCallback(() => {
+    if (localValue !== tableFilter.value) {
+      onChange({ ...tableFilter, value: localValue }, index);
+    }
+  }, [tableFilter, index, onChange, localValue]);
+
+  // Fetch runs data when the run name column is selected
+  const runsQuery = useGenAiExperimentRunsForComparison(experimentId);
+
+  // Transform runs data into the format expected by TableFilterItemTypeahead
+  const runNameQuery = useMemo(() => {
+    const transformedData = runsQuery.runInfos
+      ?.filter((run) => run.runUuid && run.runName)
+      ?.map((run) => ({
+        value: run.runUuid as string,
+        renderValue: () => run.runName as string,
+      }));
+
+    return {
+      data: transformedData,
+      isLoading: runsQuery.isLoading,
+    };
+  }, [runsQuery]);
+
+  // Fetch versions data when the version column is selected
+  const versionsDataQuery = useExperimentVersionsQuery(experimentId);
+
+  // Transform versions data into the format expected by TableFilterItemTypeahead
+  const versionsQuery = useMemo(() => {
+    const transformedData = versionsDataQuery.data?.map((loggedModel) => ({
+      value: loggedModel.info.model_id,
+      renderValue: () => loggedModel.info.name,
+    }));
+
+    return {
+      data: transformedData,
+      isLoading: versionsDataQuery.isLoading,
+    };
+  }, [versionsDataQuery]);
+
+  const stateOptions: TableFilterOption[] = [
+    { value: 'IN_PROGRESS', renderValue: () => intl.formatMessage(ExperimentViewTracesStatusLabels.IN_PROGRESS) },
+    { value: 'OK', renderValue: () => intl.formatMessage(ExperimentViewTracesStatusLabels.OK) },
+    { value: 'ERROR', renderValue: () => intl.formatMessage(ExperimentViewTracesStatusLabels.ERROR) },
+  ];
+
+  if (tableFilter.column === RUN_NAME_COLUMN_ID) {
+    return (
+      <TableFilterItemTypeahead
+        id={id}
+        item={runNameQuery.data?.find((item) => item.value === tableFilter.value)}
+        query={runNameQuery}
+        onChange={(value: string) => {
+          onChange({ ...tableFilter, value }, index);
+        }}
+        placeholder="Select run"
+        width={200}
+        canSearchCustomValue={false}
+      />
+    );
+  }
+
+  if (tableFilter.column === LOGGED_MODEL_COLUMN_ID) {
+    return (
+      <TableFilterItemTypeahead
+        id={id}
+        item={versionsQuery.data?.find((item) => item.value === tableFilter.value)}
+        query={versionsQuery}
+        onChange={(value: string) => {
+          onChange({ ...tableFilter, value }, index);
+        }}
+        placeholder="Select version"
+        width={200}
+        canSearchCustomValue={false}
+      />
+    );
+  }
+
+  if (tableFilter.column === TracesTableColumnGroup.ASSESSMENT) {
+    const assessmentInfo = assessmentInfos.find((assessment) => assessment.name === tableFilter.key);
+    if (assessmentInfo && assessmentInfo.dtype === 'numeric') {
+      // Numeric assessments get a number input field
+      return (
+        <Input
+          aria-label="Value"
+          componentId="mlflow.evaluations_review.table_ui.filter_value_numeric"
+          id={id}
+          placeholder="Numeric value"
+          type="number"
+          value={localValue as string}
+          onChange={(e) => {
+            setLocalValue(e.target.value);
+          }}
+          onBlur={() => {
+            const numVal = localValue === '' || localValue === undefined ? '' : Number(localValue);
+            if (numVal !== tableFilter.value) {
+              onChange({ ...tableFilter, value: numVal === '' ? '' : numVal }, index);
+            }
+          }}
+          css={{ width: 200 }}
+        />
+      );
+    }
+    if (assessmentInfo && assessmentInfo.dtype !== 'unknown') {
+      const options: TableFilterOption[] = Array.from(assessmentInfo.uniqueValues.values()).map((value) => {
+        return {
+          value: assessmentValueToSerializedString(value),
+          renderValue: () => getAssessmentValueLabel(intl, theme, assessmentInfo, value).content,
+        };
+      });
+
+      // Add Error option when assessment contains errors, similar to how bar charts handle it
+      if (assessmentInfo.containsErrors) {
+        options.push({
+          value: assessmentValueToSerializedString(ERROR_KEY),
+          renderValue: () => getAssessmentValueLabel(intl, theme, assessmentInfo, ERROR_KEY).content,
+        });
+      }
+
+      return (
+        <TableFilterItemTypeahead
+          id={id}
+          item={options.find((item) => item.value === assessmentValueToSerializedString(tableFilter.value))}
+          options={options}
+          onChange={(value: string) => {
+            onChange({ ...tableFilter, value: serializedStringToAssessmentValueV2(value) }, index);
+          }}
+          placeholder="Select"
+          width={200}
+          canSearchCustomValue={false}
+        />
+      );
+    }
+  }
+
+  if (tableFilter.column === STATE_COLUMN_ID) {
+    return (
+      <TableFilterItemTypeahead
+        id={id}
+        item={stateOptions.find((item) => item.value === tableFilter.value)}
+        options={stateOptions}
+        onChange={(value: string) => {
+          onChange({ ...tableFilter, value }, index);
+        }}
+        placeholder="Select"
+        width={200}
+        canSearchCustomValue={false}
+      />
+    );
+  }
+
+  if (tableFilter.column === SOURCE_COLUMN_ID) {
+    const sourceOptions = tableFilterOptions.source;
+    return (
+      <TableFilterItemTypeahead
+        id={id}
+        item={sourceOptions.find((item) => item.value === tableFilter.value)}
+        options={sourceOptions}
+        onChange={(value: string) => {
+          onChange({ ...tableFilter, value }, index);
+        }}
+        placeholder="Select source"
+        width={200}
+        canSearchCustomValue={false}
+      />
+    );
+  }
+
+  if (tableFilter.column === SPAN_STATUS_COLUMN_ID) {
+    const spanStatusOptions: TableFilterOption[] = [
+      { value: 'OK', renderValue: () => intl.formatMessage(ExperimentViewTracesStatusLabels.OK) },
+      { value: 'ERROR', renderValue: () => intl.formatMessage(ExperimentViewTracesStatusLabels.ERROR) },
+    ];
+    return (
+      <TableFilterItemTypeahead
+        id={id}
+        item={spanStatusOptions.find((item) => item.value === tableFilter.value)}
+        options={spanStatusOptions}
+        onChange={(value: string) => {
+          onChange({ ...tableFilter, value }, index);
+        }}
+        placeholder="Select"
+        width={200}
+        canSearchCustomValue={false}
+      />
+    );
+  }
+
+  // Only available in OSS
+  if (tableFilter.column === LINKED_PROMPTS_COLUMN_ID) {
+    const promptOptions = tableFilterOptions.prompt || [];
+    return (
+      <TableFilterItemTypeahead
+        id={id}
+        item={promptOptions.find((item) => item.value === tableFilter.value)}
+        options={promptOptions}
+        onChange={(value: string) => {
+          onChange({ ...tableFilter, value }, index);
+        }}
+        placeholder="Select prompt"
+        width={200}
+        canSearchCustomValue
+      />
+    );
+  }
+
+  return (
+    <Input
+      aria-label="Value"
+      componentId="mlflow.evaluations_review.table_ui.filter_value"
+      id={id}
+      placeholder={tableFilter.column === EXECUTION_DURATION_COLUMN_ID ? 'Time in milliseconds' : 'Value'}
+      type={tableFilter.column === EXECUTION_DURATION_COLUMN_ID ? 'number' : 'text'}
+      value={localValue as string}
+      onChange={(e) => {
+        setLocalValue(e.target.value);
+      }}
+      onBlur={onValueBlur}
+      css={{ width: 200 }}
+      // Disable it for assessment column when the data type is unknown
+      disabled={
+        tableFilter.column === TracesTableColumnGroup.ASSESSMENT &&
+        (() => {
+          const info = assessmentInfos.find((a) => a.name === tableFilter.key);
+          return !info || info.dtype === 'unknown';
+        })()
+      }
+    />
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/enum.ts
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/enum.ts
@@ -1,0 +1,28 @@
+export enum GenAiTraceEvaluationArtifactFile {
+  Evaluations = '_evaluations.json',
+  Assessments = '_assessments.json',
+  Metrics = '_metrics.json',
+}
+
+export enum KnownEvaluationResultAssessmentMetadataFields {
+  IS_OVERALL_ASSESSMENT = 'is_overall_assessment',
+  CHUNK_INDEX = 'chunk_index',
+  IS_COPIED_FROM_AI = 'is_copied_from_ai',
+}
+
+export enum KnownEvaluationResultAssessmentName {
+  OVERALL_ASSESSMENT = 'overall_assessment',
+  SAFETY = 'safety',
+  GROUNDEDNESS = 'groundedness',
+  CORRECTNESS = 'correctness',
+  RELEVANCE_TO_QUERY = 'relevance_to_query',
+  CHUNK_RELEVANCE = 'chunk_relevance',
+  CONTEXT_SUFFICIENCY = 'context_sufficiency',
+  GUIDELINE_ADHERENCE = 'guideline_adherence',
+  GLOBAL_GUIDELINE_ADHERENCE = 'global_guideline_adherence',
+  TOTAL_TOKEN_COUNT = 'agent/total_token_count',
+  TOTAL_INPUT_TOKEN_COUNT = 'agent/total_input_token_count',
+  TOTAL_OUTPUT_TOKEN_COUNT = 'agent/total_output_token_count',
+  DOCUMENT_RECALL = 'retrieval/ground_truth/document_recall',
+  DOCUMENT_RATINGS = 'retrieval/ground_truth/document_ratings',
+}

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/useActiveEvaluation.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/useActiveEvaluation.tsx
@@ -1,0 +1,63 @@
+import { createContext, useCallback, useContext } from 'react';
+
+import { createTraceV4LongIdentifier } from '../../model-trace-explorer/ModelTraceExplorer.utils';
+import type { ModelTraceInfoV3 } from '../../model-trace-explorer/ModelTrace.types';
+import { useSearchParams } from '../utils/RoutingUtils';
+import { doesTraceSupportV4API } from '../utils/TraceLocationUtils';
+
+const QUERY_PARAM_KEY = 'selectedEvaluationId';
+
+type SetSelectedEvaluationIdFn = (selectedEvaluationId: string | undefined, traceInfo?: ModelTraceInfoV3) => void;
+
+/**
+ * Context to override the active evaluation state.
+ * When provided, useActiveEvaluation will use the context value instead of URL params.
+ * This is useful for components like SelectTracesModal that need to render a traces table
+ * without inheriting the parent's selected evaluation state.
+ */
+export const ActiveEvaluationContext = createContext<{
+  selectedEvaluationId: string | undefined;
+  setSelectedEvaluationId: SetSelectedEvaluationIdFn;
+} | null>(null);
+
+/**
+ * Query param-powered hook that returns the currently selected evaluation ID
+ * and a function to set the selected evaluation ID.
+ *
+ * If ActiveEvaluationContext is provided, uses context value instead of URL params.
+ */
+export const useActiveEvaluation = () => {
+  const context = useContext(ActiveEvaluationContext);
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const selectedEvaluationIdFromUrl = searchParams.get(QUERY_PARAM_KEY) ?? undefined;
+
+  const setSelectedEvaluationIdFromUrl: SetSelectedEvaluationIdFn = useCallback(
+    (selectedEvaluationId, traceInfo) => {
+      setSearchParams((params) => {
+        if (selectedEvaluationId === undefined) {
+          params.delete(QUERY_PARAM_KEY);
+          return params;
+        }
+        // If the trace supports V4 identifiers, use this format instead.
+        if (traceInfo && doesTraceSupportV4API(traceInfo)) {
+          const longIdentifier = createTraceV4LongIdentifier(traceInfo);
+          params.set(QUERY_PARAM_KEY, longIdentifier);
+
+          return params;
+        }
+
+        params.set(QUERY_PARAM_KEY, selectedEvaluationId);
+        return params;
+      });
+    },
+    [setSearchParams],
+  );
+
+  // If context is provided, use context values instead of URL params
+  if (context) {
+    return [context.selectedEvaluationId, context.setSelectedEvaluationId] as const;
+  }
+
+  return [selectedEvaluationIdFromUrl, setSelectedEvaluationIdFromUrl] as const;
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/useAssessmentFilters.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/useAssessmentFilters.tsx
@@ -1,0 +1,117 @@
+import { useCallback, useMemo } from 'react';
+
+import type { AssessmentFilter, AssessmentInfo, AssessmentValueType } from '../types';
+import { useSearchParams } from '../utils/RoutingUtils';
+
+const QUERY_PARAM_KEY = 'assessmentFilter';
+const VALUE_SEPARATOR = '::';
+
+/**
+ * Query param-powered hook that returns the compare to run uuid when comparison is enabled.
+ */
+export const useAssessmentFilters = (assessmentInfos: AssessmentInfo[]) => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const assessmentFilters: AssessmentFilter[] = useMemo(() => {
+    const assessmentFiltersUrl = searchParams.getAll(QUERY_PARAM_KEY) ?? [];
+
+    return assessmentFiltersUrl.reduce<AssessmentFilter[]>((filters, urlFilter) => {
+      const [run, assessmentName, filterValueString, filterType] = urlFilter.split(VALUE_SEPARATOR);
+      const assessmentInfo = assessmentInfos?.find((info) => info.name === assessmentName);
+      if (assessmentInfo) {
+        const filterValue = serializedStringToAssessmentValue(assessmentInfo, filterValueString);
+        filters.push({
+          run,
+          assessmentName,
+          filterValue,
+          filterType: filterType === '' ? undefined : filterType,
+        } as AssessmentFilter);
+      }
+      return filters;
+    }, []);
+  }, [assessmentInfos, searchParams]);
+
+  const setAssessmentFilters = useCallback(
+    (filters: AssessmentFilter[] | undefined, replace = false) => {
+      setSearchParams(
+        (params: URLSearchParams) => {
+          params.delete(QUERY_PARAM_KEY);
+
+          if (filters) {
+            filters.forEach((filter) => {
+              params.append(
+                QUERY_PARAM_KEY,
+                [
+                  filter.run,
+                  filter.assessmentName,
+                  assessmentValueToSerializedString(filter.filterValue),
+                  filter.filterType,
+                ].join(VALUE_SEPARATOR),
+              );
+            });
+          }
+
+          return params;
+        },
+        { replace },
+      );
+    },
+    [setSearchParams],
+  );
+
+  return [assessmentFilters, setAssessmentFilters] as const;
+};
+
+export function serializedStringToAssessmentValueV2(value: string): AssessmentValueType {
+  if (value === 'undefined') {
+    return undefined;
+  }
+
+  // Handle boolean values
+  if (value === 'true') {
+    return true;
+  }
+  if (value === 'false') {
+    return false;
+  }
+
+  // Handle numeric values
+  const numValue = Number(value);
+  if (!isNaN(numValue) && value.trim() !== '') {
+    return numValue;
+  }
+
+  return value;
+}
+
+export function serializedStringToAssessmentValue(assessmentInfo: AssessmentInfo, value: string): AssessmentValueType {
+  if (assessmentInfo.dtype === 'pass-fail') {
+    if (value === 'undefined') {
+      return undefined;
+    }
+    return value;
+  } else if (assessmentInfo.dtype === 'boolean') {
+    if (value === 'true') {
+      return true;
+    } else if (value === 'false') {
+      return false;
+    } else {
+      return undefined;
+    }
+  } else if (assessmentInfo.dtype === 'numeric') {
+    if (value === 'undefined') {
+      return undefined;
+    }
+    const numValue = Number(value);
+    if (!isNaN(numValue) && value.trim() !== '') {
+      return numValue;
+    }
+    return value;
+  }
+  return value;
+}
+
+export function assessmentValueToSerializedString(value: AssessmentValueType): string {
+  if (value === undefined || value === null) return 'undefined';
+  return `${value}`;
+}

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/useColumnsURL.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/useColumnsURL.tsx
@@ -1,0 +1,44 @@
+import { useCallback, useMemo } from 'react';
+
+import { useSearchParams } from '../utils/RoutingUtils';
+
+const QUERY_PARAM_KEY = 'selectedColumns';
+const VALUE_SEPARATOR = ',';
+
+/**
+ * Query param-powered hook that manages selected column IDs in URL.
+ * Format: comma-separated list of column IDs
+ */
+export const useColumnsURL = (): [
+  string[] | undefined,
+  (columnIds: string[] | undefined, replace?: boolean) => void,
+] => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const selectedColumnIds: string[] | undefined = useMemo(() => {
+    const columnsParam = searchParams.get(QUERY_PARAM_KEY);
+    if (!columnsParam) return undefined;
+
+    return columnsParam.split(VALUE_SEPARATOR).filter(Boolean);
+  }, [searchParams]);
+
+  const setSelectedColumnIds = useCallback(
+    (columnIds: string[] | undefined, replace = false) => {
+      setSearchParams(
+        (params: URLSearchParams) => {
+          params.delete(QUERY_PARAM_KEY);
+
+          if (columnIds && columnIds.length > 0) {
+            params.set(QUERY_PARAM_KEY, columnIds.join(VALUE_SEPARATOR));
+          }
+
+          return params;
+        },
+        { replace },
+      );
+    },
+    [setSearchParams],
+  );
+
+  return [selectedColumnIds, setSelectedColumnIds];
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/useEditAssessmentFormState.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/useEditAssessmentFormState.tsx
@@ -1,0 +1,50 @@
+import { useCallback, useState } from 'react';
+
+import { useIntl } from '@databricks/i18n';
+
+import { getAssessmentValueSuggestions } from '../components/GenAiEvaluationTracesReview.utils';
+import type { AssessmentInfo, AssessmentDropdownSuggestionItem, RunEvaluationResultAssessment } from '../types';
+
+/**
+ * Manages the state of the edit assessment form. Provides methods to start adding and editing assessments.
+ */
+export const useEditAssessmentFormState = (
+  assessmentHistory: RunEvaluationResultAssessment[],
+  assessmentInfos?: AssessmentInfo[],
+) => {
+  const intl = useIntl();
+
+  // The assessment that is currently being edited.
+  const [editingAssessment, setEditingAssessment] = useState<RunEvaluationResultAssessment | undefined>(undefined);
+  // True if the upsert form is currently being shown, false otherwise.
+  const [showUpsertForm, setShowUpsertForm] = useState(false);
+  // A list of suggestions for the value dropdown.
+  const [suggestions, setSuggestions] = useState<AssessmentDropdownSuggestionItem[]>([]);
+
+  const setFormState = useCallback(
+    (isEditing: boolean, assessment?: RunEvaluationResultAssessment) => {
+      setEditingAssessment(assessment);
+      setShowUpsertForm(isEditing);
+      setSuggestions(getAssessmentValueSuggestions(intl, assessment, assessmentHistory, assessmentInfos));
+    },
+    [intl, assessmentInfos, assessmentHistory],
+  );
+  const editAssessment = useCallback(
+    (assessment: RunEvaluationResultAssessment) => setFormState(true, assessment),
+    [setFormState],
+  );
+  const addAssessment = useCallback(() => setFormState(true, undefined), [setFormState]);
+  const closeForm = useCallback(() => {
+    setEditingAssessment(undefined);
+    setShowUpsertForm(false);
+  }, []);
+
+  return {
+    suggestions,
+    editingAssessment,
+    showUpsertForm,
+    addAssessment,
+    editAssessment,
+    closeForm,
+  };
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/useEvaluationsSearchQuery.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/useEvaluationsSearchQuery.tsx
@@ -1,0 +1,30 @@
+import { useCallback } from 'react';
+
+import { useSearchParams } from '../utils/RoutingUtils';
+
+const QUERY_PARAM_KEY = 'searchQuery';
+
+/**
+ * Query param-powered hook that returns the search query for evaluations.
+ */
+export const useEvaluationsSearchQuery = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const searchQuery = searchParams.get(QUERY_PARAM_KEY) ?? '';
+
+  const setSearchQuery = useCallback(
+    (value: string | undefined) => {
+      setSearchParams((params) => {
+        if (value === undefined || value === '') {
+          params.delete(QUERY_PARAM_KEY);
+          return params;
+        }
+        params.set(QUERY_PARAM_KEY, value);
+        return params;
+      });
+    },
+    [setSearchParams],
+  );
+
+  return [searchQuery, setSearchQuery] as const;
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/useExperimentVersionsQuery.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/useExperimentVersionsQuery.tsx
@@ -1,0 +1,60 @@
+import { useQuery } from '../../query-client/queryClient';
+
+import { getAjaxUrl, makeRequest } from '../utils/FetchUtils';
+
+interface LoggedModel {
+  info: {
+    model_id: string;
+    experiment_id: string;
+    name: string;
+    creation_timestamp_ms?: number;
+    last_updated_timestamp_ms?: number;
+    artifact_uri?: string;
+    status?: string;
+    creator_id?: number;
+    tags?: Array<{
+      key: string;
+      value: string;
+    }>;
+  };
+  data: any;
+}
+
+interface UseExperimentVersionsQueryResponseType {
+  models: LoggedModel[];
+  next_page_token?: string;
+}
+
+export const useExperimentVersionsQuery = (
+  experimentId: string | undefined,
+  disabled = false,
+): {
+  data: LoggedModel[] | undefined;
+  isLoading: boolean;
+  error?: Error;
+} => {
+  const queryKey = ['EXPERIMENT_MODEL_VERSIONS', experimentId ?? ''];
+
+  const { data, isLoading, error } = useQuery<UseExperimentVersionsQueryResponseType, Error>({
+    queryKey,
+    queryFn: async () => {
+      // Search for model versions related to this experiment
+      const requestBody = {
+        experiment_ids: [experimentId],
+      };
+
+      return makeRequest(getAjaxUrl('ajax-api/2.0/mlflow/logged-models/search'), 'POST', requestBody);
+    },
+    staleTime: Infinity,
+    cacheTime: Infinity,
+    enabled: !disabled && Boolean(experimentId),
+    refetchOnMount: false,
+    retry: false,
+  });
+
+  return {
+    data: data?.models,
+    isLoading,
+    error: error || undefined,
+  };
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/useFetchTraceV4.ts
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/useFetchTraceV4.ts
@@ -1,0 +1,93 @@
+import { useCallback } from 'react';
+
+import { type UseQueryOptions, useQuery, useQueryClient } from '../../query-client/queryClient';
+
+import type { ModelTraceInfoV3 } from '../../model-trace-explorer/ModelTrace.types';
+import { TracesServiceV4 } from '../../model-trace-explorer/api';
+import type { TraceV3 } from '../types';
+
+const FETCH_TRACE_V4_QUERY_KEY = 'FETCH_TRACE_V4_QUERY_KEY';
+
+type UseFetchTraceV4Params = never;
+
+/**
+ * Hook for lazy fetching of V4 traces.
+ */
+export const useFetchTraceV4LazyQuery = (params: UseFetchTraceV4Params) => {
+  const queryClient = useQueryClient();
+  return useCallback(
+    (traceInput?: TraceInput) => {
+      if (!traceInput) return Promise.resolve(undefined);
+      return queryClient.ensureQueryData({
+        queryKey: getTraceV4QueryKey(traceInput),
+        queryFn: async () => {
+          return TracesServiceV4.getTraceV4(
+            // prettier-ignore
+            traceInput,
+          );
+        },
+      });
+    },
+    // prettier-ignore
+    [
+      queryClient,
+    ],
+  );
+};
+
+/**
+ * Hook for immediate fetching of V4 traces.
+ *
+ * @param traceInput - Trace identifier (serialized string like "trace:/catalog.schema/trace_id" or ModelTraceInfoV3 object)
+ * @param params - Fetch parameters including SQL warehouse ID
+ * @param options - Additional React Query options
+ */
+export const useFetchTraceV4Query = <T = TraceV3 | null>(
+  traceInput: TraceInput | undefined,
+  params: UseFetchTraceV4Params,
+  options?: Omit<UseQueryOptions<TraceV3 | null, unknown, T>, 'queryFn'>,
+) => {
+  const enabled = options?.enabled ?? Boolean(traceInput);
+  const result = useQuery({
+    queryKey: getTraceV4QueryKey(traceInput),
+    queryFn: async () => {
+      if (!traceInput) return null;
+      return TracesServiceV4.getTraceV4(
+        // prettier-ignore
+        traceInput,
+      );
+    },
+    enabled,
+    staleTime: Infinity,
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
+    ...options,
+  });
+
+  return {
+    ...result,
+    // Re-return isLoading with enabled condition to prevent misleading loading states when query is disabled
+    isLoading: result.isLoading && enabled,
+  };
+};
+
+/**
+ * Input can be either:
+ * 1. ModelTraceInfoV3 object with trace_id and trace_location
+ * 2. Serialized trace ID string (format: "trace:/catalog.schema/trace_id")
+ */
+type TraceInput = ModelTraceInfoV3 | string;
+
+/**
+ * Generates query key for v4 trace fetching.
+ * Uses the trace ID: either the string passed in as is, or the trace_id from the ModelTraceInfoV3 object.
+ */
+export const getTraceV4QueryKey = (traceInput: TraceInput | undefined) => {
+  if (!traceInput) return [FETCH_TRACE_V4_QUERY_KEY, undefined];
+
+  if (typeof traceInput === 'string') {
+    return [FETCH_TRACE_V4_QUERY_KEY, traceInput];
+  }
+
+  return [FETCH_TRACE_V4_QUERY_KEY, traceInput.trace_id];
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/useFilters.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/useFilters.tsx
@@ -1,0 +1,103 @@
+import { useCallback, useEffect, useMemo } from 'react';
+
+import { useLocalStorage } from '../../hooks/useLocalStorage';
+
+import { assessmentValueToSerializedString, serializedStringToAssessmentValueV2 } from './useAssessmentFilters';
+import {
+  type TableFilter,
+  type TableFilterValue,
+  type FilterOperator,
+  TracesTableColumnGroup,
+  isNullOperator,
+} from '../types';
+import { useSearchParams } from '../utils/RoutingUtils';
+
+const QUERY_PARAM_KEY = 'filter';
+const VALUE_SEPARATOR = '::';
+
+/**
+ * Query param-powered hook that manages both generic and assessment filters.
+ * Each filter is stored in the URL as: key::operator::value::type
+ */
+export const useFilters = ({
+  persist = false,
+  loadPersistedValues = false,
+  persistKey,
+}: { persist?: boolean; loadPersistedValues?: boolean; persistKey?: string } = {}) => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const [localStorageFilters, setLocalStorageFilters] = useLocalStorage<TableFilter[] | undefined>({
+    initialValue: undefined,
+    key: `traces_useFilters_${persistKey}`,
+    version: 1,
+  });
+
+  const isEmptySearchParams = useMemo(() => !searchParams.get(QUERY_PARAM_KEY), [searchParams]);
+
+  const filters: TableFilter[] = useMemo(() => {
+    const filtersUrl = searchParams.getAll(QUERY_PARAM_KEY) ?? [];
+
+    return filtersUrl.reduce<TableFilter[]>((filters, urlFilter) => {
+      const [column, urlOperator, value, key] = urlFilter.split(VALUE_SEPARATOR);
+      // IS NULL / IS NOT NULL operators don't require a value
+      if (!column || !urlOperator || (!value && !isNullOperator(urlOperator))) return filters;
+
+      const operator = urlOperator as FilterOperator;
+
+      const isAssessmentFilter = column === TracesTableColumnGroup.ASSESSMENT;
+      let filterValue: TableFilterValue = value;
+      if (isAssessmentFilter) {
+        filterValue = serializedStringToAssessmentValueV2(value);
+      }
+
+      filters.push({
+        column,
+        key,
+        operator,
+        value: filterValue,
+      });
+
+      return filters;
+    }, []);
+  }, [searchParams]);
+
+  const setFilters = useCallback(
+    (newFilters: TableFilter[] | undefined, replace = false) => {
+      if (persist) {
+        setLocalStorageFilters(newFilters);
+      }
+      setSearchParams(
+        (params: URLSearchParams) => {
+          params.delete(QUERY_PARAM_KEY);
+
+          if (newFilters) {
+            newFilters.forEach((filter) => {
+              let filterValue = filter.value;
+              if (filter.column === TracesTableColumnGroup.ASSESSMENT) {
+                filterValue = assessmentValueToSerializedString(filter.value);
+              }
+              params.append(
+                QUERY_PARAM_KEY,
+                [filter.column, filter.operator, filterValue, filter.key].join(VALUE_SEPARATOR),
+              );
+            });
+          }
+
+          return params;
+        },
+        { replace },
+      );
+    },
+    [setSearchParams, setLocalStorageFilters, persist],
+  );
+
+  useEffect(() => {
+    if (isEmptySearchParams && loadPersistedValues && localStorageFilters) {
+      setFilters(localStorageFilters, true);
+    }
+    // Rehydrate from local storage only once
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loadPersistedValues]);
+
+  return [filters, setFilters] as const;
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/useGenAITracesTableConfig.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/useGenAITracesTableConfig.tsx
@@ -1,0 +1,46 @@
+import { merge } from 'lodash';
+import type { ReactNode } from 'react';
+import React, { createContext, useContext } from 'react';
+
+import { shouldEnableRunEvaluationReviewUIWriteFeatures } from '../utils/FeatureUtils';
+
+export interface GenAITracesTableConfig {
+  enableRunEvaluationWriteFeatures: NonNullable<boolean | undefined>;
+}
+
+// Define a default configuration
+const getDefaultConfig = (): GenAITracesTableConfig => ({
+  enableRunEvaluationWriteFeatures: shouldEnableRunEvaluationReviewUIWriteFeatures() ?? false,
+});
+
+// Use a static module-load default so flag reads stay inside a render context.
+const GenAITracesTableConfigContext = createContext<GenAITracesTableConfig | null>(null);
+
+interface GenAITracesTableConfigProviderProps {
+  config?: Partial<GenAITracesTableConfig>;
+  children: ReactNode;
+}
+
+export const GenAITracesTableConfigProvider: React.FC<React.PropsWithChildren<GenAITracesTableConfigProviderProps>> = ({
+  config = {},
+  children,
+}) => {
+  const defaultConfig = getDefaultConfig();
+  // Remove undefined values from the config object
+
+  const mergedConfig: GenAITracesTableConfig = merge({}, defaultConfig, config);
+
+  return (
+    <GenAITracesTableConfigContext.Provider value={mergedConfig}>{children}</GenAITracesTableConfigContext.Provider>
+  );
+};
+
+export const useGenAITracesTableConfig = (): GenAITracesTableConfig => {
+  const context = useContext(GenAITracesTableConfigContext);
+
+  if (!context) {
+    return getDefaultConfig(); // Fallback to defaults if no provider is found
+  }
+
+  return context;
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/useGenAITracesUIState.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/useGenAITracesUIState.tsx
@@ -1,0 +1,220 @@
+import { isNil } from 'lodash';
+import { useCallback, useMemo } from 'react';
+
+import { useLocalStorage } from '../../hooks/useLocalStorage';
+
+import { useColumnsURL } from './useColumnsURL';
+import {
+  EXECUTION_DURATION_COLUMN_ID,
+  SOURCE_COLUMN_ID,
+  STATE_COLUMN_ID,
+  TRACE_NAME_COLUMN_ID,
+} from './useTableColumns';
+import { shouldEnableTracesTableStatePersistence } from '../../model-trace-explorer/FeatureUtils';
+import type { TracesTableColumn } from '../types';
+import { TracesTableColumnType } from '../types';
+
+export interface GenAITracesUIState {
+  /**
+   * A map of column ids to boolean values.
+   * If a column id is present in the map, the column is hidden if the value is false, and visible if the value is true.
+   */
+  columnOverrides: Record<string, boolean>;
+}
+
+const DEFAULT_MAX_VISIBLE_COLUMNS = 10;
+
+const LOCAL_STORAGE_KEY = 'genaiTracesUIState-columns';
+const LOCAL_STORAGE_VERSION = 1;
+
+const toVisibleColumnsFromHiddenColumns = (hiddenColumns: string[], allColumns: TracesTableColumn[]) => {
+  return allColumns.filter((col) => !hiddenColumns.includes(col.id));
+};
+
+const toHiddenColumnsFromVisibleColumns = (visibleColumns: TracesTableColumn[], allColumns: TracesTableColumn[]) => {
+  return allColumns.filter((col) => !visibleColumns.includes(col)).map((col) => col.id);
+};
+
+// This function adjusts the hidden columns to ensure that the number of visible columns is at most DEFAULT_MAX_VISIBLE_COLUMNS
+// If over the limit, it removes assessment columns until the limit is met.
+const adjustHiddenColumns = (hiddenColumns: string[], allColumns: TracesTableColumn[]): string[] => {
+  let visibleColumns = toVisibleColumnsFromHiddenColumns(hiddenColumns, allColumns);
+  if (visibleColumns.length > DEFAULT_MAX_VISIBLE_COLUMNS) {
+    const assessmentColumns = visibleColumns.filter((col) => col.type === TracesTableColumnType.ASSESSMENT);
+    const nonAssessmentColumns = visibleColumns.filter((col) => col.type !== TracesTableColumnType.ASSESSMENT);
+
+    // Calculate how many assessment columns we need to remove
+    const columnsToRemove = visibleColumns.length - DEFAULT_MAX_VISIBLE_COLUMNS;
+    const assessmentColumnsToKeep = Math.max(0, assessmentColumns.length - columnsToRemove);
+
+    // Keep the first N assessment columns and all non-assessment columns
+    visibleColumns = [...nonAssessmentColumns, ...assessmentColumns.slice(0, assessmentColumnsToKeep)];
+  }
+  return toHiddenColumnsFromVisibleColumns(visibleColumns, allColumns);
+};
+
+const getDefaultHiddenColumns = (
+  allColumns: TracesTableColumn[],
+  defaultSelectedColumns?: (allColumns: TracesTableColumn[]) => TracesTableColumn[],
+): string[] => {
+  if (defaultSelectedColumns) {
+    return adjustHiddenColumns(
+      toHiddenColumnsFromVisibleColumns(defaultSelectedColumns(allColumns), allColumns),
+      allColumns,
+    );
+  }
+
+  return adjustHiddenColumns(
+    [TRACE_NAME_COLUMN_ID, SOURCE_COLUMN_ID, EXECUTION_DURATION_COLUMN_ID, STATE_COLUMN_ID],
+    allColumns,
+  );
+};
+
+export const useGenAITracesUIStateColumns = (
+  experimentId: string,
+  allColumns: TracesTableColumn[],
+  defaultSelectedColumns?: (allColumns: TracesTableColumn[]) => TracesTableColumn[],
+  runUuid?: string,
+  storageKeyPrefix?: string,
+): {
+  hiddenColumns: string[];
+  toggleColumns: (cols: TracesTableColumn[]) => void;
+} => {
+  const enableURLPersistence = shouldEnableTracesTableStatePersistence();
+
+  const storageKey = storageKeyPrefix
+    ? `${LOCAL_STORAGE_KEY}-${storageKeyPrefix}-${experimentId}-${runUuid}`
+    : `${LOCAL_STORAGE_KEY}-${experimentId}-${runUuid}`;
+
+  const [columnState, setColumnState] = useLocalStorage<GenAITracesUIState | undefined>({
+    key: storageKey,
+    version: LOCAL_STORAGE_VERSION,
+    initialValue: undefined,
+  });
+
+  const [urlColumnIds, setUrlColumnIds] = useColumnsURL();
+
+  const defaultHidden = useMemo(() => {
+    return getDefaultHiddenColumns(allColumns, defaultSelectedColumns);
+  }, [allColumns, defaultSelectedColumns]);
+
+  const hiddenColumns = useMemo(() => {
+    if (enableURLPersistence && urlColumnIds && urlColumnIds.length > 0) {
+      const urlSelectedSet = new Set(urlColumnIds);
+      return allColumns.filter((col) => !urlSelectedSet.has(col.id)).map((col) => col.id);
+    }
+
+    const hidden = new Set(defaultHidden);
+
+    if (!columnState?.columnOverrides) {
+      return defaultHidden;
+    }
+
+    Object.entries(columnState.columnOverrides).forEach(([id, show]) => {
+      if (show) {
+        hidden.delete(id);
+      } else {
+        hidden.add(id);
+      }
+    });
+
+    return [...hidden];
+  }, [enableURLPersistence, columnState, defaultHidden, urlColumnIds, allColumns]);
+
+  const toggleColumns = useCallback(
+    (cols: TracesTableColumn[]) => {
+      if (!cols.length) return;
+
+      setColumnState((prev) => {
+        const prevOverrides = prev?.columnOverrides ?? {};
+        const nextOverrides = { ...prevOverrides };
+        let changed = false;
+
+        cols.forEach((col) => {
+          const currentlyHidden = hiddenColumns.includes(col.id);
+          const newShow = currentlyHidden;
+
+          if (nextOverrides[col.id] !== newShow) {
+            nextOverrides[col.id] = newShow;
+            changed = true;
+          }
+        });
+
+        return changed ? { ...prev, columnOverrides: nextOverrides } : prev;
+      });
+
+      if (enableURLPersistence) {
+        const currentHiddenSet = new Set(hiddenColumns);
+        cols.forEach((col) => {
+          if (currentHiddenSet.has(col.id)) {
+            currentHiddenSet.delete(col.id);
+          } else {
+            currentHiddenSet.add(col.id);
+          }
+        });
+
+        const newSelectedIds = allColumns.filter((col) => !currentHiddenSet.has(col.id)).map((col) => col.id);
+        // Use replace=true: column visibility is UI config, not navigation state
+        setUrlColumnIds(newSelectedIds, true);
+      }
+    },
+    [enableURLPersistence, setColumnState, hiddenColumns, allColumns, setUrlColumnIds],
+  );
+
+  return { hiddenColumns, toggleColumns };
+};
+
+/**
+ * This hook is used to manage the selected columns for the GenAITracesTable.
+ * It uses the useGenAITracesUIStateColumns hook to manage the hidden columns, and then filters the allColumns to get the selected columns.
+ * It also provides a function to set the selected columns, which will toggle the columns to be visible or hidden.
+ * @returns selectedColumns: The selected columns
+ * @returns toggleColumns: A function to toggle the columns
+ * @returns setSelectedColumns: A function to set the selected columns - can use to do bulk updates to selected columns
+ */
+export const useSelectedColumns = (
+  experimentId: string,
+  allColumns: TracesTableColumn[],
+  defaultSelectedColumns?: (cols: TracesTableColumn[]) => TracesTableColumn[],
+  runUuid?: string,
+  storageKeyPrefix?: string,
+) => {
+  const { hiddenColumns, toggleColumns } = useGenAITracesUIStateColumns(
+    experimentId,
+    allColumns,
+    defaultSelectedColumns,
+    runUuid,
+    storageKeyPrefix,
+  );
+
+  const selectedColumns = useMemo(
+    () => allColumns.filter((c) => !hiddenColumns.includes(c.id)),
+    [allColumns, hiddenColumns],
+  );
+
+  const setSelectedColumns = useCallback(
+    (nextSelected: TracesTableColumn[]) => {
+      if (isNil(nextSelected)) return;
+
+      const wantSelected = new Set(nextSelected.map((c) => c.id));
+      const toToggle: TracesTableColumn[] = [];
+
+      allColumns.forEach((col) => {
+        const isSelectedNow = !hiddenColumns.includes(col.id);
+        const willBeSelected = wantSelected.has(col.id);
+
+        if (isSelectedNow !== willBeSelected) {
+          // only flip what actually changes
+          toToggle.push(col);
+        }
+      });
+
+      if (toToggle.length) {
+        toggleColumns(toToggle);
+      }
+    },
+    [allColumns, hiddenColumns, toggleColumns],
+  );
+
+  return { selectedColumns, toggleColumns, setSelectedColumns };
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/useGenAiExperimentRunsForComparison.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/useGenAiExperimentRunsForComparison.tsx
@@ -1,0 +1,58 @@
+import type { QueryFunctionContext } from '../../query-client/queryClient';
+import { useQuery } from '../../query-client/queryClient';
+
+import { getAjaxUrl, makeRequest } from '../utils/FetchUtils';
+
+type UseExperimentRunsForTraceComparisonQueryKey = ['EXPERIMENT_RUNS_FOR_TRACE_COMPARISON', { experimentId: string }];
+
+const getQueryKey = (experimentId: string): UseExperimentRunsForTraceComparisonQueryKey => [
+  'EXPERIMENT_RUNS_FOR_TRACE_COMPARISON',
+  { experimentId },
+];
+
+type RawSearchRunsResponse = {
+  runs: {
+    info?: {
+      run_uuid?: string;
+      run_name?: string;
+    };
+  }[];
+};
+
+const queryFn = async ({
+  queryKey: [, { experimentId }],
+}: QueryFunctionContext<UseExperimentRunsForTraceComparisonQueryKey>): Promise<RawSearchRunsResponse> => {
+  const url = getAjaxUrl('ajax-api/2.0/mlflow/runs/search');
+  return makeRequest(url, 'POST', {
+    experiment_ids: [experimentId],
+  });
+};
+
+/**
+ * Fetches the runs for the given experiment, used for the "compare to" dropdown in the eval page.
+ */
+export const useGenAiExperimentRunsForComparison = (experimentId: string | undefined, disabled = false) => {
+  const { data, error, isLoading, isFetching } = useQuery<
+    RawSearchRunsResponse,
+    Error,
+    RawSearchRunsResponse,
+    UseExperimentRunsForTraceComparisonQueryKey
+  >(getQueryKey(experimentId ?? ''), {
+    queryFn,
+    enabled: !disabled && Boolean(experimentId),
+    cacheTime: Infinity,
+    staleTime: Infinity,
+  });
+
+  const runInfos = data?.runs?.map((run) => ({
+    runUuid: run.info?.run_uuid,
+    runName: run.info?.run_name,
+  }));
+
+  return {
+    requestError: error,
+    isLoading,
+    isFetching,
+    runInfos,
+  };
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/useGenAiTraceEvaluationArtifacts.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/useGenAiTraceEvaluationArtifacts.tsx
@@ -1,0 +1,93 @@
+import { useMemo } from 'react';
+
+import type { QueryFunctionContext } from '../../query-client/queryClient';
+import { useQueries } from '../../query-client/queryClient';
+
+import { GenAiTraceEvaluationArtifactFile } from '../enum';
+import type {
+  EvaluationArtifactTableEntryAssessment,
+  EvaluationArtifactTableEntryEvaluation,
+  EvaluationArtifactTableEntryMetric,
+  RawGenaiEvaluationArtifactResponse,
+} from '../types';
+import { mergeMetricsAndAssessmentsWithEvaluations, parseRawTableArtifact } from '../utils/EvaluationDataParseUtils';
+import { getAjaxUrl, makeRequest } from '../utils/FetchUtils';
+
+type UseGetTraceEvaluationArtifactQueryKey = [
+  'GET_TRACE_EVALUATION_ARTIFACT',
+  { runUuid: string; artifactFile: GenAiTraceEvaluationArtifactFile },
+];
+
+const getQueryKey = (
+  runUuid: string,
+  artifactFile: GenAiTraceEvaluationArtifactFile,
+): UseGetTraceEvaluationArtifactQueryKey => ['GET_TRACE_EVALUATION_ARTIFACT', { runUuid, artifactFile }];
+
+const queryFn = async ({
+  queryKey: [, { runUuid, artifactFile }],
+}: QueryFunctionContext<UseGetTraceEvaluationArtifactQueryKey>): Promise<RawGenaiEvaluationArtifactResponse> => {
+  const queryParams = new URLSearchParams({ run_uuid: runUuid, path: artifactFile });
+  const url = [getAjaxUrl('ajax-api/2.0/mlflow/get-artifact'), queryParams].join('?');
+  return makeRequest(url, 'GET').then((data) => ({
+    ...data,
+    filename: artifactFile,
+  }));
+};
+
+const allArtifactFiles = [
+  GenAiTraceEvaluationArtifactFile.Assessments,
+  GenAiTraceEvaluationArtifactFile.Evaluations,
+  GenAiTraceEvaluationArtifactFile.Metrics,
+];
+
+/**
+ * Fetches evaluation trace artifacts for a given run.
+ * @param runUuid - The run UUID for which to fetch evaluation artifacts.
+ * @param artifacts - The list of artifact files to fetch. By default, all artifacts are fetched.
+ */
+export const useGenAiTraceEvaluationArtifacts = (
+  { runUuid, artifacts = allArtifactFiles }: { runUuid: string; artifacts?: GenAiTraceEvaluationArtifactFile[] },
+  { disabled = false }: { disabled?: boolean } = {},
+) => {
+  const isAnyArtifactRetrievalEnabled =
+    !disabled && allArtifactFiles.some((artifactFile) => artifacts.includes(artifactFile));
+
+  const queriesResult = useQueries({
+    queries: allArtifactFiles.map((artifactFile) => ({
+      queryFn,
+      queryKey: getQueryKey(runUuid, artifactFile),
+      enabled: !disabled && artifacts.includes(artifactFile),
+      refetchOnWindowFocus: false,
+    })),
+  });
+
+  const isLoading = queriesResult.some((query) => query.isLoading);
+  const isFetching = queriesResult.some((query) => query.isFetching);
+  const error = queriesResult.find((query) => query.error);
+
+  const [assessments, evaluations, metrics] = queriesResult.map((query) => query.data);
+
+  const parsedAssessments = useMemo(
+    () => parseRawTableArtifact<EvaluationArtifactTableEntryAssessment[]>(assessments),
+    [assessments],
+  );
+  const parsedEvaluations = useMemo(
+    () => parseRawTableArtifact<EvaluationArtifactTableEntryEvaluation[]>(evaluations),
+    [evaluations],
+  );
+  const parsedMetrics = useMemo(() => parseRawTableArtifact<EvaluationArtifactTableEntryMetric[]>(metrics), [metrics]);
+
+  const mergedData = useMemo(() => {
+    if (!parsedEvaluations) {
+      return undefined;
+    }
+    return mergeMetricsAndAssessmentsWithEvaluations(parsedEvaluations, parsedMetrics, parsedAssessments);
+  }, [parsedAssessments, parsedEvaluations, parsedMetrics]);
+
+  return {
+    requestError: error,
+    isLoading: isLoading && isAnyArtifactRetrievalEnabled,
+    isFetching: isFetching && isAnyArtifactRetrievalEnabled,
+    data: mergedData,
+  };
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/useGenAiTraceTableRowSelection.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/useGenAiTraceTableRowSelection.tsx
@@ -1,0 +1,50 @@
+import type { RowSelectionState } from '@tanstack/react-table';
+import type { SetStateAction } from 'react';
+import { createContext, useContext, useState } from 'react';
+
+const GenAiTraceTableRowSelectionContext = createContext<{
+  rowSelection: RowSelectionState;
+  setRowSelection: (rowSelection: SetStateAction<RowSelectionState>) => void;
+} | null>(null);
+
+export const useGenAiTraceTableRowSelection = () => {
+  const context = useContext(GenAiTraceTableRowSelectionContext);
+
+  // In a regular use case, we use the local state to manage the row selection.
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+
+  // However, if context is provided, we use the context to manage the row selection.
+  if (context) {
+    return context;
+  }
+  return { rowSelection, setRowSelection };
+};
+
+/**
+ * Hook to check if we're inside a GenAiTraceTableRowSelectionProvider.
+ * Useful for components that need to conditionally create their own provider.
+ */
+export const useIsInsideGenAiTraceTableRowSelectionProvider = () => {
+  const context = useContext(GenAiTraceTableRowSelectionContext);
+  return context !== null;
+};
+
+/**
+ * Use this provider to manage selected rows across the table using a context.
+ * If not used, the consumers of `useGenAiTraceTableRowSelection()` will use the local state to manage the row selection.
+ */
+export const GenAiTraceTableRowSelectionProvider = ({
+  children,
+  rowSelection,
+  setRowSelection,
+}: {
+  children: React.ReactNode;
+  rowSelection: RowSelectionState;
+  setRowSelection: (rowSelection: SetStateAction<RowSelectionState>) => void;
+}) => {
+  return (
+    <GenAiTraceTableRowSelectionContext.Provider value={{ rowSelection, setRowSelection }}>
+      {children}
+    </GenAiTraceTableRowSelectionContext.Provider>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/useGetTrace.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/useGetTrace.tsx
@@ -1,0 +1,147 @@
+import { isNil } from 'lodash';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+
+import type { ModelTraceInfoV3, ModelTrace } from '../../model-trace-explorer/ModelTrace.types';
+import { isV3ModelTraceInfo, isV4TraceId } from '../../model-trace-explorer/ModelTraceExplorer.utils';
+import { useQuery } from '../../query-client/queryClient';
+
+import { createTraceLocationForExperiment, createTraceLocationForDestinationPath } from '../utils/TraceLocationUtils';
+import { formatTraceId } from '../utils/TraceUtils';
+
+export type GetTraceFunction = (
+  traceId?: string,
+  traceInfo?: ModelTrace['info'],
+  // should be undefined in OSS
+  sqlWarehouseId?: string,
+) => Promise<ModelTrace | undefined>;
+
+export function useGetTrace({
+  getTrace,
+  traceInfo,
+  enablePolling,
+  sqlWarehouseId,
+}: {
+  getTrace?: GetTraceFunction;
+  traceInfo?: ModelTrace['info'];
+  enablePolling?: boolean;
+  sqlWarehouseId?: string;
+}) {
+  const traceId = useMemo(() => {
+    if (!traceInfo) {
+      return undefined;
+    }
+    return isV3ModelTraceInfo(traceInfo) ? formatTraceId(traceInfo) : (traceInfo.request_id ?? '');
+  }, [traceInfo]);
+
+  const getTraceFn = useCallback(
+    (traceInfo?: ModelTrace['info']) => {
+      if (!getTrace || isNil(traceId)) {
+        return Promise.resolve(undefined);
+      }
+      // prettier-ignore
+      return getTrace(
+        traceId,
+        traceInfo,
+        sqlWarehouseId,
+      );
+    },
+    [getTrace, traceId, sqlWarehouseId],
+  );
+
+  // Maximum number of polling attempts after the trace reaches OK state.
+  // This allows child spans that are still being uploaded to arrive,
+  // while preventing infinite polling when num_spans metadata is inconsistent.
+  const MAX_OK_STATE_POLL_COUNT = 60; // 60 seconds at 1s interval
+  const okStatePollCountRef = useRef(0);
+
+  // Reset poll count when navigating to a different trace
+  useEffect(() => {
+    okStatePollCountRef.current = 0;
+  }, [traceId]);
+
+  const getRefreshInterval = (data: ModelTrace | undefined) => {
+    // Keep polling until trace is completed and span counts matches with the number logged in the
+    // trace info. The latter check is to avoid race condition where the trace status is finalized
+    // before child spans arrive at the backend.
+    const traceInfo = data && isV3ModelTraceInfo(data.info) ? data.info : undefined;
+
+    // ERROR state indicates that the trace is likely finished, so stop polling
+    if (traceInfo?.state === 'ERROR') {
+      return false;
+    }
+
+    if (!traceInfo || traceInfo.state === 'IN_PROGRESS') return 1000;
+
+    const traceStats = traceInfo.trace_metadata?.['mlflow.trace.sizeStats'];
+
+    // If the stats metadata is not available, stop polling.
+    if (!traceStats) return false;
+
+    const expected = JSON.parse(traceStats).num_spans;
+    const actual = data?.data?.spans?.length ?? 0;
+
+    // Poll until the actual span count reaches at least the expected count.
+    // NB: In distributed tracing case, the actual span count exceeds the expected count because
+    // sizeStats only counts spans from the originating process.
+    if (actual >= expected) {
+      okStatePollCountRef.current = 0;
+      return false;
+    }
+
+    // Stop polling after the maximum number of attempts to prevent infinite loops
+    // when num_spans metadata is inconsistent with actual span count.
+    okStatePollCountRef.current += 1;
+    if (okStatePollCountRef.current >= MAX_OK_STATE_POLL_COUNT) {
+      okStatePollCountRef.current = 0;
+      return false;
+    }
+
+    // Poll again after 1 second
+    return 1000;
+  };
+
+  return useQuery({
+    queryKey: ['getTrace', traceId],
+    queryFn: () => getTraceFn(traceInfo),
+    enabled: !isNil(getTrace) && !isNil(traceId),
+    staleTime: Infinity, // Keep data fresh as long as the component is mounted
+    refetchOnWindowFocus: false, // Disable refetching on window focus
+    retry: 1,
+    keepPreviousData: true,
+    refetchInterval: enablePolling ? getRefreshInterval : false,
+  });
+}
+
+export const useGetTraceByFullTraceId = (getTrace?: GetTraceFunction, fullTraceId?: string) => {
+  const parsedTraceLocation = useMemo<Partial<ModelTraceInfoV3> | undefined>(() => {
+    const parseV4TraceId = (traceId: string): Partial<ModelTraceInfoV3> | undefined => {
+      if (!isV4TraceId(traceId)) {
+        return undefined;
+      }
+      const [, trace_location_string, trace_id] = traceId.split('/');
+
+      const trace_location = !trace_location_string.includes('.')
+        ? createTraceLocationForExperiment(trace_location_string)
+        : createTraceLocationForDestinationPath(trace_location_string);
+
+      return {
+        trace_id,
+        trace_location,
+      };
+    };
+
+    if (!fullTraceId) {
+      return undefined;
+    }
+    return parseV4TraceId(fullTraceId);
+  }, [fullTraceId]);
+  return useQuery({
+    queryKey: ['getTrace', fullTraceId],
+    queryFn: () => getTrace?.(fullTraceId, parsedTraceLocation),
+    enabled: !isNil(getTrace) && !isNil(fullTraceId),
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+    retry: 1,
+    keepPreviousData: true,
+  });
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/useGetTraces.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/useGetTraces.tsx
@@ -1,0 +1,53 @@
+import { compact, isNil } from 'lodash';
+import { useCallback } from 'react';
+
+import { isV3ModelTraceInfo } from '../../model-trace-explorer/ModelTraceExplorer.utils';
+import type { ModelTrace } from '../../model-trace-explorer/ModelTrace.types';
+import { useArrayMemo } from '../../model-trace-explorer/hooks/useArrayMemo';
+import { useQueries, useQueryClient } from '../../query-client/queryClient';
+
+export type GetTraceFunction = (traceId?: string, traceInfo?: ModelTrace['info']) => Promise<ModelTrace | undefined>;
+
+const QUERY_KEY = 'getTrace';
+
+// unfortunately the util from model-trace-explorer
+// requires the whole trace object, not just the info
+function getModelTraceId(traceInfo: ModelTrace['info']): string {
+  return isV3ModelTraceInfo(traceInfo) ? traceInfo.trace_id : (traceInfo.request_id ?? '');
+}
+
+export function useGetTraces(getTrace?: GetTraceFunction, traceInfos?: ModelTrace['info'][]) {
+  const queryClient = useQueryClient();
+
+  const queries = useQueries({
+    queries: (traceInfos ?? []).map((traceInfo) => {
+      const traceId = getModelTraceId(traceInfo);
+
+      return {
+        queryKey: [QUERY_KEY, traceId],
+        queryFn: async () => {
+          return getTrace?.(traceId, traceInfo);
+        },
+        enabled: !isNil(getTrace) && Boolean(traceId),
+        refetchOnWindowFocus: false,
+        retry: 1,
+        keepPreviousData: true,
+      };
+    }),
+  });
+
+  const data = useArrayMemo(compact(queries.map((query) => query.data)));
+  const isLoading = queries.some((query) => query.isLoading);
+  const invalidateSingleTraceQuery = useCallback(
+    (traceId?: string) => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEY, traceId] });
+    },
+    [queryClient],
+  );
+
+  return {
+    data,
+    isLoading,
+    invalidateSingleTraceQuery,
+  };
+}

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/useMlflowTraces.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/useMlflowTraces.tsx
@@ -1,0 +1,1097 @@
+import { isNil } from 'lodash';
+import { useMemo } from 'react';
+
+import { useIntl } from '@databricks/i18n';
+import type { NetworkRequestError } from '../../errors/PredefinedErrors';
+import type { QueryClient } from '../../query-client/queryClient';
+import { useQuery, useInfiniteQuery } from '../../query-client/queryClient';
+import {
+  isV4TraceId,
+  parseV4TraceId,
+  parseTraceV4SerializedLocation,
+  createTraceV4SerializedLocation,
+} from '../../model-trace-explorer/ModelTraceExplorer.utils';
+
+import {
+  EXECUTION_DURATION_COLUMN_ID,
+  REQUEST_TIME_COLUMN_ID,
+  RUN_NAME_COLUMN_ID,
+  SESSION_COLUMN_ID,
+  STATE_COLUMN_ID,
+  USER_COLUMN_ID,
+  LOGGED_MODEL_COLUMN_ID,
+  TRACE_NAME_COLUMN_ID,
+  SOURCE_COLUMN_ID,
+  useTableColumns,
+  LINKED_PROMPTS_COLUMN_ID,
+  CUSTOM_METADATA_COLUMN_ID,
+  SPAN_NAME_COLUMN_ID,
+  SPAN_TYPE_COLUMN_ID,
+  SPAN_STATUS_COLUMN_ID,
+  SPAN_CONTENT_COLUMN_ID,
+  INPUTS_COLUMN_ID,
+  RESPONSE_COLUMN_ID,
+  ISSUE_ID_COLUMN_ID,
+  GIT_BRANCH_COLUMN_ID,
+  GIT_COMMIT_COLUMN_ID,
+} from './useTableColumns';
+import { TracesServiceV4, fetchTraceInfoV3 } from '../../model-trace-explorer/api';
+import type { ModelTraceInfoV3, ModelTraceSearchLocation } from '../../model-trace-explorer/ModelTrace.types';
+import { SourceCellRenderer } from '../cellRenderers/Source/SourceRenderer';
+import type {
+  TableFilterOption,
+  EvaluationsOverviewTableSort,
+  AssessmentFilter,
+  TableFilter,
+  TableFilterOptions,
+} from '../types';
+import {
+  FilterOperator,
+  HiddenFilterOperator,
+  TracesTableColumnGroup,
+  TracesTableColumnType,
+  isNullOperator,
+} from '../types';
+import { ERROR_KEY, getAssessmentInfos } from '../utils/AggregationUtils';
+import { filterEvaluationResults } from '../utils/EvaluationsFilterUtils';
+import {
+  getMlflowTracesSearchPageSize,
+  getEvalTabTotalTracesLimit,
+  shouldUseTracesV4API,
+  shouldUseLongRunningTracesAPI,
+  shouldUseInfinitePaginatedTraces,
+} from '../utils/FeatureUtils';
+import { fetchAPI, getAjaxUrl } from '../utils/FetchUtils';
+import MlflowUtils from '../utils/MlflowUtils';
+import {
+  convertTraceInfoV3ToRunEvalEntry,
+  filterTracesByAssessmentSourceRunId,
+  getCustomMetadataKeyFromColumnId,
+} from '../utils/TraceUtils';
+import { isV4TraceLocation } from '../utils/TraceLocationUtils';
+
+interface SearchMlflowTracesRequest {
+  locations?: ModelTraceSearchLocation[];
+  filter?: string;
+  max_results: number;
+  page_token?: string;
+  order_by?: string[];
+  model_id?: string;
+  sql_warehouse_id?: string;
+}
+
+export const SEARCH_MLFLOW_TRACES_QUERY_KEY = 'searchMlflowTraces';
+const TRACE_ID_LOOKUP_QUERY_KEY = 'traceIdLookup';
+
+export const invalidateMlflowSearchTracesCache = ({ queryClient }: { queryClient: QueryClient }) => {
+  queryClient.invalidateQueries({ queryKey: [SEARCH_MLFLOW_TRACES_QUERY_KEY] });
+};
+
+/**
+ * Hex string pattern: 32-char hex strings (common backend trace ID format).
+ */
+const HEX_TRACE_ID_PATTERN = /^[0-9a-fA-F]{32}$/;
+
+/**
+ * Detects whether a search query looks like a trace ID.
+ * Supports:
+ *   - Full V4 trace ID: trace:/catalog.schema/abc123...
+ *   - Backend trace ID: 32-character hex string (e.g. 11301f0bdf2dfa5a762a4bac74b45db1)
+ */
+export const extractTraceIdFromSearchQuery = (
+  searchQuery: string,
+): { backendTraceId: string; traceLocation?: string } | undefined => {
+  const trimmed = searchQuery.trim();
+
+  // Check for V4 full trace ID format: trace:/location/traceId
+  if (isV4TraceId(trimmed)) {
+    const parsed = parseV4TraceId(trimmed);
+    if (parsed?.trace_id && parsed?.trace_location) {
+      return { backendTraceId: parsed.trace_id, traceLocation: parsed.trace_location };
+    }
+    return undefined;
+  }
+
+  // Check for plain backend trace ID (32-char hex string)
+  if (HEX_TRACE_ID_PATTERN.test(trimmed)) {
+    return { backendTraceId: trimmed };
+  }
+
+  return undefined;
+};
+
+/**
+ * Hook that looks up a single trace by trace ID when the search query appears to be a trace ID.
+ * Uses get_trace / batch get API to fetch the trace directly, since trace_id is not a
+ * searchable field in the search traces API.
+ */
+const useTraceIdLookup = ({
+  searchQuery,
+  locations,
+  sqlWarehouseId,
+  enabled = true,
+}: {
+  searchQuery?: string;
+  locations?: ModelTraceSearchLocation[];
+  sqlWarehouseId?: string;
+  enabled?: boolean;
+}): { data: ModelTraceInfoV3 | undefined; isLoading: boolean } => {
+  const traceIdInfo = useMemo(() => {
+    if (!searchQuery) return undefined;
+    return extractTraceIdFromSearchQuery(searchQuery);
+  }, [searchQuery]);
+
+  const isQueryEnabled = enabled && !isNil(traceIdInfo);
+  const usingV4APIs = locations?.some(isV4TraceLocation) && shouldUseTracesV4API();
+
+  const result = useQuery<ModelTraceInfoV3 | undefined, NetworkRequestError>({
+    refetchOnWindowFocus: false,
+    enabled: isQueryEnabled,
+    queryKey: [TRACE_ID_LOOKUP_QUERY_KEY, traceIdInfo?.backendTraceId, traceIdInfo?.traceLocation],
+    queryFn: async () => {
+      if (!traceIdInfo) return undefined;
+
+      const { backendTraceId, traceLocation: traceLocationString } = traceIdInfo;
+
+      try {
+        if (usingV4APIs && traceLocationString) {
+          // Only look up traces in locations linked to the current experiment
+          const isLinkedLocation = locations?.some(
+            (loc) => createTraceV4SerializedLocation(loc) === traceLocationString,
+          );
+          if (!isLinkedLocation) return undefined;
+
+          const traceLocation = parseTraceV4SerializedLocation(traceLocationString);
+          const response = await TracesServiceV4.getBatchTracesV4({
+            traceIds: [backendTraceId],
+            traceLocation,
+          });
+          return response?.traces?.[0]?.trace_info;
+        } else if (usingV4APIs && locations && locations.length > 0) {
+          // For V4 APIs without a location in the trace ID, try each location
+          let lastError: unknown;
+          for (const location of locations) {
+            try {
+              const response = await TracesServiceV4.getBatchTracesV4({
+                traceIds: [backendTraceId],
+                traceLocation: location,
+              });
+              if (response?.traces?.[0]?.trace_info) {
+                return response.traces[0].trace_info;
+              }
+            } catch (error) {
+              lastError = error;
+            }
+          }
+          // If every location returned empty, the trace wasn't found
+          if (!lastError) return undefined;
+          // If every location errored, throw the last one so react-query
+          // marks it as failed rather than caching undefined as success
+          throw lastError;
+        } else {
+          // For V3 APIs, use the V3 fetch
+          const response = await fetchTraceInfoV3({ traceId: backendTraceId });
+          return response?.trace?.trace_info;
+        }
+      } catch (error) {
+        if (error instanceof Error && 'status' in error && (error as NetworkRequestError).status === 404) {
+          return undefined;
+        }
+        throw error;
+      }
+    },
+    retry: false,
+  });
+
+  return {
+    data: result.data ?? undefined,
+    // Only report loading when the query is actually enabled
+    isLoading: isQueryEnabled && result.isLoading,
+  };
+};
+
+const defaultTableSort: EvaluationsOverviewTableSort = {
+  asc: false,
+  key: REQUEST_TIME_COLUMN_ID,
+  type: TracesTableColumnType.TRACE_INFO,
+};
+
+export const useMlflowTracesTableMetadata = ({
+  locations,
+  runUuid,
+  timeRange,
+  otherRunUuid,
+  filterByLoggedModelId,
+  loggedModelId,
+  sqlWarehouseId,
+  disabled,
+  networkFilters,
+  filterByAssessmentSourceRun = false,
+}: {
+  locations: ModelTraceSearchLocation[];
+  runUuid?: string;
+  timeRange?: { startTime?: string; endTime?: string };
+  otherRunUuid?: string;
+  /**
+   * Logged model ID to filter offline traces by. Uses trace's request metadata for filtering.
+   * To fetch online traces related to a certain logged model, use "loggedModelId" field.
+   * N/B: request fields for fetching online and offline traces will be unified in the near future.
+   */
+  filterByLoggedModelId?: string;
+  /**
+   * Used to request online traces by logged model ID.
+   * If provided, sqlWarehouseId is required in order to query inference tables.
+   * N/B: request fields for fetching online and offline traces will be unified in the near future.
+   */
+  loggedModelId?: string;
+  sqlWarehouseId?: string;
+  disabled?: boolean;
+  networkFilters?: TableFilter[];
+  /**
+   * If true, filters traces by assessment source run ID. This is used in the eval tab
+   * to only show assessments that were created by the current evaluation run.
+   * Defaults to false for other tabs (traces, labeling, etc.).
+   */
+  filterByAssessmentSourceRun?: boolean;
+}) => {
+  const intl = useIntl();
+  const filter = createMlflowSearchFilter(runUuid, timeRange, networkFilters, filterByLoggedModelId);
+  const usingV4APIs = locations?.some(isV4TraceLocation) && shouldUseTracesV4API();
+
+  const orderBy = createMlflowSearchOrderBy(defaultTableSort);
+
+  const {
+    data: traces,
+    isLoading: isInnerLoading,
+    error,
+  } = useSearchMlflowTracesInner({
+    locations,
+    filter,
+    loggedModelId,
+    sqlWarehouseId,
+    enabled: !disabled,
+    orderBy,
+  });
+  const filteredTraces = useMemo(
+    () => (filterByAssessmentSourceRun ? filterTracesByAssessmentSourceRunId(traces, runUuid) : traces),
+    [traces, runUuid, filterByAssessmentSourceRun],
+  );
+
+  const otherFilter = createMlflowSearchFilter(otherRunUuid, timeRange);
+  const {
+    data: otherTraces,
+    isLoading: isOtherInnerLoading,
+    error: otherError,
+  } = useSearchMlflowTracesInner({
+    locations,
+    filter: otherFilter,
+    enabled: !disabled && Boolean(otherRunUuid),
+    loggedModelId,
+    sqlWarehouseId,
+    orderBy,
+  });
+
+  const filteredOtherTraces = useMemo(
+    () => (filterByAssessmentSourceRun ? filterTracesByAssessmentSourceRunId(otherTraces, otherRunUuid) : otherTraces),
+    [otherTraces, otherRunUuid, filterByAssessmentSourceRun],
+  );
+
+  const evaluatedTraces = useMemo(() => {
+    if (!filteredTraces || isInnerLoading || error || !filteredTraces.length) {
+      return [];
+    }
+    return filteredTraces.map((trace) => convertTraceInfoV3ToRunEvalEntry(trace));
+  }, [filteredTraces, isInnerLoading, error]);
+
+  const otherEvaluatedTraces = useMemo(() => {
+    const isOtherLoading = isOtherInnerLoading && Boolean(otherRunUuid);
+    if (!filteredOtherTraces || isOtherLoading || otherError || !filteredOtherTraces.length) {
+      return [];
+    }
+    return filteredOtherTraces.map((trace) => convertTraceInfoV3ToRunEvalEntry(trace));
+  }, [filteredOtherTraces, isOtherInnerLoading, otherError, otherRunUuid]);
+
+  const assessmentInfos = useMemo(() => {
+    return getAssessmentInfos(intl, evaluatedTraces || [], otherEvaluatedTraces || []);
+  }, [intl, evaluatedTraces, otherEvaluatedTraces]);
+
+  const tableFilterOptions = useMemo(() => {
+    // Add source options
+    const sourceMap = new Map<string, TableFilterOption>();
+    const promptMap = new Map<string, TableFilterOption>();
+
+    filteredTraces?.forEach((trace) => {
+      const traceMetadata = trace.trace_metadata;
+      if (traceMetadata) {
+        const sourceName = traceMetadata[MlflowUtils.sourceNameTag];
+        if (sourceName && !sourceMap.has(sourceName)) {
+          sourceMap.set(sourceName, {
+            value: sourceName,
+            renderValue: () => <SourceCellRenderer traceInfo={trace} isComparing={false} disableLinks />,
+          });
+        }
+      }
+
+      // Extract linked prompts from trace tags. Fetch data from backend if users
+      // want to filter by prompt not included in the current traces.
+      const tags = trace.tags;
+      if (tags && tags['mlflow.linkedPrompts']) {
+        try {
+          const linkedPrompts = JSON.parse(tags['mlflow.linkedPrompts']);
+          if (Array.isArray(linkedPrompts)) {
+            linkedPrompts.forEach((prompt: { name: string; version: string }) => {
+              const promptValue = `${prompt.name}/${prompt.version}`;
+              if (!promptMap.has(promptValue)) {
+                promptMap.set(promptValue, {
+                  value: promptValue,
+                  renderValue: () => promptValue,
+                });
+              }
+            });
+          }
+        } catch (e) {
+          // Ignore invalid JSON
+        }
+      }
+    });
+
+    return {
+      source: Array.from(sourceMap.values()).sort((a, b) => a.value.localeCompare(b.value)),
+      prompt: Array.from(promptMap.values()).sort((a, b) => a.value.localeCompare(b.value)),
+    } as TableFilterOptions;
+  }, [filteredTraces]);
+
+  const allColumns = useTableColumns(intl, evaluatedTraces || [], assessmentInfos, runUuid, undefined, true);
+
+  return useMemo(() => {
+    return {
+      assessmentInfos,
+      allColumns,
+      totalCount: evaluatedTraces.length,
+      evaluatedTraces,
+      otherEvaluatedTraces,
+      isLoading: isInnerLoading && !disabled,
+      error,
+      isEmpty: evaluatedTraces.length === 0,
+      tableFilterOptions,
+    };
+  }, [
+    assessmentInfos,
+    allColumns,
+    isInnerLoading,
+    error,
+    evaluatedTraces,
+    tableFilterOptions,
+    disabled,
+    otherEvaluatedTraces,
+  ]);
+};
+
+const getNetworkAndClientFilters = (
+  filters: TableFilter[],
+  assessmentsFilteredOnClientSide = true,
+): {
+  networkFilters: TableFilter[];
+  clientFilters: TableFilter[];
+} => {
+  return filters.reduce<{
+    networkFilters: TableFilter[];
+    clientFilters: TableFilter[];
+  }>(
+    (acc, filter) => {
+      // IS NULL / IS NOT NULL operators should always go to network filters
+      // since they don't require a value and are handled by the backend
+      if (filter.column === TracesTableColumnGroup.ASSESSMENT && isNullOperator(filter.operator)) {
+        acc.networkFilters.push(filter);
+        return acc;
+      }
+
+      // Assessment filters with undefined or 'Error' value must always be filtered client-side
+      // because the backend cannot query for absence of an assessment or error state.
+      // Note: filter.value is already converted from string 'undefined' to actual undefined by useFilters
+      //
+      // All numeric assessment filters are handled client-side because the backend
+      // does not yet support numeric assessment comparisons.
+      const isNumericValue =
+        typeof filter.value === 'number' ||
+        (typeof filter.value === 'string' && !isNaN(Number(filter.value)) && filter.value.trim() !== '');
+      const isClientOnlyAssessmentFilter =
+        filter.column === TracesTableColumnGroup.ASSESSMENT &&
+        (filter.value === undefined || filter.value === ERROR_KEY || isNumericValue);
+
+      if (isClientOnlyAssessmentFilter) {
+        acc.clientFilters.push(filter);
+      } else if (filter.column === TracesTableColumnGroup.ASSESSMENT && assessmentsFilteredOnClientSide) {
+        acc.clientFilters.push(filter);
+      } else {
+        acc.networkFilters.push(filter);
+      }
+      return acc;
+    },
+    { networkFilters: [], clientFilters: [] },
+  );
+};
+
+export const useSearchMlflowTraces = ({
+  locations,
+  currentRunDisplayName,
+  runUuid,
+  timeRange,
+  searchQuery,
+  filters,
+  disabled,
+  pageSize,
+  limit,
+  filterByLoggedModelId,
+  tableSort,
+  loggedModelId,
+  sqlWarehouseId,
+  filterByAssessmentSourceRun = false,
+  enablePagination = true,
+  refetchInterval,
+}: {
+  locations: ModelTraceSearchLocation[];
+  runUuid?: string | null;
+  timeRange?: { startTime?: string; endTime?: string };
+  searchQuery?: string;
+  filters?: TableFilter[];
+  disabled?: boolean;
+  pageSize?: number;
+  limit?: number;
+  // TODO: Remove these once mlflow apis support filtering
+  currentRunDisplayName?: string;
+  /**
+   * Logged model ID to filter offline traces by. Uses trace's request metadata for filtering.
+   * To fetch online traces related to a certain logged model, use "loggedModelId" field.
+   * N/B: request fields for fetching online and offline traces will be unified in the near future.
+   */
+  filterByLoggedModelId?: string;
+  /**
+   * Used to request online traces by logged model ID.
+   * If provided, sqlWarehouseId is required in order to query inference tables.
+   * N/B: request fields for fetching online and offline traces will be unified in the near future.
+   */
+  loggedModelId?: string;
+  sqlWarehouseId?: string;
+  tableSort?: EvaluationsOverviewTableSort;
+  /**
+   * If true, filters traces by assessment source run ID. This is used in the eval tab
+   * to only show assessments that were created by the current evaluation run.
+   * Defaults to false for other tabs (traces, labeling, etc.).
+   */
+  filterByAssessmentSourceRun?: boolean;
+  /**
+   * When false, forces the eager-fetch path even when infinite pagination is globally enabled.
+   * Used to disable pagination in run comparison mode where both runs need complete data
+   * to join on inputs.
+   */
+  enablePagination?: boolean;
+  /**
+   * Optional React Query refetch interval (ms). When set, the underlying query
+   * is polled at this interval. Pass `false` to disable polling.
+   */
+  refetchInterval?: number | false;
+}): {
+  data: ModelTraceInfoV3[] | undefined;
+  isLoading: boolean;
+  isFetching: boolean;
+  error?: NetworkRequestError | Error;
+  refetchMlflowTraces?: () => void;
+  fetchNextPage?: () => void;
+  hasNextPage?: boolean;
+  isFetchingNextPage?: boolean;
+} => {
+  // Client-side filtering is always disabled in OSS MLflow. It is only used in Databricks.
+  const useClientSideFiltering = false;
+
+  const { networkFilters, clientFilters } = useMemo(
+    () => getNetworkAndClientFilters(filters || [], useClientSideFiltering),
+    [filters, useClientSideFiltering],
+  );
+
+  const filter = createMlflowSearchFilter(
+    runUuid,
+    timeRange,
+    networkFilters,
+    filterByLoggedModelId,
+    useClientSideFiltering ? undefined : searchQuery,
+  );
+  const orderBy = createMlflowSearchOrderBy(tableSort);
+
+  // When the search query looks like a trace ID, look it up directly via get_trace API
+  // since trace_id is not a searchable field in the search traces API.
+  const { data: traceIdLookupResult, isLoading: isTraceIdLookupLoading } = useTraceIdLookup({
+    searchQuery,
+    locations,
+    sqlWarehouseId,
+    enabled: !disabled,
+  });
+
+  const {
+    data: traces,
+    isLoading: isInnerLoading,
+    isFetching: isInnerFetching,
+    error,
+    refetch: refetchMlflowTraces,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useSearchMlflowTracesInner({
+    locations,
+    filter,
+    enabled: !disabled,
+    pageSize,
+    limit,
+    orderBy,
+    loggedModelId,
+    sqlWarehouseId,
+    enablePagination,
+    refetchInterval,
+  });
+
+  // Merge the trace ID lookup result with the search results. If the lookup found a trace,
+  // prepend it to the list (if not already present) so it appears in the results.
+  const tracesWithIdLookup = useMemo(() => {
+    if (!traceIdLookupResult || !traces) {
+      return traces;
+    }
+    const alreadyPresent = traces.some((t) => t.trace_id === traceIdLookupResult.trace_id);
+    if (alreadyPresent) {
+      return traces;
+    }
+    return [traceIdLookupResult, ...traces];
+  }, [traces, traceIdLookupResult]);
+
+  // TODO: Remove this once mlflow apis support filtering
+  const evalTraceComparisonEntries = useMemo(() => {
+    if (!tracesWithIdLookup) {
+      return undefined;
+    }
+
+    return tracesWithIdLookup.map((trace) => {
+      return {
+        currentRunValue: convertTraceInfoV3ToRunEvalEntry(trace),
+        otherRunValue: undefined,
+      };
+    });
+  }, [tracesWithIdLookup]);
+
+  const filteredTraces: ModelTraceInfoV3[] | undefined = useMemo(() => {
+    if (!evalTraceComparisonEntries) return undefined;
+
+    const hasClientFilters = clientFilters && clientFilters.length > 0;
+    // Only apply client-side search filtering when useClientSideFiltering is true.
+    // When false, searchQuery is already applied server-side via createMlflowSearchFilter.
+    const clientSearchQuery = useClientSideFiltering ? searchQuery : undefined;
+    const hasClientSearchQuery = clientSearchQuery && clientSearchQuery !== '';
+
+    // Skip filtering if there are no client filters to apply
+    if (!hasClientFilters && !hasClientSearchQuery) {
+      return evalTraceComparisonEntries.reduce<ModelTraceInfoV3[]>((acc, entry) => {
+        if (entry.currentRunValue?.traceInfo) {
+          acc.push(entry.currentRunValue.traceInfo);
+        }
+        return acc;
+      }, []);
+    }
+
+    const assessmentFilters: AssessmentFilter[] = clientFilters.map((filter) => {
+      return {
+        assessmentName: filter.key || '',
+        filterValue: filter.value,
+        filterOperator: filter.operator as FilterOperator,
+        run: currentRunDisplayName || '',
+      };
+    });
+
+    const res = filterEvaluationResults(
+      evalTraceComparisonEntries,
+      assessmentFilters || [],
+      clientSearchQuery,
+      currentRunDisplayName,
+      undefined,
+    ).reduce<ModelTraceInfoV3[]>((acc, entry) => {
+      if (entry.currentRunValue?.traceInfo) {
+        acc.push(entry.currentRunValue.traceInfo);
+      }
+      return acc;
+    }, []);
+
+    return res;
+  }, [evalTraceComparisonEntries, clientFilters, searchQuery, currentRunDisplayName, useClientSideFiltering]);
+
+  const tracesFilteredBySourceRun = useMemo(
+    () => (filterByAssessmentSourceRun ? filterTracesByAssessmentSourceRunId(filteredTraces, runUuid) : filteredTraces),
+    [filteredTraces, runUuid, filterByAssessmentSourceRun],
+  );
+
+  if (disabled) {
+    return {
+      data: [],
+      isLoading: false,
+      isFetching: false,
+    };
+  }
+
+  return {
+    data: tracesFilteredBySourceRun,
+    isLoading: isInnerLoading || isTraceIdLookupLoading,
+    isFetching: isInnerFetching,
+    error: error || undefined,
+    refetchMlflowTraces,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  };
+};
+
+/**
+ * Query function for searching MLflow traces.
+ * Fetches all traces for given locations/filters, paginating through results.
+ */
+export const searchMlflowTracesQueryFn = async ({
+  signal,
+  locations,
+  filter,
+  pageSize: pageSizeProp,
+  limit: limitProp,
+  orderBy,
+  loggedModelId,
+  sqlWarehouseId,
+}: {
+  signal?: AbortSignal;
+  locations?: ModelTraceSearchLocation[];
+  filter?: string;
+  pageSize?: number;
+  limit?: number;
+  orderBy?: string[];
+  loggedModelId?: string;
+  sqlWarehouseId?: string;
+}): Promise<ModelTraceInfoV3[]> => {
+  const usingV4APIs = locations?.some(isV4TraceLocation) && shouldUseTracesV4API();
+
+  if (usingV4APIs) {
+    return TracesServiceV4.searchTracesV4({
+      signal,
+      orderBy,
+      locations,
+      filter,
+      pageSize: pageSizeProp,
+    });
+  }
+  let allTraces: ModelTraceInfoV3[] = [];
+  let pageToken: string | undefined = undefined;
+
+  const pageSize = pageSizeProp || getMlflowTracesSearchPageSize();
+  const tracesLimit = limitProp || getEvalTabTotalTracesLimit();
+
+  while (allTraces.length < tracesLimit) {
+    const payload: SearchMlflowTracesRequest = {
+      locations,
+      filter,
+      max_results: pageSize,
+      order_by: orderBy,
+    };
+    if (loggedModelId && sqlWarehouseId) {
+      payload.model_id = loggedModelId;
+      payload.sql_warehouse_id = sqlWarehouseId;
+    }
+    if (pageToken) {
+      payload.page_token = pageToken;
+    }
+    const json = (await fetchAPI(getAjaxUrl('ajax-api/3.0/mlflow/traces/search'), {
+      method: 'POST',
+      body: payload,
+      signal,
+    })) as { traces: ModelTraceInfoV3[]; next_page_token?: string };
+    const traces = json.traces;
+    if (!isNil(traces)) {
+      allTraces = allTraces.concat(traces);
+    }
+
+    // If there's no next page, break out of the loop.
+    pageToken = json.next_page_token;
+    if (!pageToken) break;
+  }
+  return allTraces;
+};
+
+interface UseSearchMlflowTracesInnerParams {
+  locations?: ModelTraceSearchLocation[];
+  filter?: string;
+  pageSize?: number;
+  limit?: number;
+  orderBy?: string[];
+  loggedModelId?: string;
+  sqlWarehouseId?: string;
+  enabled?: boolean;
+  enablePagination?: boolean;
+  refetchInterval?: number | false;
+}
+
+interface UseSearchMlflowTracesInnerResult {
+  data: ModelTraceInfoV3[] | undefined;
+  isLoading: boolean;
+  isFetching: boolean;
+  error?: NetworkRequestError | Error | null;
+  refetch: () => void;
+  fetchNextPage?: () => void;
+  hasNextPage?: boolean;
+  isFetchingNextPage?: boolean;
+}
+
+/**
+ * Query cache config for trace search. Exported for tests.
+ * keepPreviousData in both modes prevents the trace list from "bouncing" (disappearing
+ * and showing a full loading skeleton) when search/filter changes.
+ */
+export function getSearchMlflowTracesQueryCacheConfig(usingV4APIs: boolean) {
+  return {
+    keepPreviousData: true,
+    refetchOnWindowFocus: false,
+    // For V4 APIs, we use server-side filtering for all filters. Since it's server-side, we
+    // do not need to cache indefinitely.
+    // In previous APIs, we relied on client-side filtering so we want to cache indefinitely.
+    ...(usingV4APIs ? {} : { staleTime: Infinity, cacheTime: Infinity }),
+  };
+}
+
+const SEARCH_TRACES_INFINITE_PAGE_SIZE = 100;
+
+type SearchMlflowTracesResponse = {
+  traces: ModelTraceInfoV3[];
+  next_page_token?: string;
+};
+
+/**
+ * Fetches traces using useInfiniteQuery, loading one page at a time.
+ * Enabled only when shouldUseInfinitePaginatedTraces() is true.
+ */
+const useSearchMlflowTracesInfinite = ({
+  locations,
+  filter,
+  orderBy,
+  loggedModelId,
+  sqlWarehouseId,
+  enabled = true,
+  refetchInterval,
+}: Omit<UseSearchMlflowTracesInnerParams, 'limit' | 'pageSize'>): UseSearchMlflowTracesInnerResult => {
+  const { data, isLoading, isFetching, isFetchingNextPage, fetchNextPage, hasNextPage, refetch, error } =
+    useInfiniteQuery<SearchMlflowTracesResponse, NetworkRequestError>({
+      keepPreviousData: true,
+      refetchOnWindowFocus: false,
+      staleTime: Infinity,
+      cacheTime: Infinity,
+      enabled,
+      refetchInterval,
+      queryKey: [
+        SEARCH_MLFLOW_TRACES_QUERY_KEY,
+        'infinite',
+        {
+          locations,
+          filter,
+          orderBy,
+          loggedModelId,
+          sqlWarehouseId,
+        },
+      ],
+      queryFn: async ({ signal, pageParam }) => {
+        const payload: SearchMlflowTracesRequest = {
+          locations,
+          filter,
+          max_results: SEARCH_TRACES_INFINITE_PAGE_SIZE,
+          order_by: orderBy,
+        };
+        if (loggedModelId && sqlWarehouseId) {
+          payload.model_id = loggedModelId;
+          payload.sql_warehouse_id = sqlWarehouseId;
+        }
+        if (pageParam) {
+          payload.page_token = pageParam;
+        }
+        return fetchAPI(getAjaxUrl('ajax-api/3.0/mlflow/traces/search'), {
+          method: 'POST',
+          body: payload,
+          signal,
+        }) as Promise<SearchMlflowTracesResponse>;
+      },
+      getNextPageParam: (lastPage) => lastPage.next_page_token,
+    });
+
+  const allTraces = useMemo(() => data?.pages.flatMap((page) => page.traces).filter(Boolean), [data]);
+
+  return {
+    data: allTraces,
+    isLoading,
+    isFetching,
+    error,
+    refetch,
+    fetchNextPage,
+    hasNextPage: hasNextPage ?? false,
+    isFetchingNextPage,
+  };
+};
+
+/**
+ * Fetches all mlflow traces for a given location/filter.
+ * Uses either the regular API or long-running async API based on feature flags.
+ *
+ * When using long-running API:
+ * - Initiates an async search operation
+ * - Polls for completion
+ * - Returns progress information via `longRunningProgress`
+ *
+ * TODO: De-dup with useSearchMlflowTraces defined in webapp/web/js/genai
+ */
+const useSearchMlflowTracesInner = ({
+  locations,
+  filter,
+  pageSize: pageSizeProp,
+  limit: limitProp,
+  orderBy,
+  loggedModelId,
+  sqlWarehouseId,
+  enabled = true,
+  enablePagination = true,
+  refetchInterval,
+}: UseSearchMlflowTracesInnerParams): UseSearchMlflowTracesInnerResult => {
+  const usingV4APIs = locations?.some(isV4TraceLocation) && shouldUseTracesV4API();
+  const usingLongRunningAPI = usingV4APIs && shouldUseLongRunningTracesAPI();
+  const usingInfinitePagination = !usingV4APIs && shouldUseInfinitePaginatedTraces() && enablePagination;
+
+  const queryCacheConfig = useMemo(() => getSearchMlflowTracesQueryCacheConfig(Boolean(usingV4APIs)), [usingV4APIs]);
+
+  const sqlWarehouseQueryKey = usingV4APIs ? sqlWarehouseId : undefined;
+
+  // Infinite paginated search (only active when feature flag is enabled)
+  const infiniteResult = useSearchMlflowTracesInfinite({
+    locations,
+    filter,
+    orderBy,
+    loggedModelId,
+    sqlWarehouseId,
+    enabled: enabled && usingInfinitePagination,
+    refetchInterval,
+  });
+
+  // Standard synchronous search (only active when not using long-running API or infinite pagination)
+  const syncResult = useQuery<ModelTraceInfoV3[], NetworkRequestError>({
+    ...queryCacheConfig,
+    enabled: enabled && !usingLongRunningAPI && !usingInfinitePagination,
+    refetchInterval,
+    queryKey: [
+      SEARCH_MLFLOW_TRACES_QUERY_KEY,
+      {
+        locations,
+        filter,
+        orderBy,
+        loggedModelId,
+        sqlWarehouseQueryKey,
+        pageSize: pageSizeProp,
+      },
+    ],
+    queryFn: ({ signal }) =>
+      searchMlflowTracesQueryFn({
+        signal,
+        locations,
+        filter,
+        pageSize: pageSizeProp,
+        limit: limitProp,
+        orderBy,
+        loggedModelId,
+        sqlWarehouseId,
+      }),
+  });
+
+  if (usingInfinitePagination) {
+    return infiniteResult;
+  }
+
+  return syncResult;
+};
+
+export const createMlflowSearchFilter = (
+  runUuid: string | null | undefined,
+  timeRange?: { startTime?: string; endTime?: string } | null,
+  networkFilters?: TableFilter[],
+  loggedModelId?: string,
+  searchQuery?: string,
+) => {
+  const filter: string[] = [];
+  if (runUuid) {
+    filter.push(`attributes.run_id = '${runUuid}'`);
+  }
+  if (searchQuery) {
+    filter.push(
+      // If the query is a trace ID, use a direct indexed lookup on request_id
+      // instead of trace.text ILIKE which scans the spans.content column.
+      // See: https://github.com/mlflow/mlflow/discussions/21193
+      /^tr-[0-9a-f]{32}$/i.test(searchQuery)
+        ? `attributes.request_id = '${searchQuery.toLowerCase()}'`
+        : `trace.text ILIKE '%${searchQuery}%'`,
+    );
+  }
+  if (timeRange) {
+    const timestampField = 'attributes.timestamp_ms';
+    if (timeRange.startTime) {
+      filter.push(`${timestampField} > ${timeRange.startTime}`);
+    }
+    if (timeRange.endTime) {
+      filter.push(`${timestampField} < ${timeRange.endTime}`);
+    }
+  }
+  if (loggedModelId) {
+    filter.push(`request_metadata."mlflow.modelId" = '${loggedModelId}'`);
+  }
+  if (networkFilters) {
+    networkFilters.forEach((networkFilter) => {
+      switch (networkFilter.column) {
+        case TracesTableColumnGroup.TAG:
+          if (networkFilter.key) {
+            const tagField = 'tags';
+            // Use backticks for field names with special characters
+            const fieldName =
+              networkFilter.key.includes('.') || networkFilter.key.includes(' ')
+                ? `${tagField}.\`${networkFilter.key}\``
+                : `${tagField}.${networkFilter.key}`;
+            if (
+              networkFilter.operator === FilterOperator.IS_NULL ||
+              networkFilter.operator === FilterOperator.IS_NOT_NULL
+            ) {
+              filter.push(`${fieldName} ${networkFilter.operator}`);
+            } else {
+              filter.push(`${fieldName} ${networkFilter.operator} '${networkFilter.value}'`);
+            }
+          }
+          break;
+        case EXECUTION_DURATION_COLUMN_ID:
+          const executionField = 'attributes.execution_time_ms';
+          filter.push(`${executionField} ${networkFilter.operator} ${networkFilter.value}`);
+          break;
+        case STATE_COLUMN_ID:
+          const statusField = 'attributes.status';
+          filter.push(`${statusField} = '${networkFilter.value}'`);
+          break;
+        case USER_COLUMN_ID:
+          filter.push(`request_metadata."mlflow.trace.user" = '${networkFilter.value}'`);
+          break;
+        case SESSION_COLUMN_ID:
+          if (networkFilter.operator === 'CONTAINS') {
+            filter.push(`request_metadata.mlflow.trace.session ILIKE '%${networkFilter.value}%'`);
+          } else {
+            filter.push(`request_metadata.mlflow.trace.session = '${networkFilter.value}'`);
+          }
+          break;
+        case RUN_NAME_COLUMN_ID:
+          filter.push(`attributes.run_id = '${networkFilter.value}'`);
+          break;
+        case LOGGED_MODEL_COLUMN_ID:
+          filter.push(`request_metadata."mlflow.modelId" = '${networkFilter.value}'`);
+          break;
+        // Only available in OSS
+        case LINKED_PROMPTS_COLUMN_ID:
+          filter.push(`prompt = '${networkFilter.value}'`);
+          break;
+        case TRACE_NAME_COLUMN_ID:
+          filter.push(`attributes.name ${networkFilter.operator} '${networkFilter.value}'`);
+          break;
+        case SOURCE_COLUMN_ID:
+          filter.push(`request_metadata."mlflow.source.name" ${networkFilter.operator} '${networkFilter.value}'`);
+          break;
+        case GIT_BRANCH_COLUMN_ID:
+          filter.push(`request_metadata."mlflow.source.git.branch" ${networkFilter.operator} '${networkFilter.value}'`);
+          break;
+        case GIT_COMMIT_COLUMN_ID:
+          filter.push(`request_metadata."mlflow.source.git.commit" ${networkFilter.operator} '${networkFilter.value}'`);
+          break;
+        case TracesTableColumnGroup.ASSESSMENT:
+          // Handle IS NULL / IS NOT NULL operators for assessments
+          // Note: This is not supported in managed backend
+          if (
+            networkFilter.operator === FilterOperator.IS_NULL ||
+            networkFilter.operator === FilterOperator.IS_NOT_NULL
+          ) {
+            filter.push(`feedback.\`${networkFilter.key}\` ${networkFilter.operator}`);
+          } else if (networkFilter.value !== 'undefined') {
+            // Skip 'undefined' values - these must be filtered client-side since they represent
+            // absence of an assessment, which cannot be queried on the backend
+            filter.push(`feedback.\`${networkFilter.key}\` ${networkFilter.operator} '${networkFilter.value}'`);
+          }
+          break;
+        case TracesTableColumnGroup.EXPECTATION:
+          filter.push(`expectation.\`${networkFilter.key}\` ${networkFilter.operator} '${networkFilter.value}'`);
+          break;
+        case SPAN_NAME_COLUMN_ID:
+          if (networkFilter.operator === '=') {
+            // Use ILIKE instead of = for case-insensitive matching (better UX for span name filtering)
+            filter.push(`span.name ILIKE '${networkFilter.value}'`);
+          } else if (networkFilter.operator === 'CONTAINS') {
+            filter.push(`span.name ILIKE '%${networkFilter.value}%'`);
+          } else {
+            filter.push(`span.name ${networkFilter.operator} '${networkFilter.value}'`);
+          }
+          break;
+        case INPUTS_COLUMN_ID:
+        case RESPONSE_COLUMN_ID:
+          filter.push(`${networkFilter.column} ${networkFilter.operator} '${networkFilter.value}'`);
+          break;
+        case SPAN_TYPE_COLUMN_ID:
+          if (networkFilter.operator === '=') {
+            // Use ILIKE instead of = for case-insensitive matching (better UX for span type filtering)
+            filter.push(`span.type ILIKE '${networkFilter.value}'`);
+          } else if (networkFilter.operator === 'CONTAINS') {
+            filter.push(`span.type ILIKE '%${networkFilter.value}%'`);
+          } else {
+            filter.push(`span.type ${networkFilter.operator} '${networkFilter.value}'`);
+          }
+          break;
+        case SPAN_STATUS_COLUMN_ID:
+          // Span status uses exact match (OK, ERROR, UNSET)
+          filter.push(`span.status ${networkFilter.operator} '${networkFilter.value}'`);
+          break;
+        case SPAN_CONTENT_COLUMN_ID:
+          if (networkFilter.operator === 'CONTAINS') {
+            filter.push(`span.content ILIKE '%${networkFilter.value}%'`);
+          }
+          break;
+        case ISSUE_ID_COLUMN_ID:
+          filter.push(`${ISSUE_ID_COLUMN_ID} ${networkFilter.operator} '${networkFilter.value}'`);
+          break;
+        default:
+          if (networkFilter.column.startsWith(CUSTOM_METADATA_COLUMN_ID)) {
+            const columnKey = `request_metadata.${getCustomMetadataKeyFromColumnId(networkFilter.column)}`;
+            if (networkFilter.operator === HiddenFilterOperator.IS_NOT_NULL) {
+              filter.push(`${columnKey} IS NOT NULL`);
+            } else if (networkFilter.operator === FilterOperator.CONTAINS) {
+              filter.push(`${columnKey} ILIKE '%${networkFilter.value}%'`);
+            } else {
+              filter.push(`${columnKey} ${networkFilter.operator} '${networkFilter.value}'`);
+            }
+          }
+          break;
+      }
+    });
+  }
+
+  if (filter.length > 0) {
+    return filter.join(' AND ');
+  }
+  return undefined;
+};
+
+const createMlflowSearchOrderBy = (tableSort?: EvaluationsOverviewTableSort): string[] | undefined => {
+  if (!tableSort) {
+    return undefined;
+  }
+
+  // Currently the server only supports sorting by execution time and request time. Should add
+  // more columns as they are supported by the server.
+  switch (tableSort.key) {
+    case EXECUTION_DURATION_COLUMN_ID:
+      return [`execution_time ${tableSort.asc ? 'ASC' : 'DESC'}`];
+    case REQUEST_TIME_COLUMN_ID:
+      return [`timestamp ${tableSort.asc ? 'ASC' : 'DESC'}`];
+    default:
+      return [];
+  }
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/usePendingAssessmentEntries.ts
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/usePendingAssessmentEntries.ts
@@ -1,0 +1,134 @@
+import { flatMap, groupBy, orderBy, uniq } from 'lodash';
+import { useCallback, useMemo, useReducer } from 'react';
+
+import {
+  KnownEvaluationResultAssessmentMetadataFields,
+  getEvaluationResultAssessmentChunkIndex,
+  getEvaluationResultAssessmentValue,
+  isEvaluationResultOverallAssessment,
+  isEvaluationResultPerRetrievalChunkAssessment,
+} from '../components/GenAiEvaluationTracesReview.utils';
+import type { RunEvaluationResultAssessmentDraft, RunEvaluationTracesDataEntry } from '../types';
+
+export const usePendingAssessmentEntries = (evaluationResult: RunEvaluationTracesDataEntry) => {
+  const [pendingAssessments, dispatch] = useReducer(
+    (
+      state: RunEvaluationResultAssessmentDraft[],
+      action:
+        | {
+            type: 'upsertAssessment';
+            payload: RunEvaluationResultAssessmentDraft;
+          }
+        | {
+            type: 'resetPendingAssessments';
+          },
+    ): RunEvaluationResultAssessmentDraft[] => {
+      switch (action.type) {
+        case 'resetPendingAssessments':
+          return [];
+        case 'upsertAssessment':
+          const existingPendingAssessment = state.find(
+            (assessment) =>
+              assessment.name === action.payload.name &&
+              getEvaluationResultAssessmentChunkIndex(assessment) ===
+                getEvaluationResultAssessmentChunkIndex(action.payload),
+          );
+
+          // If the incoming assessment is already in the pending list, update it.
+          if (existingPendingAssessment) {
+            return state.map((assessment) => {
+              if (assessment === existingPendingAssessment) {
+                // Special case: handling existing assessment without value. The value of the incoming assessment
+                // will be used to update the name of the assessment.
+                if (getEvaluationResultAssessmentValue(assessment) === '' && action.payload.stringValue) {
+                  return { ...action.payload, stringValue: '', name: action.payload.stringValue };
+                }
+                return action.payload;
+              }
+              return assessment;
+            });
+          }
+          return [action.payload, ...state];
+      }
+    },
+    [],
+  );
+
+  const overallAssessmentList = useMemo(() => {
+    if (!evaluationResult) {
+      return [];
+    }
+    const pendingOverallAssessment = pendingAssessments.find(isEvaluationResultOverallAssessment);
+    if (pendingOverallAssessment) {
+      return [pendingOverallAssessment, ...evaluationResult.overallAssessments];
+    }
+    return evaluationResult.overallAssessments;
+  }, [evaluationResult, pendingAssessments]);
+
+  const responseAssessmentMap = useMemo(() => {
+    if (!evaluationResult) {
+      return {};
+    }
+
+    const allAssessmentNames = uniq([
+      ...Object.keys(evaluationResult.responseAssessmentsByName),
+      ...pendingAssessments
+        .filter(
+          (assessment) =>
+            !isEvaluationResultOverallAssessment(assessment) &&
+            !isEvaluationResultPerRetrievalChunkAssessment(assessment),
+        )
+        .map((assessment) => assessment.name),
+    ]);
+
+    return Object.fromEntries(
+      allAssessmentNames.map((key) => {
+        const pendingAssessmentForType = pendingAssessments.filter((assessment) => assessment.name === key);
+        return [key, [...pendingAssessmentForType, ...(evaluationResult.responseAssessmentsByName[key] || [])]];
+      }),
+    );
+  }, [evaluationResult, pendingAssessments]);
+
+  const retrievalChunksWithDraftAssessments = useMemo(() => {
+    const perChunkAssessments = pendingAssessments.filter(isEvaluationResultPerRetrievalChunkAssessment);
+    return evaluationResult.retrievalChunks?.map((chunk, index) => {
+      const pendingAssessmentForChunk = perChunkAssessments.filter(
+        (assessment) => assessment.metadata?.[KnownEvaluationResultAssessmentMetadataFields.CHUNK_INDEX] === index,
+      );
+      const existingAssessments = flatMap(chunk.retrievalAssessmentsByName ?? {});
+      // Group detailed assessments by name
+      const retrievalAssessmentsByName = groupBy([...pendingAssessmentForChunk, ...existingAssessments], 'name');
+      // Ensure each group is sorted by timestamp in descending order
+      Object.keys(retrievalAssessmentsByName).forEach((key) => {
+        retrievalAssessmentsByName[key] = orderBy(retrievalAssessmentsByName[key], 'timestamp', 'desc');
+      });
+      return {
+        ...chunk,
+        retrievalAssessmentsByName: retrievalAssessmentsByName,
+      };
+    });
+  }, [pendingAssessments, evaluationResult]);
+
+  const draftEvaluationResult = useMemo(() => {
+    return {
+      ...evaluationResult,
+      overallAssessments: overallAssessmentList,
+      responseAssessmentsByName: responseAssessmentMap,
+      retrievalChunks: retrievalChunksWithDraftAssessments,
+    };
+  }, [evaluationResult, overallAssessmentList, responseAssessmentMap, retrievalChunksWithDraftAssessments]);
+
+  const upsertAssessment = useCallback(
+    (assessment: RunEvaluationResultAssessmentDraft) => dispatch({ type: 'upsertAssessment', payload: assessment }),
+    [],
+  );
+
+  const resetPendingAssessments = useCallback(() => dispatch({ type: 'resetPendingAssessments' }), []);
+
+  return {
+    pendingAssessments,
+    draftEvaluationResult,
+    upsertAssessment,
+    resetPendingAssessments,
+  };
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/useTableColumns.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/useTableColumns.tsx
@@ -1,0 +1,418 @@
+import { isNil } from 'lodash';
+import { useMemo } from 'react';
+
+import type { IntlShape } from '@databricks/i18n';
+
+import type { ModelTraceInfoV3 } from '../../model-trace-explorer/ModelTrace.types';
+import { KnownEvaluationResultAssessmentName } from '../enum';
+import type { AssessmentInfo, RunEvaluationTracesDataEntry, TracesTableColumn } from '../types';
+import { TracesTableColumnGroup, TracesTableColumnType } from '../types';
+import { shouldEnableSessionGrouping, shouldEnableTagGrouping } from '../utils/FeatureUtils';
+import {
+  createCustomMetadataColumnId,
+  createTagColumnId,
+  MLFLOW_INTERNAL_PREFIX,
+  shouldUseTraceInfoV3,
+} from '../utils/TraceUtils';
+
+export const USER_COLUMN_ID = 'user';
+export const SESSION_COLUMN_ID = 'session';
+export const RESPONSE_COLUMN_ID = 'response';
+export const TRACE_ID_COLUMN_ID = 'trace_id';
+export const REQUEST_TIME_COLUMN_ID = 'request_time';
+export const EXECUTION_DURATION_COLUMN_ID = 'execution_duration';
+export const STATE_COLUMN_ID = 'state';
+export const SOURCE_COLUMN_ID = 'source';
+export const TAGS_COLUMN_ID = 'tags';
+export const TRACE_NAME_COLUMN_ID = 'trace_name';
+export const INPUTS_COLUMN_ID = 'request';
+export const RUN_NAME_COLUMN_ID = 'run_name';
+export const LOGGED_MODEL_COLUMN_ID = 'logged_model';
+export const TOKENS_COLUMN_ID = 'tokens';
+export const CUSTOM_METADATA_COLUMN_ID = 'custom_metadata';
+export const SPAN_NAME_COLUMN_ID = 'span.name';
+export const SPAN_TYPE_COLUMN_ID = 'span.type';
+export const SPAN_STATUS_COLUMN_ID = 'span.status';
+export const SPAN_CONTENT_COLUMN_ID = 'span.content';
+export const SIMULATION_GOAL_COLUMN_ID = 'simulation_goal';
+export const SIMULATION_PERSONA_COLUMN_ID = 'simulation_persona';
+export const LINKED_PROMPTS_COLUMN_ID = 'prompt';
+export const ISSUE_ID_COLUMN_ID = 'issue.id';
+export const ISSUES_COLUMN_ID = 'issues';
+export const GIT_BRANCH_COLUMN_ID = 'git_branch';
+export const GIT_COMMIT_COLUMN_ID = 'git_commit';
+
+export const SORTABLE_INFO_COLUMNS = [EXECUTION_DURATION_COLUMN_ID, REQUEST_TIME_COLUMN_ID, SESSION_COLUMN_ID];
+// Columns that are sortable by the server. Server-side sorting should be prioritized over client-side sorting.
+export const SERVER_SORTABLE_INFO_COLUMNS = [EXECUTION_DURATION_COLUMN_ID, REQUEST_TIME_COLUMN_ID];
+
+// This is a short term fix to not display any additional assessments with the trace info v3 migration.
+// Long term we should decide how to best display these assessments.
+const EXCLUDED_ASSESSMENT_NAMES = [
+  KnownEvaluationResultAssessmentName.CHUNK_RELEVANCE,
+  KnownEvaluationResultAssessmentName.TOTAL_INPUT_TOKEN_COUNT,
+  KnownEvaluationResultAssessmentName.TOTAL_OUTPUT_TOKEN_COUNT,
+  KnownEvaluationResultAssessmentName.TOTAL_TOKEN_COUNT,
+  KnownEvaluationResultAssessmentName.DOCUMENT_RECALL,
+  KnownEvaluationResultAssessmentName.DOCUMENT_RATINGS,
+];
+
+const ASSESSMENT_COLUMN_ID_SUFFIX = '_assessment_column';
+const EXPECTATION_COLUMN_ID_SUFFIX = '_expectation_column';
+
+// Add a suffix to the assessment name as the id to make it work for blank names.
+export function createAssessmentColumnId(assessmentName: string) {
+  return assessmentName + ASSESSMENT_COLUMN_ID_SUFFIX;
+}
+
+export function createExpectationColumnId(expectationName: string) {
+  return expectationName + EXPECTATION_COLUMN_ID_SUFFIX;
+}
+
+export const useTableColumns = (
+  intl: IntlShape,
+  currentEvaluationResults: RunEvaluationTracesDataEntry[],
+  assessmentInfos: AssessmentInfo[],
+  runUuid: string | undefined,
+  otherEvaluationResults?: RunEvaluationTracesDataEntry[],
+  isTraceInfoV3Override?: boolean,
+) => {
+  const allColumns: TracesTableColumn[] = useMemo(() => {
+    const isTraceInfoV3 = isTraceInfoV3Override ?? shouldUseTraceInfoV3(currentEvaluationResults);
+    let inputCols = [];
+    if (!isTraceInfoV3) {
+      let inputKeys = new Set<string>();
+      let traceInfoColumns = new Set<keyof ModelTraceInfoV3>();
+
+      currentEvaluationResults.forEach((result) => {
+        const { inputs } = result;
+        inputKeys = new Set<string>([...inputKeys, ...Object.keys(inputs || {})]);
+
+        traceInfoColumns = new Set<keyof ModelTraceInfoV3>([
+          ...traceInfoColumns,
+          ...Object.keys(result.traceInfo || {}),
+        ] as (keyof ModelTraceInfoV3)[]);
+      });
+
+      inputCols = [...inputKeys].map((key) => ({
+        id: key,
+        label: key,
+        type: TracesTableColumnType.INPUT,
+      }));
+    } else {
+      inputCols = [
+        {
+          id: INPUTS_COLUMN_ID,
+          label: intl.formatMessage({
+            defaultMessage: 'Request',
+            description: 'Column label for request',
+          }),
+          type: TracesTableColumnType.INPUT,
+          group: TracesTableColumnGroup.INFO,
+          filterOrder: 0,
+        },
+      ];
+    }
+
+    const assessmentColumns = assessmentInfos
+      .map((assessmentInfo) => ({
+        id: createAssessmentColumnId(assessmentInfo.name),
+        label: assessmentInfo.displayName,
+        type: TracesTableColumnType.ASSESSMENT,
+        assessmentInfo,
+        group: TracesTableColumnGroup.ASSESSMENT,
+      }))
+      .filter(
+        (assessment) =>
+          // retrieval columns should not be displayed in the table since they don't apply to the overall trace
+          !assessment.assessmentInfo.isRetrievalAssessment &&
+          !EXCLUDED_ASSESSMENT_NAMES.includes(assessment.assessmentInfo.name as KnownEvaluationResultAssessmentName),
+      );
+
+    let infoCols;
+    const expectationColumns: Record<string, TracesTableColumn> = {};
+    if (isTraceInfoV3) {
+      infoCols = [
+        {
+          id: TRACE_ID_COLUMN_ID,
+          label: intl.formatMessage({
+            defaultMessage: 'Test',
+            description: 'Column label for the test name in the regression-test table',
+          }),
+          type: TracesTableColumnType.TRACE_INFO,
+          group: TracesTableColumnGroup.INFO,
+        },
+        {
+          id: TRACE_NAME_COLUMN_ID,
+          label: intl.formatMessage({
+            defaultMessage: 'Trace name',
+            description: 'Column label for trace name',
+          }),
+          type: TracesTableColumnType.TRACE_INFO,
+          group: TracesTableColumnGroup.INFO,
+        },
+        {
+          id: RESPONSE_COLUMN_ID,
+          label: intl.formatMessage({
+            defaultMessage: 'Response',
+            description: 'Column label for response',
+          }),
+          type: TracesTableColumnType.TRACE_INFO,
+          group: TracesTableColumnGroup.INFO,
+          filterOrder: 0,
+        },
+        {
+          id: USER_COLUMN_ID,
+          label: intl.formatMessage({
+            defaultMessage: 'User',
+            description: 'Column label for user',
+          }),
+          type: TracesTableColumnType.TRACE_INFO,
+          group: TracesTableColumnGroup.INFO,
+        },
+        {
+          id: SESSION_COLUMN_ID,
+          label: intl.formatMessage({
+            defaultMessage: 'Session',
+            description: 'Column label for session',
+          }),
+          filterLabel: intl.formatMessage({
+            defaultMessage: 'Session ID',
+            description: 'Filter label for session ID',
+          }),
+          type: TracesTableColumnType.TRACE_INFO,
+          group: TracesTableColumnGroup.INFO,
+        },
+        {
+          id: EXECUTION_DURATION_COLUMN_ID,
+          label: intl.formatMessage({
+            defaultMessage: 'Latency',
+            description: 'Column label for agent latency in the regression-test table',
+          }),
+          filterLabel: intl.formatMessage({
+            defaultMessage: 'Latency (ms)',
+            description: 'Column label for agent latency with the unit suffix',
+          }),
+          type: TracesTableColumnType.TRACE_INFO,
+          group: TracesTableColumnGroup.INFO,
+        },
+        {
+          id: REQUEST_TIME_COLUMN_ID,
+          label: intl.formatMessage({
+            defaultMessage: 'Request time',
+            description: 'Column label for request time',
+          }),
+          type: TracesTableColumnType.TRACE_INFO,
+          group: TracesTableColumnGroup.INFO,
+        },
+        {
+          id: STATE_COLUMN_ID,
+          label: intl.formatMessage({
+            defaultMessage: 'State',
+            description: 'Column label for state',
+          }),
+          type: TracesTableColumnType.TRACE_INFO,
+          group: TracesTableColumnGroup.INFO,
+        },
+        {
+          id: SOURCE_COLUMN_ID,
+          label: intl.formatMessage({
+            defaultMessage: 'Source',
+            description: 'Column label for source',
+          }),
+          type: TracesTableColumnType.TRACE_INFO,
+          group: TracesTableColumnGroup.INFO,
+        },
+        {
+          id: GIT_BRANCH_COLUMN_ID,
+          label: intl.formatMessage({
+            defaultMessage: 'Git branch',
+            description: 'Column label for the git branch the trace was produced on',
+          }),
+          type: TracesTableColumnType.TRACE_INFO,
+          group: TracesTableColumnGroup.INFO,
+        },
+        {
+          id: GIT_COMMIT_COLUMN_ID,
+          label: intl.formatMessage({
+            defaultMessage: 'Git commit',
+            description: 'Column label for the git commit hash the trace was produced on',
+          }),
+          type: TracesTableColumnType.TRACE_INFO,
+          group: TracesTableColumnGroup.INFO,
+        },
+        {
+          id: LOGGED_MODEL_COLUMN_ID,
+          label: intl.formatMessage({
+            defaultMessage: 'Version',
+            description: 'Column label for logged model',
+          }),
+          type: TracesTableColumnType.TRACE_INFO,
+          group: TracesTableColumnGroup.INFO,
+        },
+        // Only available in OSS
+        {
+          id: LINKED_PROMPTS_COLUMN_ID,
+          label: intl.formatMessage({
+            defaultMessage: 'Prompt',
+            description: 'Column label for linked prompts',
+          }),
+          type: TracesTableColumnType.TRACE_INFO,
+          group: TracesTableColumnGroup.INFO,
+        },
+        {
+          id: TOKENS_COLUMN_ID,
+          label: intl.formatMessage({
+            defaultMessage: 'Tokens',
+            description: 'Column label for tokens',
+          }),
+          type: TracesTableColumnType.TRACE_INFO,
+          group: TracesTableColumnGroup.INFO,
+        },
+        // Only show run name column on experiment level traces, where runUuid is not provided
+        isNil(runUuid) && {
+          id: RUN_NAME_COLUMN_ID,
+          label: intl.formatMessage({
+            defaultMessage: 'Run name',
+            description: 'Column label for run name',
+          }),
+          type: TracesTableColumnType.TRACE_INFO,
+          group: TracesTableColumnGroup.INFO,
+        },
+        !shouldEnableTagGrouping() && {
+          id: TAGS_COLUMN_ID,
+          label: intl.formatMessage({
+            defaultMessage: 'Tags',
+            description: 'Column label for tags',
+          }),
+          type: TracesTableColumnType.TRACE_INFO,
+          group: TracesTableColumnGroup.TAG,
+        },
+      ];
+
+      const allResults = [...currentEvaluationResults, ...(otherEvaluationResults || [])];
+      // Populate custom metadata columns
+      const customMetadataColumns: Record<string, TracesTableColumn> = {};
+      let hasGoal = false;
+      let hasPersona = false;
+      const sessionGroupingEnabled = shouldEnableSessionGrouping();
+
+      allResults.forEach((result: RunEvaluationTracesDataEntry) => {
+        const traceMetadata = result.traceInfo?.trace_metadata;
+        if (traceMetadata) {
+          // Check for simulation goal and persona (only when session grouping is enabled)
+          if (sessionGroupingEnabled) {
+            if (traceMetadata['mlflow.simulation.goal']) {
+              hasGoal = true;
+            }
+            if (traceMetadata['mlflow.simulation.persona']) {
+              hasPersona = true;
+            }
+          }
+
+          Object.keys(traceMetadata).forEach((key) => {
+            if (!key.startsWith(MLFLOW_INTERNAL_PREFIX) && !customMetadataColumns[key]) {
+              customMetadataColumns[key] = {
+                id: createCustomMetadataColumnId(key),
+                label: key,
+                type: TracesTableColumnType.TRACE_INFO,
+                group: TracesTableColumnGroup.INFO,
+              };
+            }
+          });
+        }
+
+        const expectations = result.targets;
+        if (expectations) {
+          Object.keys(expectations).forEach((expectationName) => {
+            if (!expectationColumns[expectationName]) {
+              expectationColumns[expectationName] = {
+                id: createExpectationColumnId(expectationName),
+                label: expectationName,
+                type: TracesTableColumnType.EXPECTATION,
+                group: TracesTableColumnGroup.EXPECTATION,
+                expectationName,
+              };
+            }
+          });
+        }
+      });
+      infoCols = [...infoCols, ...Object.values(customMetadataColumns)];
+
+      // Add simulation goal and persona columns if present
+      if (hasGoal) {
+        infoCols.push({
+          id: SIMULATION_GOAL_COLUMN_ID,
+          label: intl.formatMessage({
+            defaultMessage: 'Goal',
+            description: 'Column label for simulation goal',
+          }),
+          type: TracesTableColumnType.TRACE_INFO,
+          group: TracesTableColumnGroup.INFO,
+        });
+      }
+      if (hasPersona) {
+        infoCols.push({
+          id: SIMULATION_PERSONA_COLUMN_ID,
+          label: intl.formatMessage({
+            defaultMessage: 'Persona',
+            description: 'Column label for simulation persona',
+          }),
+          type: TracesTableColumnType.TRACE_INFO,
+          group: TracesTableColumnGroup.INFO,
+        });
+      }
+
+      if (shouldEnableTagGrouping()) {
+        const tagColumnRecords: Record<string, TracesTableColumn> = {};
+        allResults
+          .map((result) => result.traceInfo?.tags)
+          .forEach((tag) => {
+            Object.keys(tag || {}).forEach((key) => {
+              if (!key.startsWith(MLFLOW_INTERNAL_PREFIX) && !tagColumnRecords[key]) {
+                tagColumnRecords[key] = {
+                  id: createTagColumnId(key),
+                  label: key,
+                  type: TracesTableColumnType.TRACE_INFO,
+                  group: TracesTableColumnGroup.TAG,
+                };
+              }
+            });
+          });
+        const tagColumns = Object.values(tagColumnRecords);
+
+        infoCols = [...infoCols, ...tagColumns];
+      }
+    } else {
+      infoCols = currentEvaluationResults.some((result) => !isNil(result.requestTime))
+        ? [
+            {
+              id: REQUEST_TIME_COLUMN_ID,
+              label: intl.formatMessage({
+                defaultMessage: 'Request time',
+                description: 'Column label for request time',
+              }),
+              type: TracesTableColumnType.INTERNAL_MONITOR_REQUEST_TIME,
+            },
+          ]
+        : [];
+    }
+
+    // Issues column is placed at the end of INFO group
+    const issuesCol = {
+      id: ISSUES_COLUMN_ID,
+      label: intl.formatMessage({
+        defaultMessage: 'Issues',
+        description: 'Column label for issues',
+      }),
+      type: TracesTableColumnType.TRACE_INFO,
+      group: TracesTableColumnGroup.INFO,
+    };
+
+    return [...inputCols, ...infoCols, issuesCol, ...assessmentColumns, ...Object.values(expectationColumns)].filter(
+      (col): col is TracesTableColumn => Boolean(col),
+    );
+  }, [currentEvaluationResults, intl, assessmentInfos, runUuid, otherEvaluationResults, isTraceInfoV3Override]);
+
+  return allColumns;
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/useTableSort.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/useTableSort.tsx
@@ -1,0 +1,54 @@
+import { useCallback, useMemo, useState } from 'react';
+
+import { useTableSortURL } from './useTableSortURL';
+import { shouldEnableTracesTableStatePersistence } from '../../model-trace-explorer/FeatureUtils';
+import type { EvaluationsOverviewTableSort, TracesTableColumn } from '../types';
+
+export const useTableSort = (
+  selectedColumns: TracesTableColumn[],
+  initialTableSort?: EvaluationsOverviewTableSort,
+): [EvaluationsOverviewTableSort | undefined, (sort: EvaluationsOverviewTableSort | undefined) => void] => {
+  const enableURLPersistence = shouldEnableTracesTableStatePersistence();
+
+  const [urlTableSort, setUrlTableSort] = useTableSortURL();
+
+  const [localTableSort, setLocalTableSort] = useState<EvaluationsOverviewTableSort | undefined>(
+    initialTableSort && selectedColumns.find((c) => c.id === initialTableSort.key) ? initialTableSort : undefined,
+  );
+
+  const derivedTableSort = useMemo(() => {
+    let sourceSort: EvaluationsOverviewTableSort | undefined;
+
+    if (enableURLPersistence) {
+      // Priority: URL (if valid) → initial → undefined
+      if (urlTableSort && selectedColumns.find((c) => c.id === urlTableSort.key)) {
+        sourceSort = urlTableSort;
+      } else {
+        sourceSort = initialTableSort;
+      }
+    } else {
+      // Old behavior: use local state
+      sourceSort = localTableSort;
+    }
+
+    // Validate: sort column must be visible in selectedColumns
+    if (!sourceSort || !selectedColumns.find((c) => c.id === sourceSort.key)) {
+      return undefined;
+    }
+
+    return sourceSort;
+  }, [enableURLPersistence, urlTableSort, initialTableSort, localTableSort, selectedColumns]);
+
+  const setTableSort = useCallback(
+    (sort: EvaluationsOverviewTableSort | undefined) => {
+      if (enableURLPersistence) {
+        setUrlTableSort(sort, false);
+      } else {
+        setLocalTableSort(sort);
+      }
+    },
+    [enableURLPersistence, setUrlTableSort, setLocalTableSort],
+  );
+
+  return [derivedTableSort, setTableSort];
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/useTableSortURL.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/hooks/useTableSortURL.tsx
@@ -1,0 +1,52 @@
+import { useCallback, useMemo } from 'react';
+
+import type { EvaluationsOverviewTableSort } from '../types';
+import { useSearchParams } from '../utils/RoutingUtils';
+
+const QUERY_PARAM_KEY = 'sort';
+const VALUE_SEPARATOR = '::';
+
+/**
+ * Query param-powered hook that manages table sort state in URL.
+ * Format: key::type::asc
+ */
+export const useTableSortURL = (): [
+  EvaluationsOverviewTableSort | undefined,
+  (sort: EvaluationsOverviewTableSort | undefined, replace?: boolean) => void,
+] => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const tableSort: EvaluationsOverviewTableSort | undefined = useMemo(() => {
+    const sortParam = searchParams.get(QUERY_PARAM_KEY);
+    if (!sortParam) return undefined;
+
+    const [key, type, ascStr] = sortParam.split(VALUE_SEPARATOR);
+    if (!key || !type || !ascStr) return undefined;
+
+    return {
+      key,
+      type: type as any,
+      asc: ascStr === 'true',
+    };
+  }, [searchParams]);
+
+  const setTableSort = useCallback(
+    (newSort: EvaluationsOverviewTableSort | undefined, replace = false) => {
+      setSearchParams(
+        (params: URLSearchParams) => {
+          params.delete(QUERY_PARAM_KEY);
+
+          if (newSort) {
+            params.set(QUERY_PARAM_KEY, [newSort.key, newSort.type, newSort.asc].join(VALUE_SEPARATOR));
+          }
+
+          return params;
+        },
+        { replace },
+      );
+    },
+    [setSearchParams],
+  );
+
+  return [tableSort, setTableSort];
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/index.ts
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/index.ts
@@ -1,0 +1,150 @@
+// DELETE_BARREL_FILE
+// TBD: this module will provide a space for trace UI components shared
+// between new Tiles UI in webapp and evaluation review UI in MLflow.
+// Eventually everything will be moved to monolith codebase.
+
+export { mergeMetricsAndAssessmentsWithEvaluations } from './utils/EvaluationDataParseUtils';
+
+export { COMPARE_TO_RUN_COLOR, CURRENT_RUN_COLOR } from './utils/Colors';
+
+export { useAssessmentFilters } from './hooks/useAssessmentFilters';
+
+export {
+  isEvaluationResultOverallAssessment,
+  isEvaluationResultPerRetrievalChunkAssessment,
+  isRetrievedContext,
+  KnownEvaluationResultAssessmentStringValue,
+  KnownEvaluationResultAssessmentValueLabel,
+} from './components/GenAiEvaluationTracesReview.utils';
+
+export { useTableSort } from './hooks/useTableSort';
+
+/**
+ * @deprecated Use `GenAITracesTableBodyContainer` and `GenAITracesTableToolbar` instead for new use cases.
+ */
+export { GenAiTracesTableDeprecated } from './GenAITracesTable';
+export { useGenAiExperimentRunsForComparison } from './hooks/useGenAiExperimentRunsForComparison';
+export { useGenAiTraceEvaluationArtifacts } from './hooks/useGenAiTraceEvaluationArtifacts';
+export {
+  useSearchMlflowTraces,
+  useMlflowTracesTableMetadata,
+  invalidateMlflowSearchTracesCache,
+  searchMlflowTracesQueryFn,
+  SEARCH_MLFLOW_TRACES_QUERY_KEY,
+} from './hooks/useMlflowTraces';
+export { getEvalTabTotalTracesLimit, shouldEnableSessionGrouping } from './utils/FeatureUtils';
+export { GenAITracesTableToolbar } from './GenAITracesTableToolbar';
+export { GenAiTracesTableSearchInput } from './GenAiTracesTableSearchInput';
+export { GenAITracesTableBodyContainer } from './GenAITracesTableBodyContainer';
+export { useTableColumns } from './hooks/useTableColumns';
+export { getAssessmentInfos } from './utils/AggregationUtils';
+
+export { useFilters } from './hooks/useFilters';
+
+export { GenAITracesTableContext, GenAITracesTableProvider } from './GenAITracesTableContext';
+
+export { MarkdownConverterProvider as GenAiTracesMarkdownConverterProvider } from './utils/MarkdownUtils';
+
+export { RunColorCircle } from './components/RunColorCircle';
+
+export { useSelectedColumns } from './hooks/useGenAITracesUIState';
+export { useTableSortURL } from './hooks/useTableSortURL';
+export { useColumnsURL } from './hooks/useColumnsURL';
+
+export { GenAiEvaluationTracesReviewModal } from './components/GenAiEvaluationTracesReviewModal';
+
+export * from './types';
+
+export {
+  GenAiTraceEvaluationArtifactFile,
+  KnownEvaluationResultAssessmentMetadataFields,
+  KnownEvaluationResultAssessmentName,
+} from './enum';
+
+export {
+  ASSESSMENTS_DOC_LINKS,
+  getJudgeMetricsLink,
+  KnownEvaluationResultAssessmentValueDescription,
+} from './components/GenAiEvaluationTracesReview.utils';
+
+export {
+  COMPARE_TO_RUN_DROPDOWN_COMPONENT_ID,
+  RUN_EVALUATION_RESULTS_TAB_COMPARE_RUNS,
+  RUN_EVALUATION_RESULTS_TAB_SINGLE_RUN,
+} from './utils/EvaluationLogging';
+
+export { SIMULATION_GOAL_KEY, SIMULATION_PERSONA_KEY } from './utils/SessionGroupingUtils';
+
+export {
+  getTracesTagKeys,
+  getTraceInfoInputs,
+  getTraceInfoOutputs,
+  convertTraceInfoV3ToRunEvalEntry,
+  getSpanAttribute,
+  formatTraceId,
+  getSpansLocation,
+  TRACKING_STORE_SPANS_LOCATION,
+} from './utils/TraceUtils';
+
+export {
+  INPUTS_COLUMN_ID,
+  REQUEST_TIME_COLUMN_ID,
+  EXECUTION_DURATION_COLUMN_ID,
+  STATE_COLUMN_ID,
+  TAGS_COLUMN_ID,
+  RESPONSE_COLUMN_ID,
+  TOKENS_COLUMN_ID,
+  TRACE_ID_COLUMN_ID,
+  CUSTOM_METADATA_COLUMN_ID,
+  SESSION_COLUMN_ID,
+  SIMULATION_GOAL_COLUMN_ID,
+  SIMULATION_PERSONA_COLUMN_ID,
+  SPAN_NAME_COLUMN_ID,
+  SPAN_STATUS_COLUMN_ID,
+  USER_COLUMN_ID,
+  ISSUE_ID_COLUMN_ID,
+  ISSUES_COLUMN_ID,
+  GIT_BRANCH_COLUMN_ID,
+  GIT_COMMIT_COLUMN_ID,
+  createAssessmentColumnId,
+} from './hooks/useTableColumns';
+
+export { ExperimentViewTracesStatusLabels } from './cellRenderers/StatusRenderer';
+
+export { getSimulationColumnsToAdd } from './GenAiTracesTable.utils';
+
+// Test utilities
+export {
+  createTestTraceInfoV3,
+  createTestAssessmentInfo,
+  createTestColumns,
+} from './test-fixtures/EvaluatedTraceTestUtils';
+
+export {
+  shouldUseTracesV4API,
+  shouldUseLongRunningTracesAPI,
+  shouldUseInfinitePaginatedTraces,
+} from './utils/FeatureUtils';
+export {
+  createTraceLocationForExperiment,
+  createTraceLocationForUCSchema,
+  createTraceLocationForUCTablePrefix,
+  createTraceLocationForDestinationPath,
+  isTablePrefixDestinationPath,
+  isV4TraceLocation,
+} from './utils/TraceLocationUtils';
+export type { GetTraceFunction } from './hooks/useGetTrace';
+export { useFetchTraceV4LazyQuery, useFetchTraceV4Query, getTraceV4QueryKey } from './hooks/useFetchTraceV4';
+export { doesTraceSupportV4API } from './utils/TraceLocationUtils';
+export { GenAIChatSessionsTable } from './sessions-table/GenAIChatSessionsTable';
+export { groupTracesBySession } from './sessions-table/utils';
+export { GenAITracesTableBodySkeleton } from './GenAITracesTableBodySkeleton';
+export { useGetTraces } from './hooks/useGetTraces';
+export { useGetTrace } from './hooks/useGetTrace';
+export { ActiveEvaluationContext, useActiveEvaluation } from './hooks/useActiveEvaluation';
+export { isSqlWarehouseTimeoutError } from './utils/ErrorUtils';
+export {
+  GenAiTraceTableRowSelectionProvider,
+  useGenAiTraceTableRowSelection,
+  useIsInsideGenAiTraceTableRowSelectionProvider,
+} from './hooks/useGenAiTraceTableRowSelection';

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/sessions-table/GenAIChatSessionsActions.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/sessions-table/GenAIChatSessionsActions.tsx
@@ -1,0 +1,181 @@
+import type { RowSelectionState } from '@tanstack/react-table';
+import { useCallback, useMemo, useState } from 'react';
+
+import { Button, Tooltip, DropdownMenu, ChevronDownIcon } from '@databricks/design-system';
+import { useIntl } from '@databricks/i18n';
+import type { ModelTraceInfoV3 } from '../../model-trace-explorer/ModelTrace.types';
+import {
+  displayErrorNotification,
+  displaySuccessNotification,
+} from '../../model-trace-explorer/ModelTraceExplorer.utils';
+
+import type { SessionTableRow } from './types';
+import { GenAiDeleteTraceModal } from '../components/GenAiDeleteTraceModal';
+import type { RunEvaluationTracesDataEntry, TraceActions } from '../types';
+import { applyTraceInfoV3ToEvalEntry } from '../utils/TraceUtils';
+
+interface GenAIChatSessionsActionsProps {
+  experimentId: string;
+  selectedSessions: SessionTableRow[];
+  traceActions?: TraceActions;
+  setRowSelection?: React.Dispatch<React.SetStateAction<RowSelectionState>>;
+}
+
+export const GenAIChatSessionsActions = (props: GenAIChatSessionsActionsProps) => {
+  const { experimentId, selectedSessions, traceActions, setRowSelection } = props;
+  const intl = useIntl();
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+
+  const handleDeleteSessions = useCallback(() => {
+    setShowDeleteModal(true);
+  }, []);
+
+  // Collect all traces from selected sessions
+  const allTracesFromSelectedSessions = useMemo(() => {
+    const allTraces: ModelTraceInfoV3[] = [];
+    selectedSessions.forEach((session) => {
+      allTraces.push(...session.traces);
+    });
+    return allTraces;
+  }, [selectedSessions]);
+
+  const selectedTracesForActions: RunEvaluationTracesDataEntry[] = useMemo(() => {
+    return applyTraceInfoV3ToEvalEntry(
+      allTracesFromSelectedSessions.map((trace) => ({
+        evaluationId: trace.trace_id,
+        requestId: trace.client_request_id || trace.trace_id,
+        inputsId: trace.trace_id,
+        inputs: {},
+        outputs: {},
+        targets: {},
+        overallAssessments: [],
+        responseAssessmentsByName: {},
+        metrics: {},
+        traceInfo: trace,
+      })),
+    );
+  }, [allTracesFromSelectedSessions]);
+
+  const deleteTraces = useCallback(
+    async (experimentId: string, traceIds: string[]) => {
+      try {
+        await traceActions?.deleteTracesAction?.deleteTraces?.(experimentId, traceIds);
+        setRowSelection?.({});
+        setShowDeleteModal(false);
+
+        const sessionMessage = intl.formatMessage(
+          {
+            defaultMessage: '{count, plural, one {Session} other {{count} sessions}} deleted successfully',
+            description: 'Success message after deleting sessions - session count',
+          },
+          { count: selectedSessions.length },
+        );
+
+        const traceMessage = intl.formatMessage(
+          {
+            defaultMessage: '{count, plural, one {# trace was} other {# traces were}} removed',
+            description: 'Success message after deleting sessions - trace count',
+          },
+          { count: traceIds.length },
+        );
+
+        displaySuccessNotification(`${sessionMessage}. ${traceMessage}.`);
+      } catch (error) {
+        displayErrorNotification(
+          intl.formatMessage(
+            {
+              defaultMessage: 'Failed to delete sessions. Error: {error}',
+              description: 'Error message when deleting sessions fails',
+            },
+            {
+              error: error instanceof Error ? error.message : String(error),
+            },
+          ),
+        );
+        throw error;
+      }
+    },
+    [setRowSelection, traceActions, selectedSessions.length, intl],
+  );
+
+  const hasDeleteAction = Boolean(traceActions?.deleteTracesAction);
+  const hasExportAction = Boolean(traceActions?.exportToEvals);
+  const noSessionsSelected = selectedSessions.length === 0;
+  const noActionsAvailable = !hasDeleteAction && !hasExportAction;
+
+  if (noActionsAvailable) {
+    return null;
+  }
+
+  const ActionButton = (
+    <Button
+      componentId="mlflow.chat-sessions.actions-dropdown"
+      endIcon={<ChevronDownIcon />}
+      disabled={noSessionsSelected}
+    >
+      {intl.formatMessage(
+        {
+          defaultMessage: 'Actions ({count})',
+          description: 'Actions dropdown button label with count of selected sessions',
+        },
+        { count: selectedSessions.length },
+      )}
+    </Button>
+  );
+
+  return (
+    <>
+      <DropdownMenu.Root modal={false}>
+        <Tooltip
+          componentId="mlflow.chat-sessions.actions-dropdown-tooltip"
+          content={
+            noSessionsSelected
+              ? intl.formatMessage({
+                  defaultMessage: 'Select at least one session to enable actions',
+                  description: 'Tooltip for disabled actions button when no sessions are selected',
+                })
+              : traceActions?.deleteTracesAction?.disabledReason
+          }
+        >
+          <DropdownMenu.Trigger disabled={noSessionsSelected} asChild>
+            {ActionButton}
+          </DropdownMenu.Trigger>
+        </Tooltip>
+        <DropdownMenu.Content align="end">
+          {hasDeleteAction && (
+            <>
+              {hasExportAction && <DropdownMenu.Separator />}
+              <DropdownMenu.Group>
+                <DropdownMenu.Label>
+                  {intl.formatMessage({
+                    defaultMessage: 'Edit',
+                    description: 'Chat sessions actions dropdown group label for edit actions',
+                  })}
+                </DropdownMenu.Label>
+                <DropdownMenu.Item
+                  componentId="mlflow.chat-sessions.delete-sessions"
+                  onClick={handleDeleteSessions}
+                  disabled={traceActions?.deleteTracesAction?.isDisabled}
+                  disabledReason={traceActions?.deleteTracesAction?.disabledReason}
+                >
+                  {intl.formatMessage({
+                    defaultMessage: 'Delete sessions',
+                    description: 'Delete sessions action',
+                  })}
+                </DropdownMenu.Item>
+              </DropdownMenu.Group>
+            </>
+          )}
+        </DropdownMenu.Content>
+      </DropdownMenu.Root>
+
+      <GenAiDeleteTraceModal
+        experimentIds={[experimentId]}
+        visible={showDeleteModal}
+        selectedTraces={selectedTracesForActions}
+        handleClose={() => setShowDeleteModal(false)}
+        deleteTraces={deleteTraces}
+      />
+    </>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/sessions-table/GenAIChatSessionsEmptyState.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/sessions-table/GenAIChatSessionsEmptyState.tsx
@@ -1,0 +1,69 @@
+import { Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { FormattedMessage } from '@databricks/i18n';
+import { CodeSnippet } from '../../snippet/CodeSnippet';
+import { SnippetCopyAction } from '../../snippet/actions/SnippetCopyAction';
+
+const EXAMPLE_CODE = `import mlflow
+
+@mlflow.trace
+def chat_completion(message: str, user_id: str, session_id: str):
+    # Set these metadata keys to associate the trace to a user and session
+    mlflow.update_current_trace(
+        metadata={
+            "mlflow.trace.user": user_id,
+            "mlflow.trace.session": session_id,
+        }
+    )
+
+    # Replace with your chat logic
+    return "Your response here"
+
+# Depending on your setup, user and session IDs can be passed to your
+# server handler via the network request from your client applications,
+# or derived from some other request context. 
+user_id = "user-123"
+session_id = "session-123"
+
+chat_completion("Hello, how are you?", user_id, session_id)`;
+
+export const GenAIChatSessionsEmptyState = () => {
+  const { theme } = useDesignSystemTheme();
+
+  return (
+    <div css={{ flex: 1, flexDirection: 'column', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      <Typography.Title level={3}>
+        <FormattedMessage
+          defaultMessage="Group traces from the same chat session together"
+          description="Empty state title for the chat sessions table"
+        />
+      </Typography.Title>
+      <Typography.Paragraph color="secondary" css={{ maxWidth: 600 }}>
+        <FormattedMessage
+          defaultMessage="MLflow allows you associate traces with users and chat sessions. This is useful for analyzing multi-turn conversations, enabling you to inspect what happened at each step. Copy the code snippet below to generate a sample trace, or visit the documentation for a more in-depth example."
+          description="Empty state description for the chat sessions table"
+        />
+        <Typography.Link
+          componentId="mlflow.chat_sessions.empty_state.learn_more_link"
+          css={{ marginLeft: theme.spacing.xs }}
+          href="https://mlflow.org/docs/latest/genai/tracing/track-users-sessions/"
+          openInNewTab
+        >
+          <FormattedMessage
+            defaultMessage="Learn more"
+            description="Link to the documentation page for user and session tracking"
+          />
+        </Typography.Link>
+      </Typography.Paragraph>
+      <div css={{ position: 'relative', maxWidth: 600 }}>
+        <SnippetCopyAction
+          componentId="mlflow.chat_sessions.empty_state.example_code_copy"
+          css={{ position: 'absolute', top: theme.spacing.xs, right: theme.spacing.xs }}
+          copyText={EXAMPLE_CODE}
+        />
+        <CodeSnippet language="python" showLineNumbers theme={theme.isDarkMode ? 'duotoneDark' : 'light'}>
+          {EXAMPLE_CODE}
+        </CodeSnippet>
+      </div>
+    </div>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/sessions-table/GenAIChatSessionsTable.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/sessions-table/GenAIChatSessionsTable.tsx
@@ -1,0 +1,313 @@
+import type { Row, RowSelectionState, SortingState } from '@tanstack/react-table';
+import { flexRender, getCoreRowModel, getSortedRowModel } from '@tanstack/react-table';
+import React, { useEffect, useMemo, useState } from 'react';
+
+import {
+  Table,
+  TableCell,
+  TableHeader,
+  TableRow,
+  TableRowSelectCell,
+  TableSkeletonRows,
+} from '@databricks/design-system';
+import type { ModelTraceInfoV3 } from '../../model-trace-explorer/ModelTrace.types';
+import { useReactTable_verifiedWithReact18 as useReactTable } from '../../react-table/useReactTable';
+
+import { GenAIChatSessionsEmptyState } from './GenAIChatSessionsEmptyState';
+import { GenAIChatSessionsToolbar } from './GenAIChatSessionsToolbar';
+import { SessionIdCellRenderer } from './cell-renderers/SessionIdCellRenderer';
+import { SessionNumericCellRenderer } from './cell-renderers/SessionNumericCellRenderer';
+import { SessionSourceCellRenderer } from './cell-renderers/SessionSourceCellRenderer';
+import { useSessionsTableColumnVisibility } from './hooks/useSessionsTableColumnVisibility';
+import type { SessionTableRow, SessionTableColumn } from './types';
+import { getSessionTableRows } from './utils';
+import { useGenAiTraceTableRowSelection } from '../hooks/useGenAiTraceTableRowSelection';
+import type { TraceActions } from '../types';
+import MlflowUtils from '../utils/MlflowUtils';
+import { Link, useLocation } from '../utils/RoutingUtils';
+
+const columns: SessionTableColumn[] = [
+  {
+    id: 'sessionId',
+    header: 'Session ID',
+    accessorKey: 'sessionId',
+    cell: SessionIdCellRenderer,
+    defaultVisibility: true,
+    enableSorting: true,
+    sortingFn: (a: Row<SessionTableRow>, b: Row<SessionTableRow>) =>
+      a.original.sessionId.localeCompare(b.original.sessionId),
+  },
+  {
+    id: 'requestPreview',
+    header: 'Input',
+    accessorKey: 'requestPreview',
+    defaultVisibility: true,
+  },
+  {
+    id: 'sessionStartTime',
+    header: 'Session start time',
+    accessorKey: 'sessionStartTime',
+    defaultVisibility: true,
+    enableSorting: true,
+  },
+  {
+    id: 'sessionDuration',
+    header: 'Session duration',
+    accessorKey: 'sessionDuration',
+    defaultVisibility: true,
+    enableSorting: true,
+  },
+  {
+    id: 'tokens',
+    header: 'Tokens',
+    accessorKey: 'tokens',
+    defaultVisibility: false,
+    enableSorting: true,
+    cell: SessionNumericCellRenderer,
+  },
+  {
+    id: 'turns',
+    header: 'Turns',
+    accessorKey: 'turns',
+    defaultVisibility: false,
+    enableSorting: true,
+    cell: SessionNumericCellRenderer,
+  },
+  {
+    id: 'source',
+    header: 'Source',
+    cell: SessionSourceCellRenderer,
+    defaultVisibility: false,
+  },
+];
+
+interface ExperimentEvaluationDatasetsTableRowProps {
+  row: Row<SessionTableRow>;
+  enableRowSelection?: boolean;
+  enableLinks?: boolean;
+  openLinksInNewTab?: boolean;
+}
+
+const ExperimentChatSessionsTableRow: React.FC<React.PropsWithChildren<ExperimentEvaluationDatasetsTableRowProps>> =
+  React.memo(
+    function ExperimentChatSessionsTableRow({
+      row,
+      enableRowSelection,
+      enableLinks = true,
+      openLinksInNewTab = false,
+    }) {
+      const { search } = useLocation();
+
+      return (
+        <TableRow key={row.id} className="eval-datasets-table-row">
+          {enableRowSelection && (
+            <div css={{ display: 'flex', overflow: 'hidden', flexShrink: 0 }}>
+              <TableRowSelectCell
+                componentId="mlflow.chat-sessions.table-row-checkbox"
+                checked={row.getIsSelected()}
+                onChange={row.getToggleSelectedHandler()}
+                onClick={(e) => {
+                  e.stopPropagation();
+                }}
+              />
+            </div>
+          )}
+          {row.getVisibleCells().map((cell) => (
+            <TableCell key={cell.id} css={{ flex: `calc(var(--col-${cell.column.id}-size) / 100)` }}>
+              {enableLinks ? (
+                <Link
+                  componentId="mlflow.genai-traces-table.chat_sessions_table.session_row_link"
+                  to={{
+                    pathname: MlflowUtils.getExperimentChatSessionPageRoute(
+                      row.original.experimentId,
+                      row.original.sessionId,
+                    ),
+                    search: openLinksInNewTab ? undefined : search,
+                  }}
+                  target={openLinksInNewTab ? '_blank' : undefined}
+                  rel={openLinksInNewTab ? 'noopener noreferrer' : undefined}
+                  css={{
+                    display: 'flex',
+                    width: '100%',
+                    height: '100%',
+                    alignItems: 'center',
+                    color: 'inherit !important',
+                    textDecoration: 'none',
+                  }}
+                >
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </Link>
+              ) : (
+                flexRender(cell.column.columnDef.cell, cell.getContext())
+              )}
+            </TableCell>
+          ))}
+        </TableRow>
+      );
+    },
+    function ExperimentChatSessionsTableRow() {
+      return false;
+    },
+  );
+
+export const GenAIChatSessionsTable = ({
+  experimentId,
+  traces,
+  isLoading,
+  searchQuery,
+  setSearchQuery,
+  traceActions,
+  enableRowSelection: enableRowSelectionProp = false,
+  enableLinks = true,
+  openLinksInNewTab = false,
+  empty,
+  toolbarAddons,
+  onRowSelectionChange,
+}: {
+  experimentId: string;
+  traces: ModelTraceInfoV3[];
+  isLoading: boolean;
+  searchQuery: string;
+  setSearchQuery: (query: string) => void;
+  traceActions?: TraceActions;
+  enableRowSelection?: boolean;
+  enableLinks?: boolean;
+  openLinksInNewTab?: boolean;
+  empty?: React.ReactElement;
+  toolbarAddons?: React.ReactNode;
+  onRowSelectionChange?: (rowSelection: RowSelectionState) => void;
+}) => {
+  const sessionTableRows = useMemo(() => getSessionTableRows(experimentId, traces), [experimentId, traces]);
+  const [sorting, setSorting] = useState<SortingState>([{ id: 'sessionStartTime', desc: true }]);
+  const { rowSelection, setRowSelection } = useGenAiTraceTableRowSelection();
+
+  // Notify parent of row selection changes
+  useEffect(() => {
+    onRowSelectionChange?.(rowSelection);
+  }, [rowSelection, onRowSelectionChange]);
+
+  const { columnVisibility, setColumnVisibility } = useSessionsTableColumnVisibility({
+    experimentId,
+    columns,
+  });
+
+  const enableRowSelection = enableRowSelectionProp || Boolean(traceActions);
+
+  const table = useReactTable<SessionTableRow>({
+    data: sessionTableRows,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    onSortingChange: setSorting,
+    enableColumnResizing: true,
+    columnResizeMode: 'onChange',
+    enableRowSelection,
+    onRowSelectionChange: setRowSelection,
+    getRowId: (row: SessionTableRow) => row.sessionId,
+    state: {
+      sorting,
+      columnVisibility,
+      rowSelection,
+    },
+  });
+
+  const columnSizeInfo = table.getState().columnSizingInfo;
+  const columnSizeVars = React.useMemo(() => {
+    const headers = table.getFlatHeaders();
+    const colSizes: { [key: string]: number } = {};
+    for (const header of headers) {
+      colSizes[`--col-${header.column.id}-size`] = header.column.getSize();
+    }
+    return colSizes;
+    // we need to recompute this whenever columns get resized or changed
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [columnSizeInfo, table, columnVisibility]);
+
+  const selectedSessions = useMemo(
+    () => table.getSelectedRowModel().rows.map((row) => row.original),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [rowSelection],
+  );
+
+  const emptyStateElement = empty ?? <GenAIChatSessionsEmptyState />;
+
+  return (
+    <div
+      css={{
+        display: 'flex',
+        flexDirection: 'column',
+        flex: 1,
+        minHeight: 0,
+        position: 'relative',
+      }}
+    >
+      <GenAIChatSessionsToolbar
+        columns={columns}
+        columnVisibility={columnVisibility}
+        setColumnVisibility={setColumnVisibility}
+        searchQuery={searchQuery}
+        setSearchQuery={setSearchQuery}
+        traceActions={traceActions}
+        experimentId={experimentId}
+        selectedSessions={selectedSessions}
+        setRowSelection={setRowSelection}
+        addons={toolbarAddons}
+      />
+      <Table
+        style={{ ...columnSizeVars }}
+        empty={!isLoading && sessionTableRows.length === 0 ? emptyStateElement : undefined}
+        scrollable
+        someRowsSelected={
+          enableRowSelection ? table.getIsAllRowsSelected() || table.getIsSomeRowsSelected() : undefined
+        }
+      >
+        {sessionTableRows.length > 0 && (
+          <TableRow isHeader>
+            {enableRowSelection && (
+              <div css={{ display: 'flex', overflow: 'hidden', flexShrink: 0 }}>
+                <TableRowSelectCell
+                  componentId="mlflow.chat-sessions.table-header-checkbox"
+                  checked={table.getIsAllRowsSelected()}
+                  indeterminate={table.getIsSomeRowsSelected()}
+                  onChange={table.getToggleAllRowsSelectedHandler()}
+                />
+              </div>
+            )}
+            {table.getLeafHeaders().map((header) => (
+              <TableHeader
+                key={header.id}
+                componentId="mlflow.chat-sessions.table-header"
+                header={header}
+                column={header.column}
+                sortable={header.column.getCanSort()}
+                css={{
+                  cursor: header.column.getCanSort() ? 'pointer' : 'default',
+                  flex: `calc(var(--col-${header.id}-size) / 100)`,
+                }}
+                sortDirection={header.column.getIsSorted() || 'none'}
+                onToggleSort={header.column.getToggleSortingHandler()}
+              >
+                {flexRender(header.column.columnDef.header, header.getContext())}
+              </TableHeader>
+            ))}
+          </TableRow>
+        )}
+
+        {!isLoading &&
+          table
+            .getRowModel()
+            .rows.map((row) => (
+              <ExperimentChatSessionsTableRow
+                key={row.id}
+                row={row}
+                enableRowSelection={enableRowSelection}
+                enableLinks={enableLinks}
+                openLinksInNewTab={openLinksInNewTab}
+              />
+            ))}
+
+        {isLoading && <TableSkeletonRows table={table} />}
+      </Table>
+    </div>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/sessions-table/GenAIChatSessionsToolbar.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/sessions-table/GenAIChatSessionsToolbar.tsx
@@ -1,0 +1,101 @@
+import type { RowSelectionState } from '@tanstack/react-table';
+
+import {
+  ColumnsIcon,
+  DialogCombobox,
+  DialogComboboxContent,
+  DialogComboboxOptionList,
+  DialogComboboxOptionListCheckboxItem,
+  DialogComboboxTrigger,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
+import { FormattedMessage, useIntl } from '@databricks/i18n';
+
+import { GenAIChatSessionsActions } from './GenAIChatSessionsActions';
+import type { SessionTableColumn, SessionTableRow } from './types';
+import { GenAiTracesTableSearchInput } from '../GenAiTracesTableSearchInput';
+import type { TraceActions } from '../types';
+
+export const GenAIChatSessionsToolbar = ({
+  columns,
+  columnVisibility,
+  setColumnVisibility,
+  searchQuery,
+  setSearchQuery,
+  traceActions,
+  experimentId,
+  selectedSessions,
+  setRowSelection,
+  addons,
+}: {
+  columns: SessionTableColumn[];
+  columnVisibility: Record<string, boolean>;
+  setColumnVisibility: (columnVisibility: Record<string, boolean>) => void;
+  searchQuery: string;
+  setSearchQuery: (query: string) => void;
+  traceActions?: TraceActions;
+  experimentId: string;
+  selectedSessions: SessionTableRow[];
+  setRowSelection?: React.Dispatch<React.SetStateAction<RowSelectionState>>;
+  addons?: React.ReactNode;
+}) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+
+  return (
+    <div css={{ display: 'flex', gap: theme.spacing.sm }}>
+      <GenAiTracesTableSearchInput
+        searchQuery={searchQuery}
+        setSearchQuery={setSearchQuery}
+        placeholder={intl.formatMessage({
+          defaultMessage: 'Search chat sessions by input',
+          description: 'Placeholder text for the search input in the chat sessions table',
+        })}
+      />
+      <DialogCombobox
+        componentId="mlflow.chat-sessions.table-column-selector"
+        label={
+          <div css={{ display: 'flex', gap: theme.spacing.sm, alignItems: 'center' }}>
+            <ColumnsIcon />
+            <FormattedMessage
+              defaultMessage="Columns"
+              description="Columns label for the chat sessions table column selector"
+            />
+          </div>
+        }
+        multiSelect
+      >
+        <DialogComboboxTrigger />
+        <DialogComboboxContent>
+          <DialogComboboxOptionList>
+            {Object.entries(columnVisibility).map(([columnId, isVisible]) => {
+              return (
+                <DialogComboboxOptionListCheckboxItem
+                  key={columnId}
+                  value={columnId}
+                  onChange={() => {
+                    const newColumnVisibility = { ...columnVisibility };
+                    newColumnVisibility[columnId] = !isVisible;
+                    setColumnVisibility(newColumnVisibility);
+                  }}
+                  checked={isVisible}
+                >
+                  {columns.find((column) => column.id === columnId)?.header}
+                </DialogComboboxOptionListCheckboxItem>
+              );
+            })}
+          </DialogComboboxOptionList>
+        </DialogComboboxContent>
+      </DialogCombobox>
+      {traceActions && (
+        <GenAIChatSessionsActions
+          experimentId={experimentId}
+          selectedSessions={selectedSessions}
+          traceActions={traceActions}
+          setRowSelection={setRowSelection}
+        />
+      )}
+      {addons}
+    </div>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/sessions-table/cell-renderers/SessionIdCellRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/sessions-table/cell-renderers/SessionIdCellRenderer.tsx
@@ -1,0 +1,19 @@
+import type { Row } from '@tanstack/react-table';
+
+import { Tag, Typography } from '@databricks/design-system';
+
+import type { SessionTableRow } from '../types';
+
+export const SessionIdCellRenderer = ({ row }: { row: Row<SessionTableRow> }) => {
+  const sessionId = row.original.sessionId;
+
+  return (
+    <Tag
+      componentId="mlflow.chat-sessions.session-id-tag"
+      color="indigo"
+      css={{ maxWidth: '100%', overflow: 'hidden', cursor: 'pointer' }}
+    >
+      <Typography.Text ellipsis>{sessionId}</Typography.Text>
+    </Tag>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/sessions-table/cell-renderers/SessionNumericCellRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/sessions-table/cell-renderers/SessionNumericCellRenderer.tsx
@@ -1,0 +1,12 @@
+import type { CellContext } from '@tanstack/react-table';
+
+import { Tag } from '@databricks/design-system';
+
+import type { SessionTableRow } from '../types';
+
+export const SessionNumericCellRenderer = (props: CellContext<SessionTableRow, unknown>) => {
+  const { cell } = props;
+  const value = cell.getValue();
+
+  return <Tag componentId="mlflow.genai-traces-table.session-tokens">{value}</Tag>;
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/sessions-table/cell-renderers/SessionSourceCellRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/sessions-table/cell-renderers/SessionSourceCellRenderer.tsx
@@ -1,0 +1,9 @@
+import type { Row } from '@tanstack/react-table';
+
+import { SourceCellRenderer } from '../../cellRenderers/Source/SourceRenderer';
+import type { SessionTableRow } from '../types';
+
+export const SessionSourceCellRenderer = ({ row }: { row: Row<SessionTableRow> }) => {
+  const firstTrace = row.original.firstTrace;
+  return <SourceCellRenderer traceInfo={firstTrace} isComparing={false} />;
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/sessions-table/hooks/useSessionsTableColumnVisibility.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/sessions-table/hooks/useSessionsTableColumnVisibility.tsx
@@ -1,0 +1,37 @@
+import { useMemo } from 'react';
+
+import { useLocalStorage } from '../../../hooks/useLocalStorage';
+
+import type { SessionTableColumn } from '../types';
+
+const LOCAL_STORAGE_KEY = 'experiment-chat-sessions-table-column-visibility';
+const LOCAL_STORAGE_VERSION = 1;
+
+export const useSessionsTableColumnVisibility = ({
+  experimentId,
+  columns,
+}: {
+  experimentId: string;
+  columns: SessionTableColumn[];
+}) => {
+  const defaultColumnVisibility = useMemo(() => {
+    return columns.reduce(
+      (acc, column) => {
+        acc[column.id] = column.defaultVisibility;
+        return acc;
+      },
+      {} as Record<string, boolean>,
+    );
+  }, [columns]);
+
+  const [columnVisibility, setColumnVisibility] = useLocalStorage<Record<string, boolean>>({
+    key: `${LOCAL_STORAGE_KEY}-${experimentId}`,
+    version: LOCAL_STORAGE_VERSION,
+    initialValue: defaultColumnVisibility,
+  });
+
+  return {
+    columnVisibility,
+    setColumnVisibility,
+  };
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/sessions-table/types.ts
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/sessions-table/types.ts
@@ -1,0 +1,22 @@
+import type { ColumnDef } from '@tanstack/react-table';
+
+import type { ModelTraceInfoV3 } from '../../model-trace-explorer/ModelTrace.types';
+
+export type SessionTableRow = {
+  sessionId: string;
+  requestPreview?: string;
+  firstTrace: ModelTraceInfoV3;
+  experimentId: string;
+  sessionStartTime: string;
+  sessionDuration: string | null;
+  tokens: number;
+  turns: number;
+  traces: ModelTraceInfoV3[];
+};
+
+export type SessionTableColumn = {
+  id: string;
+  header: string;
+  accessorKey?: string;
+  defaultVisibility: boolean;
+} & ColumnDef<SessionTableRow>;

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/sessions-table/utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/sessions-table/utils.tsx
@@ -1,0 +1,73 @@
+import { compact, isNil, sortBy } from 'lodash';
+
+import { getTotalTokens } from '../../model-trace-explorer/ModelTraceExplorer.utils';
+import type { ModelTraceInfoV3 } from '../../model-trace-explorer/ModelTrace.types';
+import { SESSION_ID_METADATA_KEY } from '../../model-trace-explorer/constants';
+
+import type { SessionTableRow } from './types';
+import MlflowUtils from '../utils/MlflowUtils';
+
+export const groupTracesBySession = (traces: ModelTraceInfoV3[]) => {
+  const sessionIdMap: Record<string, ModelTraceInfoV3[]> = {};
+
+  traces.forEach((trace) => {
+    const sessionId = trace.trace_metadata?.[SESSION_ID_METADATA_KEY];
+    if (!sessionId) {
+      return;
+    }
+
+    const sessionTraces = sessionIdMap[sessionId] ?? [];
+    sessionIdMap[sessionId] = [...sessionTraces, trace];
+  });
+
+  return sessionIdMap;
+};
+
+export const getSessionTableRows = (experimentId: string, traces: ModelTraceInfoV3[]): SessionTableRow[] => {
+  const sessionIdMap = groupTracesBySession(traces);
+
+  return compact(
+    Object.entries(sessionIdMap).map(([sessionId, traces]) => {
+      if (traces.length === 0) {
+        return null;
+      }
+
+      // sort traces within a session by time (earliest first)
+      const sortedTraces = sortBy(traces, (trace) => new Date(trace.request_time));
+      const firstTrace = sortedTraces[0];
+
+      // take request preview from the first trace
+      const requestPreview = firstTrace.request_preview;
+
+      const totalTokens = sortedTraces.reduce((acc, trace) => acc + (getTotalTokens(trace) ?? 0), 0);
+
+      return {
+        sessionId,
+        requestPreview,
+        firstTrace,
+        experimentId,
+        sessionStartTime: MlflowUtils.formatTimestamp(new Date(firstTrace.request_time)),
+        sessionDuration: calculateSessionDuration(traces),
+        tokens: totalTokens,
+        turns: sortedTraces.length,
+        traces: sortedTraces,
+      };
+    }),
+  );
+};
+
+export const calculateSessionDuration = (traces: ModelTraceInfoV3[]) => {
+  const durations = traces.map((trace) => trace.execution_duration);
+
+  if (durations.some((duration) => isNil(duration))) {
+    return null;
+  }
+
+  const parsedSeconds = durations.map((duration) => parseFloat(duration ?? '0'));
+  if (parsedSeconds.some((duration) => isNaN(duration))) {
+    return null;
+  }
+
+  const totalMs = parsedSeconds.reduce((a, b) => a + b, 0) * 1000;
+  return MlflowUtils.formatDuration(totalMs);
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/test-fixtures/EvaluatedTraceTestUtils.ts
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/test-fixtures/EvaluatedTraceTestUtils.ts
@@ -1,0 +1,181 @@
+import type { ModelTraceInfoV3 } from '../../model-trace-explorer/ModelTrace.types';
+import { KnownEvaluationResultAssessmentName } from '../enum';
+import type {
+  RunEvaluationResultAssessment,
+  RunEvaluationTracesDataEntry,
+  AssessmentInfo,
+  AssessmentDType,
+  TracesTableColumn,
+} from '../types';
+import { TracesTableColumnType, TracesTableColumnGroup } from '../types';
+
+export function createTestTrace(entry: {
+  requestId: string;
+  request: string;
+  assessments: {
+    name: string;
+    value: string | number | boolean | null | undefined;
+    dtype: 'pass-fail' | 'float' | 'boolean' | 'string';
+  }[];
+}): RunEvaluationTracesDataEntry {
+  const assessments: RunEvaluationResultAssessment[] = entry.assessments.map((assessment) => {
+    let numericValue = null;
+    let booleanValue = null;
+    let stringValue = null;
+
+    switch (assessment.dtype) {
+      case 'pass-fail':
+      case 'string':
+        stringValue = typeof assessment.value === 'string' ? assessment.value : null;
+        break;
+      case 'float':
+        numericValue = typeof assessment.value === 'number' ? assessment.value : null;
+        break;
+      case 'boolean':
+        booleanValue = typeof assessment.value === 'boolean' ? assessment.value : null;
+        break;
+    }
+
+    return {
+      name: assessment.name,
+      stringValue,
+      numericValue,
+      booleanValue,
+    };
+  });
+
+  const responseAssessmentsByName: Record<string, RunEvaluationResultAssessment[]> = {};
+  for (const assessment of assessments) {
+    if (!responseAssessmentsByName[assessment.name]) {
+      responseAssessmentsByName[assessment.name] = [];
+    }
+    responseAssessmentsByName[assessment.name].push(assessment);
+  }
+
+  return {
+    evaluationId: `eval_${entry.requestId}`,
+    requestId: entry.requestId,
+    inputs: { request: entry.request },
+    inputsId: `input_${entry.requestId}`,
+    outputs: {},
+    targets: {},
+    overallAssessments: assessments.filter((a) => a.name === KnownEvaluationResultAssessmentName.OVERALL_ASSESSMENT),
+    responseAssessmentsByName,
+    metrics: {},
+  };
+}
+
+export function createTestTraces(
+  entries: {
+    requestId: string;
+    request: string;
+    assessments: {
+      name: string;
+      value: string | number | boolean | null | undefined;
+      dtype: 'pass-fail' | 'float' | 'boolean' | 'string';
+    }[];
+  }[],
+): RunEvaluationTracesDataEntry[] {
+  return entries.map(createTestTrace);
+}
+
+/**
+ * Helper function to create test trace info V3
+ */
+export const createTestTraceInfoV3 = (
+  traceId: string,
+  requestId: string,
+  request: string,
+  assessments: Array<{
+    name: string;
+    value: string | number | boolean;
+    dtype: 'pass-fail' | 'numeric' | 'boolean' | 'string';
+  }> = [],
+  experimentId = 'test-experiment-id',
+): ModelTraceInfoV3 => ({
+  trace_id: traceId,
+  client_request_id: requestId,
+  trace_location: {
+    type: 'MLFLOW_EXPERIMENT',
+    mlflow_experiment: { experiment_id: experimentId },
+  },
+  request,
+  request_preview: request,
+  response: 'Test response',
+  response_preview: 'Test response',
+  request_time: '2024-01-15T10:00:00Z',
+  execution_duration: '1000',
+  state: 'OK',
+  trace_metadata: {},
+  tags: {},
+  assessments: assessments.map((assessment) => ({
+    assessment_id: `${traceId}_${assessment.name}`,
+    assessment_name: assessment.name,
+    trace_id: traceId,
+    create_time: '2024-01-15T10:00:00Z',
+    last_update_time: '2024-01-15T10:00:00Z',
+    feedback: {
+      value: assessment.value,
+    },
+    source: {
+      source_type: 'LLM_JUDGE',
+      source_id: 'test-judge',
+    },
+  })),
+});
+
+/**
+ * Helper function to create test assessment info
+ */
+export const createTestAssessmentInfo = (
+  name: string,
+  displayName: string,
+  dtype: AssessmentDType = 'string',
+): AssessmentInfo => ({
+  name,
+  displayName,
+  isKnown: true,
+  isOverall: false,
+  metricName: name,
+  isCustomMetric: false,
+  isEditable: false,
+  isRetrievalAssessment: false,
+  dtype,
+  uniqueValues: new Set(['test-value']),
+  docsLink: '',
+  missingTooltip: '',
+  description: '',
+});
+
+/**
+ * Helper function to create test columns
+ */
+export const createTestColumns = (assessmentInfos: AssessmentInfo[]): TracesTableColumn[] => {
+  const columns: TracesTableColumn[] = [
+    {
+      id: 'request',
+      label: 'Request',
+      type: TracesTableColumnType.INPUT,
+      group: TracesTableColumnGroup.INFO,
+    },
+    {
+      id: 'trace_id',
+      label: 'Trace ID',
+      type: TracesTableColumnType.TRACE_INFO,
+      group: TracesTableColumnGroup.INFO,
+    },
+  ];
+
+  // Add assessment columns
+  assessmentInfos.forEach((assessmentInfo) => {
+    columns.push({
+      id: `assessment_${assessmentInfo.name}`,
+      label: assessmentInfo.displayName,
+      type: TracesTableColumnType.ASSESSMENT,
+      group: TracesTableColumnGroup.ASSESSMENT,
+      assessmentInfo,
+    });
+  });
+
+  return columns;
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/test-fixtures/queryTestUtils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/test-fixtures/queryTestUtils.tsx
@@ -1,0 +1,34 @@
+import { QueryClient, QueryClientProvider } from '../../query-client/queryClient';
+
+/**
+ * Creates a QueryClientProvider wrapper for use with renderHook in tests.
+ * Configures retry: false and silences console output.
+ */
+export function createQueryWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+    logger: {
+      error: () => {},
+      log: () => {},
+      warn: () => {},
+    },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+/**
+ * Creates a mock successful fetch response that resolves with the given data.
+ */
+export function mockFetchResponse(data: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(data),
+  } as any;
+}

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/types.ts
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/types.ts
@@ -1,0 +1,378 @@
+import type { GetTraceFunction } from './hooks/useGetTrace';
+import type { ModelTraceInfoV3, ModelTraceSpan } from '../model-trace-explorer/ModelTrace.types';
+
+export type AssessmentDType = 'string' | 'numeric' | 'boolean' | 'pass-fail' | 'unknown';
+export type AssessmentType = 'AI_JUDGE' | 'HUMAN' | 'CODE';
+export type TraceTablePageSource = 'experiment-traces' | 'chat-sessions' | 'run-view-traces';
+
+// Reflects structure logged by mlflow.log_table()
+export interface RawGenaiEvaluationArtifactResponse {
+  columns?: (string | null)[];
+  data?: (string | number | null | boolean | Record<string, any>)[][];
+  filename: string;
+}
+
+export interface AssessmentInfo {
+  name: string;
+  displayName: string;
+  // True when the assessment comes from a built-in judge.
+  isKnown: boolean;
+  isOverall: boolean;
+  // The metric that produced the assessment. Defined as the name of the judge or custom metric function that produced the assessment.
+  metricName: string;
+  source?: RunEvaluationResultAssessmentSource;
+  isCustomMetric: boolean;
+  isEditable: boolean;
+  isRetrievalAssessment: boolean;
+  // The type of the assessment value.
+  dtype: AssessmentDType;
+  uniqueValues: Set<AssessmentValueType>;
+
+  // Display metadata.
+  docsLink: string;
+  missingTooltip: string;
+  description: string;
+
+  // True if if the assesment contains at least one error
+  containsErrors?: boolean;
+
+  // True if any assessment in this column has session metadata
+  isSessionLevelAssessment?: boolean;
+}
+
+interface RootCauseAssessmentInfo {
+  assessmentName: string;
+  suggestedActions?: string;
+}
+
+export interface EvaluationArtifactTableEntryAssessment {
+  evaluation_id: string;
+
+  name: string;
+
+  boolean_value: boolean | null;
+  numeric_value: number | null;
+  string_value: string | null;
+  rationale: string | null;
+
+  source: {
+    source_type: AssessmentType;
+    source_id: string;
+    metadata: any;
+  };
+
+  metadata?: Record<string, any>;
+
+  timestamp: number;
+
+  error_code?: string;
+  error_message?: string;
+}
+
+export interface EvaluationArtifactTableEntryMetric {
+  evaluation_id: string;
+  key: string;
+  value: number;
+  timestamp: number;
+}
+
+export interface EvaluationArtifactTableEntryEvaluation {
+  evaluation_id: string;
+  inputs_id: string;
+  request_id: string;
+  run_id?: string;
+
+  inputs: Record<string, any>;
+  outputs: Record<string, any>;
+  targets: Record<string, any>;
+}
+
+export type RunEvaluationResultAssessmentSource = {
+  sourceType: AssessmentType;
+  sourceId: string;
+  metadata: Record<string, string>;
+};
+
+export type RunEvaluationResultAssessment = {
+  name: string;
+  rationale?: string | null;
+  source?: RunEvaluationResultAssessmentSource;
+  metadata?: Record<string, string | boolean | number>;
+  errorCode?: string;
+  errorMessage?: string;
+  numericValue?: number | null;
+  booleanValue?: boolean | null;
+  stringValue?: string | null;
+  // Root cause assessment points to the assessment name causing the failure.
+  rootCauseAssessment?: RootCauseAssessmentInfo | null;
+  timestamp?: number | null;
+};
+
+export type AssessmentValueType = string | boolean | number | undefined;
+
+export type AssessmentRunCounts = Map<AssessmentValueType, number>;
+
+export interface AssessmentAggregates {
+  assessmentInfo: AssessmentInfo;
+
+  // Counts for the current run and other run.
+  currentCounts?: AssessmentRunCounts;
+  otherCounts?: AssessmentRunCounts;
+
+  // Numeric averages for the current run and other run.
+  currentNumericAverage?: number;
+  otherNumericAverage?: number;
+
+  currentNumRootCause: number;
+  otherNumRootCause: number;
+
+  // Numeric aggregate counts for the current run.
+  currentNumericAggregate?: NumericAggregate;
+
+  assessmentFilters: AssessmentFilter[];
+}
+
+/**
+ * Server-side assessment count data from the trace metrics API.
+ * Each entry represents one (assessmentName, value) → count tuple.
+ */
+export interface AssessmentCountMetrics {
+  data: { assessmentName: string; assessmentValue: string; count: number }[];
+  isLoading: boolean;
+}
+
+export interface EvaluationsOverviewTableSort {
+  key: string;
+  type: TracesTableColumnType;
+  asc: boolean;
+}
+
+export interface TraceActions {
+  exportToEvals?: boolean;
+  deleteTracesAction?: {
+    deleteTraces?: (experimentId: string, traceIds: string[]) => Promise<any>;
+    isDisabled?: boolean;
+    disabledReason?: string;
+  };
+
+  editTags?: {
+    showEditTagsModalForTrace: (trace: ModelTraceInfoV3) => void;
+    EditTagsModal: React.ReactNode;
+  };
+
+  runJudgesAction?: {
+    showRunJudgesModal: (traceIds: string[]) => void;
+    RunJudgesModal: React.ReactNode;
+  };
+}
+
+// @deprecated, use TableFilter instead
+export interface AssessmentFilter {
+  assessmentName: string;
+  filterValue: AssessmentValueType;
+  // Only defined when filtering on an assessment for RCA values.
+  filterType?: 'rca' | undefined;
+  // Optional operator for numeric comparison filters (>, <, >=, <=).
+  // Defaults to equality (=) when not specified.
+  filterOperator?: FilterOperator;
+  run: string;
+}
+export type TableFilter = {
+  // The column group (e.g. "Assessments") or a specific column (e.g. "execution_duration")
+  column: TracesTableColumnGroup | string;
+  // Should be defined if a column group is used.
+  key?: string;
+  operator: FilterOperator | HiddenFilterOperator;
+  value: TableFilterValue;
+};
+
+export type TableFilterValue = string | boolean | number | undefined;
+
+export interface TableFilterOption {
+  value: string;
+  renderValue: () => string | React.ReactNode;
+}
+
+export interface TableFilterOptions {
+  source: TableFilterOption[];
+  prompt?: TableFilterOption[];
+}
+
+export enum FilterOperator {
+  EQUALS = '=',
+  NOT_EQUALS = '!=',
+  GREATER_THAN = '>',
+  LESS_THAN = '<',
+  GREATER_THAN_OR_EQUALS = '>=',
+  LESS_THAN_OR_EQUALS = '<=',
+  CONTAINS = 'CONTAINS',
+  RLIKE = 'RLIKE',
+  IS_NULL = 'IS NULL',
+  IS_NOT_NULL = 'IS NOT NULL',
+}
+
+/**
+ * Helper to check if an operator is a null-type operator (IS NULL or IS NOT NULL).
+ * These operators don't require a value.
+ */
+export const isNullOperator = (operator: string): boolean => {
+  return operator === FilterOperator.IS_NULL || operator === FilterOperator.IS_NOT_NULL;
+};
+
+// operators that are not displayed in the filter popover, but are
+// still supported in the backend. eventually we should implement
+// functionality for all these operators, but some of them take a
+// little more thought from the UX side (e.g. we need to remove the
+// value input for IS NOT NULL filters)
+export enum HiddenFilterOperator {
+  IS_NOT_NULL = 'IS NOT NULL',
+}
+
+export interface AssessmentDropdownSuggestionItem {
+  label: string;
+  key: string;
+  rootAssessmentName?: string;
+  disabled?: boolean;
+}
+
+export interface RunEvaluationResultAssessmentDraft extends RunEvaluationResultAssessment {
+  isDraft: true;
+}
+
+export type RunEvaluationResultMetric = {
+  key: string;
+  value: number;
+  timestamp: number;
+};
+
+export type RunEvaluationTracesRetrievalChunk = {
+  docUrl: string;
+  content: string;
+  retrievalAssessmentsByName?: Record<string, RunEvaluationResultAssessment[]>;
+  target?: string;
+};
+
+export type TraceV3 = {
+  info: ModelTraceInfoV3;
+  data: {
+    spans: ModelTraceSpan[];
+  };
+};
+
+/**
+ * An entity encompassing single review evaluation data.
+ */
+export type RunEvaluationTracesDataEntry = {
+  evaluationId: string;
+  fullTraceId?: string;
+  requestId: string;
+  inputsTitle?: string;
+  inputs: Record<string, any>;
+  inputsId: string;
+  outputs: Record<string, any>;
+  targets: Record<string, any>;
+  errorCode?: string;
+  errorMessage?: string;
+  requestTime?: string;
+  overallAssessments: RunEvaluationResultAssessment[];
+  responseAssessmentsByName: Record<
+    // Keyed by assessment name (e.g. "overall_judgement", "readability_score" etc.)
+    string,
+    RunEvaluationResultAssessment[]
+  >;
+  metrics: Record<string, RunEvaluationResultMetric>;
+  retrievalChunks?: RunEvaluationTracesRetrievalChunk[];
+
+  // Issues associated with this trace (id and name)
+  issues?: { id: string; name: string }[];
+
+  // NOTE(nsthorat): We will slowly migrate to this type.
+  traceInfo?: ModelTraceInfoV3;
+};
+
+export interface EvalTraceComparisonEntry {
+  currentRunValue?: RunEvaluationTracesDataEntry;
+  otherRunValue?: RunEvaluationTracesDataEntry;
+}
+
+export interface SaveAssessmentsQuery {
+  savePendingAssessments: (
+    runUuid: string,
+    evaluationId: string,
+    pendingAssessmentEntries: RunEvaluationResultAssessmentDraft[],
+  ) => void;
+  isSaving: boolean;
+}
+
+// Internal type used to determine behavior of different types of columns.
+// We should try to move away from this and start to use TracesTableColumnGroup instead.
+export enum TracesTableColumnType {
+  ASSESSMENT = 'ASSESSMENT',
+  EXPECTATION = 'EXPECTATION',
+  TRACE_INFO = 'TRACE_INFO',
+  INPUT = 'INPUT',
+  // This is a hack so that internal agent monitoring can display request time.
+  INTERNAL_MONITOR_REQUEST_TIME = 'INTERNAL_MONITOR_REQUEST_TIME',
+}
+
+// This represents columns that are grouped together.
+// For example, each assessment is its own column, but they are all grouped under the "Assessments" column group.
+export enum TracesTableColumnGroup {
+  ASSESSMENT = 'ASSESSMENT',
+  EXPECTATION = 'EXPECTATION',
+  TAG = 'TAG',
+  INFO = 'INFO',
+}
+
+export const TracesTableColumnGroupToLabelMap = {
+  [TracesTableColumnGroup.ASSESSMENT]: 'Assessments',
+  [TracesTableColumnGroup.EXPECTATION]: 'Expectations',
+  [TracesTableColumnGroup.TAG]: 'Tags',
+  // We don't show a label for the info column group
+  [TracesTableColumnGroup.INFO]: '\u00A0',
+};
+
+export interface TracesTableColumn {
+  /** This is the assessment name for assessments, and a static string for trace info and input columns */
+  id: string;
+  /** The label for the column, displayed in the table header. */
+  label: string;
+  /** The label for the column used in filter dropdowns. If not provided, defaults to `label`. */
+  filterLabel?: string;
+  /** The order of the column in the filter dropdowns. Lower numbers appear first. Defaults to 1. */
+  filterOrder?: number;
+  type: TracesTableColumnType;
+  group?: TracesTableColumnGroup;
+
+  // TODO: Remove this field once migration to trace info v3 is complete
+  assessmentInfo?: AssessmentInfo;
+  expectationName?: string;
+}
+
+export interface TableFilterFormState {
+  filters: TableFilter[];
+}
+
+// A bucket of a numeric aggregate.
+export type NumericAggregateCount = {
+  // The lower bound of the bucket, inclusive.
+  lower: number;
+  // The upper bound of the bucket, exclusive except for the last bucket.
+  upper: number;
+  // The number of values in the bucket.
+  count: number;
+};
+
+// A numeric aggregate with the min, mid, and max values, and the counts of values in each bucket.
+export type NumericAggregate = {
+  min: number;
+  max: number;
+  maxCount: number;
+  average: number;
+  counts: NumericAggregateCount[];
+};
+
+/**
+ * Required input fields that identify a dataset as multi-turn.
+ */
+export const REQUIRED_MULTITURN_INPUT_FIELDS = new Set(['goal']);

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/utils/AggregationUtils.ts
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/utils/AggregationUtils.ts
@@ -1,0 +1,879 @@
+import { first, isNil } from 'lodash';
+
+import type { ThemeType } from '@databricks/design-system';
+import type { IntlShape } from '@databricks/i18n';
+import {
+  ASSESSMENT_SESSION_METADATA_KEY,
+  INTERNAL_ASSESSMENT_ISSUE_DISCOVERY_JUDGE,
+} from '../../model-trace-explorer/constants';
+import { NOTES_ASSESSMENT_NAME } from '../../model-trace-explorer/assessments-pane/AssessmentsPaneNotesSection';
+
+import { getAssessmentValueBarBackgroundColor } from './Colors';
+import { DEFAULT_RUN_PLACEHOLDER_NAME } from './TraceUtils';
+import { isAssessmentPassing } from '../components/EvaluationsReviewAssessmentTag';
+import {
+  ASSESSMENTS_DOC_LINKS,
+  DEFAULT_ASSESSMENTS_SORT_ORDER,
+  getEvaluationResultAssessmentValue,
+  getJudgeMetricsLink,
+  KnownEvaluationResultAssessmentName,
+  KnownEvaluationResultAssessmentStringValue,
+  KnownEvaluationResultAssessmentValueDescription,
+  KnownEvaluationResultAssessmentValueLabel,
+  KnownEvaluationResultAssessmentValueMissingTooltip,
+} from '../components/GenAiEvaluationTracesReview.utils';
+import type {
+  AssessmentAggregates,
+  AssessmentCountMetrics,
+  AssessmentRunCounts,
+  AssessmentInfo,
+  EvalTraceComparisonEntry,
+  RunEvaluationResultAssessment,
+  RunEvaluationTracesDataEntry,
+  AssessmentDType,
+  AssessmentFilter,
+  AssessmentValueType,
+  NumericAggregateCount,
+  NumericAggregate,
+} from '../types';
+
+export interface StackedRunBarchartItem {
+  value: number;
+  fraction: number;
+  isSelected: boolean;
+  toggleFilter?: () => void;
+  tooltip: string;
+}
+export interface StackedBarchartItem {
+  name: string;
+  current: StackedRunBarchartItem;
+  other?: StackedRunBarchartItem;
+  backgroundColor: string;
+  scoreChange?: number;
+}
+
+export const ERROR_KEY = 'Error';
+
+export function doesAssessmentContainErrors(assessment?: RunEvaluationResultAssessment): boolean {
+  return Boolean(assessment?.errorCode || assessment?.errorMessage);
+}
+
+function getCustomMetricNameAndAssessment(assessmentPath: string): { metricName: string; assessmentName: string } {
+  // metric/all_guidelines/guideline_adherence
+  // gets parsed to {metricName: 'all_guidelines', assessmentName: 'guideline_adherence'}
+  const splits = assessmentPath.split('/');
+  if (splits.length === 1) {
+    return { metricName: assessmentPath, assessmentName: assessmentPath };
+  } else if (splits.length === 2) {
+    return { metricName: splits[0], assessmentName: splits[1] };
+  } else {
+    return { metricName: splits[1], assessmentName: splits.slice(2).join('/') };
+  }
+}
+
+const PASS_FAIL_VALUES: string[] = [
+  KnownEvaluationResultAssessmentStringValue.YES,
+  KnownEvaluationResultAssessmentStringValue.NO,
+];
+/**
+ * Computes global metadata for each of the assessments.
+ */
+export function getAssessmentInfos(
+  intl: IntlShape,
+  currentEvaluationResults: RunEvaluationTracesDataEntry[],
+  otherEvaluationResults: RunEvaluationTracesDataEntry[] | undefined,
+): AssessmentInfo[] {
+  const assessmentInfos: Record<string, AssessmentInfo> = {};
+  // Compute dtypes in the first pass.
+  // eslint-disable-next-line @databricks/no-const-object-record-string -- TODO(FEINF-2058)
+  const assessmentDtypes: Record<string, AssessmentDType | undefined> = {
+    [KnownEvaluationResultAssessmentName.OVERALL_ASSESSMENT]: 'pass-fail',
+  };
+  // Set of all assessment names. Will be filled after the first pass when computing dtypes.
+  const assessmentNames = new Set<string>();
+
+  [...currentEvaluationResults, ...(otherEvaluationResults || [])].forEach((result) => {
+    const responseAssessmentsByName: [string, RunEvaluationResultAssessment[]][] = Object.entries(
+      result.responseAssessmentsByName || {},
+    );
+
+    const overallAssessmentsByName: [string, RunEvaluationResultAssessment[]][] = result.overallAssessments.map(
+      (assessment) => [KnownEvaluationResultAssessmentName.OVERALL_ASSESSMENT as string, [assessment]],
+    );
+    const retrievalAssessmentsByName: [string, RunEvaluationResultAssessment[]][] = [];
+    result.retrievalChunks?.forEach((chunk) => {
+      // Iterate chunk.retrievalAssessmentsByName
+      for (const [assessmentName, assessments] of Object.entries(chunk.retrievalAssessmentsByName || {})) {
+        retrievalAssessmentsByName.push([assessmentName, assessments]);
+      }
+    });
+
+    for (const [assessmentName, assessments] of [
+      ...responseAssessmentsByName,
+      ...overallAssessmentsByName,
+      ...retrievalAssessmentsByName,
+    ]) {
+      // Skip internal assessments
+      if (assessmentName === INTERNAL_ASSESSMENT_ISSUE_DISCOVERY_JUDGE || assessmentName === NOTES_ASSESSMENT_NAME) {
+        continue;
+      }
+      assessmentNames.add(assessmentName);
+      // For string values, if we see a value that is not "yes" or "no", we treat it as a string.
+      // This is not a great approach, we should probably actually pass the pass-fail dtype information back somehow.
+      let dtype: AssessmentDType | undefined;
+      for (const assessment of assessments) {
+        dtype = !isNil(assessment.stringValue)
+          ? 'pass-fail'
+          : !isNil(assessment.numericValue)
+            ? 'numeric'
+            : !isNil(assessment.booleanValue)
+              ? 'boolean'
+              : undefined;
+        // If we found an assessment with a value, use it and stop searching
+        if (dtype !== undefined) {
+          break;
+        }
+      }
+
+      if (!assessmentDtypes[assessmentName]) {
+        if (assessmentName in KnownEvaluationResultAssessmentValueLabel) {
+          dtype = 'pass-fail';
+        }
+        assessmentDtypes[assessmentName] = dtype;
+      }
+
+      // Treat non-"yes"|"no" as string values.
+      for (const assessment of assessments) {
+        if (
+          dtype === 'pass-fail' &&
+          !isNil(assessment.stringValue) &&
+          !PASS_FAIL_VALUES.includes(assessment.stringValue)
+        ) {
+          assessmentDtypes[assessmentName] = 'string';
+          break;
+        }
+      }
+
+      // If the dtype is not the same as the current dtype (meaning there's mixed data types),
+      // treat it as a string.
+      if (dtype !== undefined && dtype !== assessmentDtypes[assessmentName]) {
+        assessmentDtypes[assessmentName] = 'string';
+      }
+    }
+  });
+
+  // if any assessment does not have a dtype, give it 'unknown' type. this can happen if all evaluations for that assessment are errors
+  for (const assessmentName of assessmentNames) {
+    if (!assessmentDtypes[assessmentName]) {
+      assessmentDtypes[assessmentName] = 'unknown';
+    }
+  }
+
+  [...currentEvaluationResults, ...(otherEvaluationResults || [])].forEach((result) => {
+    const responseAssessmentsByName: [string, RunEvaluationResultAssessment[]][] = Object.entries(
+      result.responseAssessmentsByName || {},
+    );
+
+    const overallAssessmentsByName: [string, RunEvaluationResultAssessment[]][] = result.overallAssessments.map(
+      (assessment) => [KnownEvaluationResultAssessmentName.OVERALL_ASSESSMENT as string, [assessment]],
+    );
+    const retrievalAssessmentsByName: [string, RunEvaluationResultAssessment[]][] = [];
+    result.retrievalChunks?.forEach((chunk) => {
+      // Iterate chunk.retrievalAssessmentsByName
+      for (const [assessmentName, assessments] of Object.entries(chunk.retrievalAssessmentsByName || {})) {
+        retrievalAssessmentsByName.push([assessmentName, assessments]);
+      }
+    });
+
+    const assessmentNames = Object.keys(assessmentDtypes);
+    for (const assessmentName of assessmentNames) {
+      const assessmentsByName = [
+        ...responseAssessmentsByName.filter(([name]) => name === assessmentName),
+        ...overallAssessmentsByName.filter(([name]) => name === assessmentName),
+        ...retrievalAssessmentsByName.filter(([name]) => name === assessmentName),
+      ];
+      const assessments = assessmentsByName.flatMap(([_, assessmentArray]) => assessmentArray);
+      const assessment: RunEvaluationResultAssessment | undefined = assessments[0];
+
+      const isError = doesAssessmentContainErrors(assessment);
+      const isSessionLevelAssessment = assessments.some(
+        (currentAssessment) => currentAssessment?.metadata?.[ASSESSMENT_SESSION_METADATA_KEY],
+      );
+
+      if (isNil(assessmentInfos[assessmentName])) {
+        let displayName: string;
+        let metricName: string;
+        let isCustomMetric = false;
+
+        const isKnown = KnownEvaluationResultAssessmentValueLabel[assessmentName] !== undefined;
+        if (isKnown) {
+          displayName = intl.formatMessage(KnownEvaluationResultAssessmentValueLabel[assessmentName]);
+          metricName = assessmentName;
+          isCustomMetric = false;
+        } else {
+          const { metricName: customMetricName, assessmentName: customAssessmentName } =
+            getCustomMetricNameAndAssessment(assessmentName);
+          displayName = customAssessmentName || '-';
+          metricName = customMetricName;
+          if (assessment?.source?.sourceType === 'CODE') {
+            isCustomMetric = true;
+          }
+        }
+        const dtype = assessmentDtypes[assessmentName] || 'string';
+
+        const docsLink = getJudgeMetricsLink(ASSESSMENTS_DOC_LINKS[assessmentName]);
+        const missingTooltip =
+          assessmentName in KnownEvaluationResultAssessmentValueMissingTooltip
+            ? intl.formatMessage(KnownEvaluationResultAssessmentValueMissingTooltip[assessmentName])
+            : '';
+        const description =
+          assessmentName in KnownEvaluationResultAssessmentValueDescription
+            ? intl.formatMessage(KnownEvaluationResultAssessmentValueDescription[assessmentName])
+            : assessment?.source?.sourceType === 'HUMAN'
+              ? intl.formatMessage({
+                  defaultMessage: 'This assessment is produced by a human judge.',
+                  description: 'Human judge assessment description',
+                })
+              : intl.formatMessage({
+                  defaultMessage: 'This assessment is produced by a custom metric.',
+                  description: 'Custom judge assessment description',
+                });
+
+        const uniqueValues = new Set<AssessmentValueType>();
+        // If no assessments exist for this name, add undefined to track missing assessments
+        if (assessments.length === 0) {
+          uniqueValues.add(undefined);
+        }
+        for (const currentAssessment of assessments) {
+          let assessmentValue = currentAssessment ? getEvaluationResultAssessmentValue(currentAssessment) : undefined;
+          if (assessmentValue === null) assessmentValue = undefined;
+          uniqueValues.add(assessmentValue);
+        }
+
+        assessmentInfos[assessmentName] = {
+          name: assessmentName,
+          displayName: displayName,
+          isKnown,
+          metricName,
+          isCustomMetric,
+          source: assessment?.source,
+          dtype,
+          uniqueValues,
+          isOverall: assessmentName === KnownEvaluationResultAssessmentName.OVERALL_ASSESSMENT,
+          docsLink,
+          missingTooltip,
+          description,
+          isEditable: assessment?.source?.sourceType === 'AI_JUDGE' || assessment?.source?.sourceType === 'HUMAN',
+          isRetrievalAssessment: retrievalAssessmentsByName.some(([name]) => name === assessmentName),
+          containsErrors: isError,
+          isSessionLevelAssessment,
+        };
+      } else {
+        const assessmentInfo = assessmentInfos[assessmentName];
+        // If no assessments exist for this name, add undefined to track missing assessments
+        if (assessments.length === 0) {
+          assessmentInfo.uniqueValues.add(undefined);
+        }
+        for (const currentAssessment of assessments) {
+          let value = currentAssessment ? getEvaluationResultAssessmentValue(currentAssessment) : undefined;
+          if (isNil(value)) value = undefined;
+          assessmentInfo.uniqueValues.add(value);
+        }
+
+        // Update isEditable.
+        if (!assessmentInfo.isEditable) {
+          assessmentInfo.isEditable =
+            assessment?.source?.sourceType === 'AI_JUDGE' || assessment?.source?.sourceType === 'HUMAN';
+        }
+
+        // isRetrievalAssessment should be true if any evaluation result has this assessment.
+        assessmentInfo.isRetrievalAssessment =
+          assessmentInfo.isRetrievalAssessment || retrievalAssessmentsByName.some(([name]) => name === assessmentName);
+
+        assessmentInfo.containsErrors = assessmentInfo.containsErrors || isError;
+        assessmentInfo.isSessionLevelAssessment = assessmentInfo.isSessionLevelAssessment || isSessionLevelAssessment;
+      }
+    }
+  });
+
+  // Remove the overall assessment if it does not have any non-null values.
+  const seenOverallAssessmentValues =
+    assessmentInfos[KnownEvaluationResultAssessmentName.OVERALL_ASSESSMENT]?.uniqueValues || new Set();
+  const hasOverallValue =
+    seenOverallAssessmentValues.has(KnownEvaluationResultAssessmentStringValue.YES) ||
+    seenOverallAssessmentValues.has(KnownEvaluationResultAssessmentStringValue.NO);
+  if (!hasOverallValue) {
+    delete assessmentInfos[KnownEvaluationResultAssessmentName.OVERALL_ASSESSMENT];
+  }
+
+  return sortAssessmentInfos(Object.values(assessmentInfos));
+}
+
+export function sortAssessmentInfos(assessmentInfos: AssessmentInfo[]): AssessmentInfo[] {
+  // Sort by DEFAULT_ASSESSMENTS_SORT_ORDER, fall back to alphabetical order of (metricName, name) which come after.
+  return assessmentInfos.sort((a, b) => {
+    const orderA = DEFAULT_ASSESSMENTS_SORT_ORDER.indexOf(a.name);
+    const orderB = DEFAULT_ASSESSMENTS_SORT_ORDER.indexOf(b.name);
+
+    // If both are in the sort order, compare their indices
+    if (orderA !== -1 && orderB !== -1) {
+      return orderA - orderB;
+    }
+
+    // If only one is in the sort order, prioritize it
+    if (orderA !== -1) return -1;
+    if (orderB !== -1) return 1;
+
+    // Otherwise, sort by name alphabetically
+    return a.name.localeCompare(b.name);
+  });
+}
+
+export function getNumericAggregate(numericValues: number[]): NumericAggregate | undefined {
+  if (numericValues.length === 0) {
+    return undefined;
+  }
+
+  const valueCounts = new Map<number, number>();
+  for (const value of numericValues) {
+    valueCounts.set(value, (valueCounts.get(value) ?? 0) + 1);
+  }
+  return getNumericAggregateFromCounts(valueCounts);
+}
+
+export function getNumericAggregateFromCounts(valueCounts: Map<number, number>): NumericAggregate | undefined {
+  if (valueCounts.size === 0) {
+    return undefined;
+  }
+
+  let min = Infinity;
+  let max = -Infinity;
+  let sum = 0;
+  let total = 0;
+  for (const [value, count] of valueCounts) {
+    if (value < min) min = value;
+    if (value > max) max = value;
+    sum += value * count;
+    total += count;
+  }
+
+  if (total === 0) {
+    return undefined;
+  }
+
+  const average = sum / total;
+  const numericAggregateCounts: NumericAggregateCount[] = [];
+
+  // Set a minimum bucket size of 0.01, since the data is displayed in 2 decimal places.
+  // Show at most 10 buckets.
+  const bucketSize = Math.max(0.01, (max - min) / 10);
+  let maxCount = 0;
+
+  if (min === max) {
+    numericAggregateCounts.push({ lower: min, upper: max, count: total });
+    maxCount = total;
+  } else {
+    for (let i = min; i < max; i += bucketSize) {
+      numericAggregateCounts.push({ lower: i, upper: Math.min(i + bucketSize, max), count: 0 });
+    }
+    numericAggregateCounts.sort((a, b) => a.lower - b.lower);
+
+    for (const [value, count] of valueCounts) {
+      const bucket = numericAggregateCounts.find(
+        (b) => value >= b.lower && (value < b.upper || (value === b.upper && value === max)),
+      );
+      if (bucket) {
+        bucket.count += count;
+        maxCount = Math.max(maxCount, bucket.count);
+      }
+    }
+  }
+
+  return { min, max, maxCount, average, counts: numericAggregateCounts };
+}
+
+export function getAssessmentNumericAggregates(
+  assessmentInfo: AssessmentInfo,
+  evalResults: RunEvaluationTracesDataEntry[],
+): NumericAggregate | undefined {
+  if (assessmentInfo.dtype !== 'numeric') {
+    return undefined;
+  }
+  const numericValues = evalResults
+    .flatMap((evalResult) => {
+      const assessments = assessmentInfo.isOverall
+        ? evalResult.overallAssessments
+        : evalResult.responseAssessmentsByName[assessmentInfo.name];
+      const result = assessments
+        ?.map((assessment) => getEvaluationResultAssessmentValue(assessment))
+        .filter((value) => value !== undefined && typeof value === 'number');
+      return result;
+    })
+    .filter((value) => !isNil(value));
+  return getNumericAggregate(numericValues);
+}
+
+function getAssessmentRunValueCounts(
+  assessmentInfo: AssessmentInfo,
+  evalResults: RunEvaluationTracesDataEntry[],
+): AssessmentRunCounts | undefined {
+  if (assessmentInfo.dtype === 'numeric') {
+    return undefined;
+  }
+  const valueCounts: AssessmentRunCounts = new Map();
+  evalResults.forEach((evalResult) => {
+    const assessments = assessmentInfo.isOverall
+      ? evalResult.overallAssessments
+      : evalResult.responseAssessmentsByName[assessmentInfo.name];
+    const valueCountsBySourceId =
+      assessments && assessments.length > 0
+        ? getUniqueValueCountsBySourceId(assessmentInfo, assessments)
+        : [{ value: undefined, count: 1 }];
+    const keysToCount = assessmentInfo.containsErrors
+      ? [ERROR_KEY, ...assessmentInfo.uniqueValues]
+      : assessmentInfo.uniqueValues;
+    for (const uniqueValue of keysToCount) {
+      const valueCountBySourceId = valueCountsBySourceId.find((valueCount) => valueCount.value === uniqueValue);
+      const count = valueCountBySourceId ? valueCountBySourceId.count : 0;
+      valueCounts.set(uniqueValue, (valueCounts.get(uniqueValue) || 0) + count);
+    }
+  });
+  return valueCounts;
+}
+
+function getRootCauseAssessmentCount(
+  assessmentInfo: AssessmentInfo,
+  evalResults: RunEvaluationTracesDataEntry[],
+): number {
+  let numRootCause = 0;
+  evalResults.forEach((evalResult) => {
+    if (isNil(evalResult)) return;
+    const overallAssessment = first(evalResult.overallAssessments);
+    if (overallAssessment?.rootCauseAssessment?.assessmentName === assessmentInfo.name) {
+      numRootCause++;
+    }
+  });
+  return numRootCause;
+}
+
+export function getAssessmentAggregates(
+  assessmentInfo: AssessmentInfo,
+  evalResults: EvalTraceComparisonEntry[],
+  allAssessmentFilters: AssessmentFilter[],
+): AssessmentAggregates {
+  const currentEvalResults = evalResults.map((entry) => entry.currentRunValue).filter((entry) => !isNil(entry));
+  const otherEvalResults = evalResults.map((entry) => entry.otherRunValue).filter((entry) => !isNil(entry));
+
+  const currentAssessmentAggregates = getAssessmentRunValueCounts(assessmentInfo, currentEvalResults);
+  const otherAssessmentAggregates = getAssessmentRunValueCounts(assessmentInfo, otherEvalResults);
+
+  const currentNumericAggregates = getAssessmentNumericAggregates(assessmentInfo, currentEvalResults);
+  const otherNumericAggregates = getAssessmentNumericAggregates(assessmentInfo, otherEvalResults);
+
+  const assessmentFilters = allAssessmentFilters.filter((filter) => filter.assessmentName === assessmentInfo.name);
+
+  return {
+    assessmentInfo,
+    currentCounts: currentAssessmentAggregates,
+    otherCounts: otherAssessmentAggregates,
+    currentNumericAverage: currentNumericAggregates?.average,
+    otherNumericAverage: otherNumericAggregates?.average,
+    currentNumericAggregate: currentNumericAggregates,
+    currentNumRootCause: getRootCauseAssessmentCount(assessmentInfo, currentEvalResults),
+    otherNumRootCause: getRootCauseAssessmentCount(assessmentInfo, otherEvalResults),
+    assessmentFilters,
+  };
+}
+
+/**
+ * Computes the total aggregate score for an assessment and evaluation results.
+ *
+ * For pass-fail dtypes, it computes what percentage of the runs have the assessment value as 'yes'.
+ * for boolean dtypes, it computes what percentage of the runs have the assessment value as 'true'.
+ */
+export function getAssessmentAggregateOverallFraction(
+  assessmentInfo: AssessmentInfo,
+  assessmentRunCounts: AssessmentRunCounts = new Map(),
+): number {
+  if (assessmentInfo.dtype === 'pass-fail' || assessmentInfo.dtype === 'boolean') {
+    let total = 0;
+    let passCount = 0;
+    for (const [value, count] of assessmentRunCounts) {
+      if (isAssessmentPassing(assessmentInfo, value)) {
+        passCount += count;
+      }
+      // We only consider non-null values for the total score.
+      if (!isNil(value) && value !== ERROR_KEY) {
+        total += count;
+      }
+    }
+    return total > 0 ? passCount / total : 0;
+  }
+  return 0;
+}
+
+function getAssessmentBarChartValueBarItem(
+  intl: IntlShape,
+  assessmentInfo: AssessmentInfo,
+  assessmentFilters: AssessmentFilter[],
+  value: string | boolean | number | undefined,
+  valueCounts: AssessmentRunCounts,
+  runName: string,
+  toggleAssessmentFilter: (
+    assessmentName: string,
+    filterValue: AssessmentValueType,
+    run: string,
+    filterType: AssessmentFilter['filterType'],
+  ) => void,
+): StackedRunBarchartItem {
+  let numEvals = 0;
+  const isErrorOrNull = value === ERROR_KEY || value === undefined;
+  for (const [key, count] of valueCounts) {
+    if (key !== undefined && key !== ERROR_KEY) {
+      numEvals += count;
+    }
+  }
+  const numValue = valueCounts.get(value) || 0;
+  const fraction = !isErrorOrNull && numEvals > 0 ? numValue / numEvals : 0;
+
+  const filterType: AssessmentFilter['filterType'] = undefined;
+
+  return {
+    value: valueCounts.get(value) || 0,
+    fraction,
+    isSelected: assessmentFilters.some(
+      (filter) =>
+        filter.filterValue === value && filter.assessmentName === assessmentInfo.name && filter.run === runName,
+    ),
+    toggleFilter: () => toggleAssessmentFilter(assessmentInfo.name, value, runName, filterType),
+    tooltip: !isErrorOrNull
+      ? intl.formatMessage(
+          {
+            defaultMessage: '{numValue}/{numEvals} for run "{runName}"',
+            description: 'Passing assessment tooltip',
+          },
+          {
+            numValue: numValue,
+            numEvals,
+            runName,
+          },
+        )
+      : intl.formatMessage(
+          {
+            defaultMessage: '{numValue} for run "{runName}"',
+            description: 'Error/null assessment tooltip',
+          },
+          {
+            numValue,
+            runName,
+          },
+        ),
+  };
+}
+
+function getBarChartKeys(assessmentInfo: AssessmentInfo) {
+  const keys = getSortedUniqueValues(assessmentInfo);
+  if (assessmentInfo.containsErrors) {
+    keys.push(ERROR_KEY);
+  }
+
+  return keys;
+}
+
+export function getBarChartData(
+  intl: IntlShape,
+  theme: ThemeType,
+  assessmentInfo: AssessmentInfo,
+  assessmentFilters: AssessmentFilter[],
+  toggleAssessmentFilter: (
+    assessmentName: string,
+    filterValue: AssessmentValueType,
+    run: string,
+    filterType: AssessmentFilter['filterType'],
+  ) => void,
+  displayInfoCounts: AssessmentAggregates,
+  currentRunDisplayName?: string,
+  compareToRunDisplayName?: string,
+): StackedBarchartItem[] {
+  const showCompareData = displayInfoCounts.otherCounts !== undefined;
+
+  const barItems: StackedBarchartItem[] = [];
+
+  for (const value of getBarChartKeys(assessmentInfo)) {
+    const currentBarItem = displayInfoCounts.currentCounts
+      ? getAssessmentBarChartValueBarItem(
+          intl,
+          assessmentInfo,
+          assessmentFilters,
+          value,
+          displayInfoCounts.currentCounts,
+          // For monitoring, there is no run name so we allow this to pass through.
+          currentRunDisplayName || DEFAULT_RUN_PLACEHOLDER_NAME,
+          toggleAssessmentFilter,
+        )
+      : undefined;
+
+    const otherBarItem =
+      showCompareData && compareToRunDisplayName
+        ? getAssessmentBarChartValueBarItem(
+            intl,
+            assessmentInfo,
+            assessmentFilters,
+            value,
+            displayInfoCounts.otherCounts || new Map(),
+            compareToRunDisplayName,
+            toggleAssessmentFilter,
+          )
+        : undefined;
+
+    const isErrorOrNull = value === ERROR_KEY || value === undefined;
+    const scoreChange =
+      showCompareData && currentBarItem && otherBarItem
+        ? isErrorOrNull
+          ? currentBarItem.value - (otherBarItem?.value || 0)
+          : currentBarItem.fraction - (otherBarItem?.fraction || 0)
+        : undefined;
+    // Only include Error or Null if there's a non-zero value or score change.
+    if (currentBarItem && (!isErrorOrNull || currentBarItem.value !== 0 || (scoreChange && scoreChange !== 0))) {
+      barItems.push({
+        name: getAssessmentBarChartValueText(intl, theme, assessmentInfo, value),
+        current: currentBarItem,
+        other: otherBarItem,
+        backgroundColor: getAssessmentValueBarBackgroundColor(theme, assessmentInfo, value, value === ERROR_KEY),
+        scoreChange,
+      });
+    }
+  }
+
+  return barItems;
+}
+
+function getSortedUniqueValues(assessmentInfo: AssessmentInfo) {
+  const uniqueValuesArray = Array.from(assessmentInfo.uniqueValues);
+  if (assessmentInfo.dtype === 'pass-fail') {
+    // Always show "YES" and "NO". We don't always show missing to reduce vertical space usage.
+    if (!uniqueValuesArray.includes(KnownEvaluationResultAssessmentStringValue.YES)) {
+      uniqueValuesArray.push(KnownEvaluationResultAssessmentStringValue.YES);
+    }
+    if (!uniqueValuesArray.includes(KnownEvaluationResultAssessmentStringValue.NO)) {
+      uniqueValuesArray.push(KnownEvaluationResultAssessmentStringValue.NO);
+    }
+    const sortOrder: string[] = [
+      KnownEvaluationResultAssessmentStringValue.YES,
+      KnownEvaluationResultAssessmentStringValue.NO,
+    ];
+
+    // Sort the unique values based on the order of the known values.
+    return uniqueValuesArray.sort((a, b) => {
+      const aIndex = sortOrder.indexOf(a as string);
+      const bIndex = sortOrder.indexOf(b as string);
+      return aIndex - bIndex;
+    });
+  } else if (assessmentInfo.dtype === 'boolean') {
+    // Sort by the value.
+    return uniqueValuesArray.sort((a, b) => {
+      return (a as boolean) === true ? -1 : 1;
+    });
+  }
+
+  // Sort the assessment.
+  return uniqueValuesArray.sort();
+}
+
+function getAssessmentBarChartValueText(
+  intl: IntlShape,
+  theme: ThemeType,
+  assessmentInfo: AssessmentInfo,
+  value: string | boolean | number | undefined,
+): string {
+  if (assessmentInfo.dtype === 'pass-fail') {
+    if (value === KnownEvaluationResultAssessmentStringValue.YES) {
+      return intl.formatMessage({
+        defaultMessage: 'Pass',
+        description: 'The label for a passing asseessment above a bar-chart in the summary stats.',
+      });
+    } else if (value === KnownEvaluationResultAssessmentStringValue.NO) {
+      return intl.formatMessage({
+        defaultMessage: 'Fail',
+        description: 'The label for a failing asseessment above a bar-chart in the summary stats.',
+      });
+    } else if (value === ERROR_KEY) {
+      return intl.formatMessage({
+        defaultMessage: 'Error',
+        description: 'The label for an error asseessment above a bar-chart in the summary stats.',
+      });
+    } else {
+      return intl.formatMessage({
+        defaultMessage: 'null',
+        description: 'null assessment label',
+      });
+    }
+  } else if (assessmentInfo.dtype === 'boolean') {
+    if (value === true) {
+      return intl.formatMessage({
+        defaultMessage: 'True',
+        description: 'True assessment label',
+      });
+    } else if (value === false) {
+      return intl.formatMessage({
+        defaultMessage: 'False',
+        description: 'False assessment label',
+      });
+    } else if (value === ERROR_KEY) {
+      return intl.formatMessage({
+        defaultMessage: 'Error',
+        description: 'The label for an error assessment above a bar-chart in the summary stats.',
+      });
+    } else {
+      return intl.formatMessage({
+        defaultMessage: 'null',
+        description: 'null assessment label',
+      });
+    }
+  }
+  return isNil(value) ? 'null' : `${value}`;
+}
+
+/**
+ * Compute the counts for each of the values given a set of assessments.
+ */
+export function getUniqueValueCountsBySourceId(
+  assessmentInfo: AssessmentInfo,
+  assessments: RunEvaluationResultAssessment[],
+): {
+  value: AssessmentValueType | undefined;
+  count: number;
+  latestAssessment: RunEvaluationResultAssessment;
+}[] {
+  const filteredAssessments = assessments.filter((assessment) => assessment.name === assessmentInfo.name);
+  // Compute the unique values of assessments.
+  let uniqueValues = new Set<AssessmentValueType | undefined>();
+  for (const assessment of filteredAssessments) {
+    const value = getEvaluationResultAssessmentValue(assessment);
+    uniqueValues.add(value);
+  }
+
+  // Sort by the latest timestamp.
+  filteredAssessments.sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0));
+
+  // Separate assessments with errors from those without.
+  const errorAssessments = filteredAssessments.filter((assessment) => doesAssessmentContainErrors(assessment));
+  const validAssessments = filteredAssessments.filter((assessment) => !doesAssessmentContainErrors(assessment));
+
+  // Recompute the unique values after filtering.
+  uniqueValues = new Set<AssessmentValueType | undefined>();
+  for (const assessment of validAssessments) {
+    const value = getEvaluationResultAssessmentValue(assessment);
+    uniqueValues.add(value);
+  }
+
+  // Compute the counts for each of the unique values.
+  const valueCounts: {
+    value: AssessmentValueType | undefined;
+    count: number;
+    latestAssessment: RunEvaluationResultAssessment;
+  }[] = [];
+  for (const value of uniqueValues) {
+    const assessmentsWithValue = filteredAssessments.filter(
+      (assessment) => getEvaluationResultAssessmentValue(assessment) === value,
+    );
+    const count = assessmentsWithValue.length;
+    valueCounts.push({ value, count, latestAssessment: assessmentsWithValue[0] });
+  }
+
+  // Add an entry for errors.
+  if (errorAssessments.length > 0) {
+    valueCounts.push({
+      value: ERROR_KEY,
+      count: errorAssessments.length,
+      latestAssessment: errorAssessments[0],
+    });
+  }
+
+  return valueCounts;
+}
+
+function buildCountsFromMetrics(
+  assessmentInfo: AssessmentInfo,
+  metricsData: AssessmentCountMetrics['data'],
+): AssessmentRunCounts {
+  const relevant = metricsData.filter((m) => m.assessmentName === assessmentInfo.name);
+  const counts: AssessmentRunCounts = new Map();
+
+  for (const metric of relevant) {
+    const typedValue = parseMetricAssessmentValue(metric.assessmentValue);
+    counts.set(typedValue, metric.count);
+  }
+
+  return counts;
+}
+
+function toNumericCounts(counts: AssessmentRunCounts): Map<number, number> {
+  const result = new Map<number, number>();
+  for (const [key, count] of counts) {
+    if (typeof key === 'number') {
+      result.set(key, count);
+    }
+  }
+  return result;
+}
+
+/**
+ * Converts a raw string value from the metrics API into a typed AssessmentValueType.
+ * The API JSON-encodes assessment values, so "\"yes\"" → "yes",
+ * "true" → true, "1.0" → 1.0, etc.
+ *
+ * "null" maps to ERROR_KEY because the metrics API only returns null for assessments
+ * that exist but have a null value (i.e. errored assessments). Truly missing assessments
+ * (no row at all) are excluded by the inner join and don't appear in the response.
+ */
+function parseMetricAssessmentValue(rawValue: string): AssessmentValueType {
+  try {
+    const parsed = JSON.parse(rawValue);
+    return parsed ?? ERROR_KEY;
+  } catch {
+    return rawValue;
+  }
+}
+
+/**
+ * Builds AssessmentAggregates from server-side count metrics.
+ * Used when infinite pagination is enabled to get accurate counts across all traces.
+ * Handles both categorical (pass-fail, boolean, string) and numeric assessments.
+ * Optionally accepts comparison run metrics data for `otherCounts`.
+ */
+export function buildAggregatesFromCountMetrics(
+  assessmentInfo: AssessmentInfo,
+  metricsData: AssessmentCountMetrics['data'],
+  allAssessmentFilters: AssessmentFilter[],
+  otherMetricsData?: AssessmentCountMetrics['data'],
+): AssessmentAggregates {
+  const currentCounts = buildCountsFromMetrics(assessmentInfo, metricsData);
+  const otherCounts = otherMetricsData ? buildCountsFromMetrics(assessmentInfo, otherMetricsData) : undefined;
+  const assessmentFilters = allAssessmentFilters.filter((f) => f.assessmentName === assessmentInfo.name);
+
+  if (assessmentInfo.dtype === 'numeric') {
+    const currentNumericCounts = toNumericCounts(currentCounts);
+    const otherNumericCounts = otherCounts ? toNumericCounts(otherCounts) : undefined;
+    const currentAggregate = getNumericAggregateFromCounts(currentNumericCounts);
+    const otherAggregate = otherNumericCounts ? getNumericAggregateFromCounts(otherNumericCounts) : undefined;
+    return {
+      assessmentInfo,
+      currentNumericAverage: currentAggregate?.average,
+      otherNumericAverage: otherAggregate?.average,
+      currentNumericAggregate: currentAggregate,
+      currentNumRootCause: 0,
+      otherNumRootCause: 0,
+      assessmentFilters,
+    };
+  }
+
+  return {
+    assessmentInfo,
+    currentCounts,
+    otherCounts,
+    currentNumRootCause: 0,
+    otherNumRootCause: 0,
+    assessmentFilters,
+  };
+}

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/utils/Colors.ts
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/utils/Colors.ts
@@ -1,0 +1,208 @@
+import { isNil } from 'lodash';
+
+import type { ThemeType } from '@databricks/design-system';
+
+import { KnownEvaluationResultAssessmentStringValue, withAlpha } from '../components/GenAiEvaluationTracesReview.utils';
+import type { AssessmentInfo, AssessmentValueType, RunEvaluationResultAssessment } from '../types';
+
+// Taken from figma: https://www.figma.com/design/2B1KMp9x624WrxaASrSv9B/Tiles-UX?node-id=3205-87588&t=1MwrDNNRIOSODm4D-0
+export const AGGREGATE_SCORE_CHANGE_BACKGROUND_COLORS = {
+  // Tag green
+  up: '#02B30214',
+  // Tag coral
+  down: '#F000400F',
+};
+
+// tagTextCoral
+export const AGGREGATE_SCORE_CHANGE_TEXT_COLOR = '#64172B';
+
+// From https://www.figma.com/design/HvkTlHxw4sKE77wDlRBDt2/Evaluation-UX?node-id=2996-40835&t=uqVDwh0gqqRJI3jS-0
+export const CURRENT_RUN_COLOR = '#077A9D';
+export const COMPARE_TO_RUN_COLOR = '#FFAB00';
+
+export const PASS_BARCHART_BAR_COLOR = '#99DDB4';
+export const FAIL_BARCHART_BAR_COLOR = '#FCA4A1';
+const ERROR_BARCHART_BAR_COLOR = '#f09065';
+
+const TAG_PASS_COLOR = '#02B30214'; // From tagBackgroundLime.
+
+const BUILTIN_SCORER_ASSESSMENT_COLORS = {
+  user_frustration: {
+    name: 'user_frustration',
+    valueColors: {
+      none: {
+        bar: PASS_BARCHART_BAR_COLOR,
+        tag: TAG_PASS_COLOR,
+        icon: (theme: ThemeType) => (theme.isDarkMode ? theme.colors.green400 : theme.colors.green600),
+        text: (theme: ThemeType) => (theme.isDarkMode ? theme.colors.green400 : theme.colors.green600),
+      },
+      resolved: {
+        bar: (theme: ThemeType) => theme.colors.yellow400,
+        tag: (theme: ThemeType) => (theme.isDarkMode ? withAlpha(theme.colors.yellow800, 0.6) : theme.colors.yellow200),
+        icon: (theme: ThemeType) => (theme.isDarkMode ? theme.colors.yellow400 : theme.colors.yellow600),
+        text: (theme: ThemeType) => (theme.isDarkMode ? theme.colors.yellow400 : theme.colors.yellow600),
+      },
+      unresolved: {
+        bar: FAIL_BARCHART_BAR_COLOR,
+        tag: (theme: ThemeType) => (theme.isDarkMode ? withAlpha(theme.colors.red800, 0.6) : theme.colors.red200),
+        icon: (theme: ThemeType) => (theme.isDarkMode ? theme.colors.red400 : theme.colors.red600),
+        text: (theme: ThemeType) => (theme.isDarkMode ? theme.colors.red400 : theme.colors.red600),
+      },
+    },
+  },
+} as const;
+
+const getBuiltInScorerAssessmentColors = (
+  assessmentInfo: AssessmentInfo,
+  assessmentValue: AssessmentValueType | string | null | undefined,
+  theme: ThemeType,
+):
+  | {
+      bar?: string;
+      tag?: string;
+      icon?: string;
+      text?: string;
+    }
+  | undefined => {
+  const builtInAssessment =
+    BUILTIN_SCORER_ASSESSMENT_COLORS[assessmentInfo.name as keyof typeof BUILTIN_SCORER_ASSESSMENT_COLORS];
+  if (!builtInAssessment) {
+    return undefined;
+  }
+
+  const valueKey = String(assessmentValue ?? '') as keyof typeof builtInAssessment.valueColors;
+  const colors = builtInAssessment.valueColors[valueKey];
+  if (!colors) {
+    return undefined;
+  }
+
+  return {
+    bar: typeof colors.bar === 'function' ? colors.bar(theme) : colors.bar,
+    tag: typeof colors.tag === 'function' ? colors.tag(theme) : colors.tag,
+    icon: typeof colors.icon === 'function' ? colors.icon(theme) : colors.icon,
+    text: typeof colors.text === 'function' ? colors.text(theme) : colors.text,
+  };
+};
+
+export const getEvaluationResultIconColor = (
+  theme: ThemeType,
+  assessmentInfo: AssessmentInfo,
+  assessment?: RunEvaluationResultAssessment | { stringValue: string; errorMessage?: string },
+) => {
+  const builtInScorerColors = getBuiltInScorerAssessmentColors(assessmentInfo, assessment?.stringValue, theme);
+  if (builtInScorerColors?.icon) {
+    return builtInScorerColors.icon;
+  }
+
+  if (assessmentInfo.dtype === 'pass-fail') {
+    // Return the color based on the assessment value
+    if (assessment?.stringValue === KnownEvaluationResultAssessmentStringValue.YES) {
+      return theme.isDarkMode ? theme.colors.green400 : theme.colors.green600;
+    }
+    if (assessment?.stringValue === KnownEvaluationResultAssessmentStringValue.NO) {
+      return theme.isDarkMode ? theme.colors.red400 : theme.colors.red600;
+    }
+  }
+  if (assessment?.errorMessage) {
+    return theme.colors.textValidationWarning;
+  }
+  return theme.colors.grey400;
+};
+
+export const getEvaluationResultAssessmentBackgroundColor = (
+  theme: ThemeType,
+  assessmentInfo: AssessmentInfo,
+  assessment?: RunEvaluationResultAssessment | { stringValue: string; booleanValue?: string; errorMessage?: string },
+  iconOnly = false,
+) => {
+  const builtInScorerColors = getBuiltInScorerAssessmentColors(assessmentInfo, assessment?.stringValue, theme);
+  if (builtInScorerColors?.tag) {
+    return builtInScorerColors.tag;
+  }
+
+  if (assessmentInfo.dtype === 'pass-fail') {
+    // Return the color based on the assessment value
+    if (assessment?.stringValue === KnownEvaluationResultAssessmentStringValue.YES) {
+      return TAG_PASS_COLOR;
+    }
+    if (assessment?.stringValue === KnownEvaluationResultAssessmentStringValue.NO) {
+      return theme.isDarkMode ? withAlpha(theme.colors.red800, 0.6) : theme.colors.red200;
+    }
+    if (!iconOnly && assessment?.errorMessage) {
+      return '';
+    }
+  } else if (assessmentInfo.dtype === 'boolean') {
+    if (isNil(assessment?.booleanValue)) {
+      return '';
+    }
+    return assessment.booleanValue ? TAG_PASS_COLOR : theme.isDarkMode ? theme.colors.red800 : theme.colors.red200;
+  }
+  return '';
+};
+
+export const getEvaluationResultTextColor = (
+  theme: ThemeType,
+  assessmentInfo: AssessmentInfo,
+  assessment?: RunEvaluationResultAssessment | { stringValue?: string; booleanValue?: boolean; errorMessage?: string },
+) => {
+  if (assessment?.errorMessage) {
+    return theme.colors.textValidationWarning;
+  }
+
+  const builtInScorerColors = getBuiltInScorerAssessmentColors(assessmentInfo, assessment?.stringValue, theme);
+  if (builtInScorerColors?.text) {
+    return builtInScorerColors.text;
+  }
+
+  if (assessmentInfo.dtype === 'pass-fail') {
+    // Return the color based on the assessment value
+    if (assessment?.stringValue === KnownEvaluationResultAssessmentStringValue.YES) {
+      return theme.isDarkMode ? theme.colors.green400 : theme.colors.green600;
+    } else if (assessment?.stringValue === KnownEvaluationResultAssessmentStringValue.NO) {
+      return theme.isDarkMode ? theme.colors.red400 : theme.colors.red600;
+    } else {
+      return theme.colors.textSecondary;
+    }
+  } else if (assessmentInfo.dtype === 'boolean') {
+    if (isNil(assessment?.booleanValue)) {
+      return theme.colors.textSecondary;
+    }
+    return theme.colors.textPrimary;
+  } else if (assessmentInfo.dtype === 'unknown') {
+    return theme.colors.textSecondary;
+  }
+  return theme.colors.textPrimary;
+};
+
+export const getAssessmentValueBarBackgroundColor = (
+  theme: ThemeType,
+  assessmentInfo: AssessmentInfo,
+  assessmentValue: AssessmentValueType,
+  isError?: boolean,
+) => {
+  if (isError) {
+    return ERROR_BARCHART_BAR_COLOR;
+  }
+
+  const builtInScorerColors = getBuiltInScorerAssessmentColors(assessmentInfo, assessmentValue, theme);
+  if (builtInScorerColors?.bar) {
+    return builtInScorerColors.bar;
+  }
+
+  if (assessmentInfo.dtype === 'pass-fail') {
+    // Return the color based on the assessment value
+    if (assessmentValue === KnownEvaluationResultAssessmentStringValue.YES) {
+      return PASS_BARCHART_BAR_COLOR;
+    }
+    if (assessmentValue === KnownEvaluationResultAssessmentStringValue.NO) {
+      return FAIL_BARCHART_BAR_COLOR;
+    }
+    return theme.isDarkMode ? theme.colors.grey800 : theme.colors.grey200;
+  } else if (assessmentInfo.dtype === 'boolean') {
+    if (isNil(assessmentValue)) {
+      return theme.isDarkMode ? theme.colors.grey800 : theme.colors.grey200;
+    }
+    return assessmentValue ? PASS_BARCHART_BAR_COLOR : FAIL_BARCHART_BAR_COLOR;
+  }
+  return theme.isDarkMode ? theme.colors.grey800 : theme.colors.grey200;
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/utils/DisplayUtils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/utils/DisplayUtils.tsx
@@ -1,0 +1,304 @@
+import { isNil } from 'lodash';
+import React from 'react';
+
+import type { IntlShape } from '@databricks/i18n';
+import { FormattedMessage } from '@databricks/i18n';
+
+import { getAssessmentAggregateOverallFraction } from './AggregationUtils';
+import type { AssessmentAggregates, AssessmentInfo } from '../types';
+const NUM_DECIMALS_PERCENTAGE_DISPLAY = 1;
+
+/** Display a fraction (0-1) as a percentage. */
+export function displayPercentage(fraction: number, numDecimalsDisplayPercentage = NUM_DECIMALS_PERCENTAGE_DISPLAY) {
+  // We wrap in a Number to remove trailing zeros (4.00 => 4).
+  return Number((fraction * 100).toFixed(numDecimalsDisplayPercentage)).toString();
+}
+
+/**
+ * Parse a duration string like "34.00000000000002ms" or "5.100s", round the numeric
+ * part to up to 3 decimals, strip trailing zeros, and reattach the unit.
+ */
+export function normalizeDurationString(val?: string): string | undefined {
+  if (val === undefined) {
+    return undefined;
+  }
+  const floatVal = parseFloat(val);
+  const unit = val
+    ?.replace?.(/[0-9.]/g, '')
+    .trim()
+    .toLowerCase();
+  if (isNil(floatVal) || isNaN(floatVal)) {
+    return undefined;
+  }
+  return [floatVal.toFixed(3).replace(/\.?0+$/, ''), unit].filter(Boolean).join('');
+}
+
+export function displayFloat(value: number | undefined | null, numDecimals = 3) {
+  if (isNil(value)) {
+    return 'null';
+  }
+  const multiplier = Math.pow(10, numDecimals);
+  const result = Math.round(value * multiplier) / multiplier;
+  return result.toString();
+}
+
+/**
+ * Computes the overall display score for an assessment, and the change in score from the other run.
+ */
+export function getDisplayOverallScoreAndChange(
+  intl: IntlShape,
+  assessmentInfo: AssessmentInfo,
+  assessmentDisplayInfo: AssessmentAggregates,
+): {
+  displayScore: string;
+  displayScoreChange: string | undefined;
+  changeDirection: 'up' | 'down' | 'none';
+  aggregateType: 'average' | 'percentage-true' | 'categorical';
+} {
+  if (assessmentInfo.dtype === 'numeric') {
+    const currentAverage = assessmentDisplayInfo.currentNumericAverage ?? NaN;
+    const otherAverage = assessmentDisplayInfo.otherNumericAverage;
+
+    const displayScore = displayFloat(currentAverage, 2);
+    const scoreChange = otherAverage !== undefined ? currentAverage - otherAverage : undefined;
+    const changeDirection = scoreChange ? (scoreChange > 0 ? 'up' : 'down') : 'none';
+
+    const displayScoreChange = scoreChange
+      ? changeDirection === 'up'
+        ? `+${displayFloat(Math.abs(scoreChange), 2)}`
+        : changeDirection === 'down'
+          ? `-${displayFloat(Math.abs(scoreChange), 2)}`
+          : '+0'
+      : undefined;
+
+    return {
+      displayScore,
+      displayScoreChange,
+      changeDirection,
+      aggregateType: 'average',
+    };
+  } else if (assessmentInfo.dtype === 'pass-fail' || assessmentInfo.dtype === 'boolean') {
+    const numDecimalsDisplayPercentage = 0;
+    const scoreFraction = getAssessmentAggregateOverallFraction(assessmentInfo, assessmentDisplayInfo.currentCounts);
+    const displayScore = displayPercentage(scoreFraction, numDecimalsDisplayPercentage) + '%';
+    const scoreChange = assessmentDisplayInfo.otherCounts
+      ? scoreFraction - getAssessmentAggregateOverallFraction(assessmentInfo, assessmentDisplayInfo.otherCounts)
+      : undefined;
+    const changeDirection = scoreChange ? (scoreChange > 0 ? 'up' : 'down') : 'none';
+    const displayScoreChange = scoreChange
+      ? (changeDirection === 'up' || changeDirection === 'none' ? '+' : '') +
+        displayPercentage(scoreChange, numDecimalsDisplayPercentage) +
+        '%'
+      : undefined;
+
+    return {
+      displayScore,
+      displayScoreChange,
+      changeDirection,
+      aggregateType: 'percentage-true',
+    };
+  } else if (assessmentInfo.dtype === 'string') {
+    const numUniqueValues = assessmentInfo.uniqueValues.size;
+    return {
+      displayScore:
+        numUniqueValues !== 1
+          ? intl.formatMessage(
+              {
+                defaultMessage: '{numUniqueValues} values',
+                description: 'Text for number of unique values for categorical assessment',
+              },
+              { numUniqueValues },
+            )
+          : intl.formatMessage({
+              defaultMessage: '1 value',
+              description: 'Text for number of unique values for categorical assessment',
+            }),
+      displayScoreChange: '',
+      changeDirection: 'none',
+      aggregateType: 'categorical',
+    };
+  } else {
+    return {
+      displayScore: 'N/A',
+      displayScoreChange: 'N/A',
+      changeDirection: 'none',
+      aggregateType: 'categorical',
+    };
+  }
+}
+
+export function getDisplayScore(assessmentInfo: AssessmentInfo, fraction: number) {
+  return displayPercentage(fraction, 0) + '%';
+}
+
+export function getDisplayScoreChange(assessmentInfo: AssessmentInfo, scoreChange: number, asPercentage = true) {
+  if (assessmentInfo.dtype === 'numeric') {
+    const changeDirection = scoreChange > 0 ? 'up' : 'down';
+    return changeDirection === 'up' ? `+${displayFloat(scoreChange, 2)}` : `-${displayFloat(scoreChange, 2)}`;
+  } else {
+    const changeDirection = scoreChange >= 0 ? 'up' : 'down';
+    if (asPercentage) {
+      return changeDirection === 'up'
+        ? `+${displayPercentage(scoreChange, 0)}%`
+        : `-${displayPercentage(scoreChange * -1, 0)}%`;
+    } else {
+      return changeDirection === 'up' ? `+${scoreChange}` : `-${scoreChange}`;
+    }
+  }
+}
+
+// This is forked from mlflow: https://src.dev.databricks.com/databricks-eng/universe/-/blob/mlflow/server/js/src/common/utils/Utils.tsx?L188
+export function timeSinceStr(date: any, referenceDate = new Date()) {
+  // @ts-expect-error TS(2362): The left-hand side of an arithmetic operation must... Remove this comment to see the full error message
+  const seconds = Math.max(0, Math.floor((referenceDate - date) / 1000));
+  let interval = Math.floor(seconds / 31536000);
+
+  if (interval >= 1) {
+    return (
+      <FormattedMessage
+        defaultMessage="{timeSince, plural, =1 {1 year} other {# years}} ago"
+        description="Text for time in years since given date for MLflow views"
+        values={{ timeSince: interval }}
+      />
+    );
+  }
+  interval = Math.floor(seconds / 2592000);
+  if (interval >= 1) {
+    return (
+      <FormattedMessage
+        defaultMessage="{timeSince, plural, =1 {1 month} other {# months}} ago"
+        description="Text for time in months since given date for MLflow views"
+        values={{ timeSince: interval }}
+      />
+    );
+  }
+  interval = Math.floor(seconds / 86400);
+  if (interval >= 1) {
+    return (
+      <FormattedMessage
+        defaultMessage="{timeSince, plural, =1 {1 day} other {# days}} ago"
+        description="Text for time in days since given date for MLflow views"
+        values={{ timeSince: interval }}
+      />
+    );
+  }
+  interval = Math.floor(seconds / 3600);
+  if (interval >= 1) {
+    return (
+      <FormattedMessage
+        defaultMessage="{timeSince, plural, =1 {1 hour} other {# hours}} ago"
+        description="Text for time in hours since given date for MLflow views"
+        values={{ timeSince: interval }}
+      />
+    );
+  }
+  interval = Math.floor(seconds / 60);
+  if (interval >= 1) {
+    return (
+      <FormattedMessage
+        defaultMessage="{timeSince, plural, =1 {1 minute} other {# minutes}} ago"
+        description="Text for time in minutes since given date for MLflow views"
+        values={{ timeSince: interval }}
+      />
+    );
+  }
+  return (
+    <FormattedMessage
+      defaultMessage="{timeSince, plural, =1 {1 second} other {# seconds}} ago"
+      description="Text for time in seconds since given date for MLflow views"
+      values={{ timeSince: seconds }}
+    />
+  );
+}
+
+// Function to escape CSS Special characters by adding \\ before them. Needed when inserting CSS variables.
+export function escapeCssSpecialCharacters(str: string) {
+  // eslint-disable-next-line no-useless-escape
+  return str.replace(/([!"#$%&'()*+,\.\/:;\s<=>?@[\\\]^`{|}~])/g, '\\$1');
+}
+
+/** Escape special regex characters so the string can be used in a RegExp literally. */
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Wraps case-insensitive matches of searchQuery in text with <mark>.
+ * Returns the original text as-is if searchQuery is empty or no match.
+ * Used to highlight search matches in the trace list (e.g. Request column).
+ */
+export function highlightSearchInText(text: string, searchQuery: string | undefined): React.ReactNode {
+  if (!text || !searchQuery?.trim()) {
+    return text;
+  }
+  const escaped = escapeRegex(searchQuery.trim());
+  const regex = new RegExp(`(${escaped})`, 'gi');
+  const parts = text.split(regex);
+  if (parts.length <= 1) {
+    return text;
+  }
+  // With a capturing group, split() includes matches: [nonMatch, match, nonMatch, match, ...]
+  return (
+    <>
+      {parts.map((part, i) =>
+        i % 2 === 1 ? (
+          <mark
+            key={i}
+            css={{
+              backgroundColor: 'var(--trace-search-highlight-bg, rgba(255, 212, 0, 0.35))',
+              padding: 0,
+              margin: 0,
+            }}
+          >
+            {part}
+          </mark>
+        ) : (
+          <React.Fragment key={i}>{part}</React.Fragment>
+        ),
+      )}
+    </>
+  );
+}
+
+// Adapted from query-insights/utils/numberUtils
+export function prettySizeWithUnit(bytes: number | null | undefined, fractionDigits?: number) {
+  return prettyNumberWithUnit(bytes, 1024, ['bytes', 'KB', 'MB', 'GB', 'TB', 'PB'], fractionDigits);
+}
+
+function prettyNumberWithUnit(
+  value: string | number | null | undefined,
+  divisor: number,
+  units: string[] = [],
+  fractionDigits?: number,
+): { unit: string; value: string; numericValue: number | undefined; divisor: number } {
+  let val = Number(value);
+
+  if (isNaN(val) || !isFinite(val)) {
+    return {
+      value: '',
+      numericValue: undefined,
+      unit: '',
+      divisor: 1,
+    };
+  }
+
+  let unit = 0;
+  let greatestDivisor = 1;
+
+  while (val >= divisor && unit < units.length - 1) {
+    val /= divisor;
+    greatestDivisor *= divisor;
+    unit += 1;
+  }
+
+  return {
+    value: formatNumber(val, fractionDigits),
+    numericValue: val,
+    unit: units[unit],
+    divisor: greatestDivisor,
+  };
+}
+
+function formatNumber(value: number, fractionDigits = 3): string {
+  return Math.round(value) !== value ? value.toFixed(fractionDigits) : value.toString();
+}

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/utils/DocUtils.ts
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/utils/DocUtils.ts
@@ -1,0 +1,3 @@
+export const getDocsLink = (docUrl: string) => {
+  return `https://mlflow.org/docs/latest${docUrl}`;
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/utils/ErrorUtils.ts
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/utils/ErrorUtils.ts
@@ -1,0 +1,20 @@
+/**
+ * Known SQL warehouse timeout error message patterns from the backend.
+ * These correspond to timeout errors in MlflowSqlExecUtils.scala.
+ */
+const SQL_TIMEOUT_PATTERNS = [
+  'Timeout while getting statement result',
+  'Timeout while issuing SQL query',
+  'Timeout while waiting for SQL query to complete',
+  'underlying SQL request timed out',
+];
+
+/**
+ * Detects whether the given error is a SQL warehouse timeout error.
+ * This helps distinguish timeout errors (which may be resolved by selecting
+ * a larger warehouse) from other types of failures.
+ */
+export const isSqlWarehouseTimeoutError = (error: Error | undefined | null): boolean => {
+  if (!error?.message) return false;
+  return SQL_TIMEOUT_PATTERNS.some((pattern) => error.message.includes(pattern));
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/utils/EvaluationDataParseUtils.ts
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/utils/EvaluationDataParseUtils.ts
@@ -1,0 +1,201 @@
+import { difference, groupBy, isNil, isNumber, isPlainObject, orderBy, zipObject } from 'lodash';
+
+import { KnownEvaluationResultAssessmentMetadataFields, KnownEvaluationResultAssessmentName } from '../enum';
+import type {
+  EvaluationArtifactTableEntryAssessment,
+  EvaluationArtifactTableEntryEvaluation,
+  EvaluationArtifactTableEntryMetric,
+  RawGenaiEvaluationArtifactResponse,
+  RunEvaluationResultAssessment,
+  RunEvaluationResultMetric,
+  RunEvaluationTracesDataEntry,
+  RunEvaluationTracesRetrievalChunk,
+} from '../types';
+
+export const isEvaluationResultOverallAssessment = (assessmentEntry: RunEvaluationResultAssessment) =>
+  assessmentEntry.metadata?.[KnownEvaluationResultAssessmentMetadataFields.IS_OVERALL_ASSESSMENT] === true;
+
+export const isEvaluationResultPerRetrievalChunkAssessment = (assessmentEntry: RunEvaluationResultAssessment) =>
+  isNumber(assessmentEntry.metadata?.[KnownEvaluationResultAssessmentMetadataFields.CHUNK_INDEX]);
+
+/**
+ * Checks if the given value is a retrieved context.
+ * A retrieved context is a list of objects with a `doc_uri` and `content` field.
+ */
+export const isRetrievedContext = (value: any): boolean => {
+  return Array.isArray(value) && value.every((v) => isPlainObject(v) && 'doc_uri' in v && 'content' in v);
+};
+
+/**
+ * Extracts the first retrieved context value from the given record.
+ * Returns undefined if no retrieved context is found.
+ */
+const getFirstRetrievedContextValue = (
+  record?: Record<string, any>,
+): { doc_uri: string; content: string }[] | undefined => {
+  return Object.values(record || {}).find(isRetrievedContext) as { doc_uri: string; content: string }[];
+};
+
+/**
+ * Extracts the retrieval chunks from the given outputs, targets and per-chunk assessments.
+ */
+export const extractRetrievalChunks = (
+  outputs?: Record<string, any>,
+  targets?: Record<string, any>,
+  perChunkAssessments?: RunEvaluationResultAssessment[],
+): RunEvaluationTracesRetrievalChunk[] => {
+  // Only support one retrieved context for now, first one is used
+  const retrievedContext = getFirstRetrievedContextValue(outputs) || [];
+  const expectedRetrievedContext = getFirstRetrievedContextValue(targets);
+
+  return retrievedContext.map((retrievedContext, index) => {
+    const target = expectedRetrievedContext?.[index];
+    const assessments = (perChunkAssessments || []).filter(
+      (assessment) => (assessment.metadata || {})[KnownEvaluationResultAssessmentMetadataFields.CHUNK_INDEX] === index,
+    );
+    // Group detailed assessments by name
+    const retrievalAssessmentsByName = groupBy(assessments, 'name');
+    // Ensure each group is sorted by timestamp in descending order
+    Object.keys(retrievalAssessmentsByName).forEach((key) => {
+      retrievalAssessmentsByName[key] = orderBy(retrievalAssessmentsByName[key], 'timestamp', 'desc');
+    });
+
+    return {
+      docUrl: retrievedContext.doc_uri,
+      content: retrievedContext.content,
+      retrievalAssessmentsByName: retrievalAssessmentsByName,
+      target: target?.content,
+    };
+  });
+};
+
+export function parseRawTableArtifact<T>(artifactData?: RawGenaiEvaluationArtifactResponse): T | undefined {
+  if (!artifactData) {
+    return undefined;
+  }
+  const { columns, data, filename } = artifactData;
+
+  if (!columns || !Array.isArray(columns)) {
+    throw new SyntaxError(`Artifact ${filename} is malformed, it does not contain "columns" array`);
+  }
+  if (!data || !Array.isArray(data)) {
+    throw new SyntaxError(`Artifact ${filename} is malformed, it does not contain "data" array`);
+  }
+
+  const normalizedColumns = columns.map((column, index) => column ?? `column_${index}`);
+
+  return data.map((row) => zipObject(normalizedColumns, row)) as T;
+}
+
+export function mergeMetricsAndAssessmentsWithEvaluations(
+  evaluations: EvaluationArtifactTableEntryEvaluation[],
+  metrics?: EvaluationArtifactTableEntryMetric[],
+  assessments?: EvaluationArtifactTableEntryAssessment[],
+): RunEvaluationTracesDataEntry[] {
+  // Group metrics by evaluation_id.
+  const metricsByEvaluation = (metrics || []).reduce<Record<string, Record<string, RunEvaluationResultMetric>>>(
+    (acc, entry: any) => {
+      if (!acc[entry.evaluation_id]) {
+        acc[entry.evaluation_id] = {};
+      }
+      const { key, value, timestamp } = entry;
+      acc[entry.evaluation_id][key] = { key, value, timestamp };
+      return acc;
+    },
+    {},
+  );
+
+  // Group assessments by evaluation_id.
+  const assessmentsByEvaluation = (assessments || []).reduce<Record<string, RunEvaluationResultAssessment[]>>(
+    (acc, entry: EvaluationArtifactTableEntryAssessment) => {
+      if (!acc[entry.evaluation_id]) {
+        acc[entry.evaluation_id] = [];
+      }
+      acc[entry.evaluation_id].push({
+        booleanValue: !isNil(entry.boolean_value) ? Boolean(entry.boolean_value) : entry.boolean_value,
+        numericValue: !isNil(entry.numeric_value) ? Number(entry.numeric_value) : entry.numeric_value,
+        stringValue: !isNil(entry.string_value) ? String(entry.string_value) : entry.string_value,
+        metadata: entry.metadata || {},
+        ...(entry.error_code && { errorCode: entry.error_code }),
+        ...(entry.error_message && { errorMessage: entry.error_message }),
+        name: entry.name,
+        rationale: entry.rationale || null,
+        source: {
+          metadata: entry.source?.metadata ?? {},
+          sourceId: entry.source?.source_id,
+          sourceType: entry.source?.source_type,
+        },
+        timestamp: entry.timestamp,
+      });
+      return acc;
+    },
+    {},
+  );
+
+  return evaluations.map((entry: any) => {
+    // Get all assessments for the evaluation and group them by name
+    const allAssessmentsSorted = orderBy(assessmentsByEvaluation[entry.evaluation_id] || [], 'timestamp', 'desc');
+    const overallAssessments: RunEvaluationResultAssessment[] = allAssessmentsSorted
+      .filter(isEvaluationResultOverallAssessment)
+      .map((assessment) => {
+        // Find the "[assessment_name]" prefix and convert it to the rootCauseAssessment, removing it from the prefix.
+        // The format is: "[assessment_name] rationale **Suggested Actions**: suggestedActions"
+        const match = assessment.rationale?.match(/^\[(.*?)\](.*?)(?:\*\*Suggested Actions\*\*:(.*))?$/s);
+
+        const assessmentName = match ? match[1]?.trim() : undefined;
+        const newRationale = match ? match[2]?.trim() : undefined;
+        const suggestedActions = match ? match[3]?.trim() : undefined;
+
+        assessment.rationale = newRationale || assessment.rationale;
+        const result: RunEvaluationResultAssessment = {
+          ...assessment,
+          rootCauseAssessment: !isNil(assessmentName) ? { assessmentName, suggestedActions } : undefined,
+        };
+        return result;
+      });
+    if (overallAssessments.length === 0) {
+      // In the special case where there is no overall assessment, we create a null here so the UI can render it.
+      overallAssessments.push({
+        name: KnownEvaluationResultAssessmentName.OVERALL_ASSESSMENT,
+        rationale: null,
+        source: {
+          sourceType: 'AI_JUDGE',
+          sourceId: 'UNKNOWN',
+          metadata: {},
+        },
+        metadata: {},
+        numericValue: null,
+        booleanValue: null,
+        stringValue: null,
+        timestamp: null,
+      });
+    }
+    // TODO(nsthorat): perRetrievalChunkAsessments should be treated differently than other methods, and removed from the overall metrics.
+    const perRetrievalChunkAssessments = allAssessmentsSorted.filter(isEvaluationResultPerRetrievalChunkAssessment);
+
+    // All assessments that are not overall or per retrieval chunk are response assessments
+    const responseAssessments = difference(allAssessmentsSorted, overallAssessments, perRetrievalChunkAssessments);
+
+    // Group response assessments by name
+    const responseAssessmentsByName = groupBy(responseAssessments, 'name');
+    // Ensure each group is sorted by timestamp in descending order
+    Object.keys(responseAssessmentsByName).forEach((key) => {
+      responseAssessmentsByName[key] = orderBy(responseAssessmentsByName[key], 'timestamp', 'desc');
+    });
+
+    return {
+      evaluationId: entry.evaluation_id,
+      requestId: entry.request_id,
+      inputs: entry.inputs,
+      inputsId: entry.inputs_id,
+      outputs: entry.outputs ?? {},
+      targets: entry.targets ?? {},
+      ...(entry.error_code && { errorCode: entry.error_code }),
+      ...(entry.error_message && { errorMessage: entry.error_message }),
+      overallAssessments,
+      responseAssessmentsByName,
+      metrics: metricsByEvaluation[entry.evaluation_id] || {},
+      retrievalChunks: extractRetrievalChunks(entry.outputs, entry.targets, perRetrievalChunkAssessments),
+    };
+  });
+}

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/utils/EvaluationLogging.ts
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/utils/EvaluationLogging.ts
@@ -1,0 +1,31 @@
+/** Constants for logging. */
+
+// Pages
+export const RUN_EVALUATION_RESULTS_TAB_SINGLE_RUN = 'mlflow.evaluations_review.run_evaluation_results_single_run_page';
+export const RUN_EVALUATION_RESULTS_TAB_COMPARE_RUNS =
+  'mlflow.evaluations_review.run_evaluation_results_compare_runs_page';
+
+// When a user opens a single item in the evaluations table, the page ID for the evaluations review page modal.
+export const RUN_EVALUATIONS_SINGLE_ITEM_REVIEW_UI_PAGE_ID = 'mlflow.evaluations_review.review_ui';
+
+// Views
+// Counts the number of times the expanded assessment details is clicked, showing how many times users view rationales.
+export const EXPANDED_ASSESSMENT_DETAILS_VIEW = {
+  // Important note: Overall is always expanded.
+  overall: 'mlflow.evaluations_review.expanded_overall_assessment_details_view',
+  response: 'mlflow.evaluations_review.expanded_response_assessment_details_view',
+  retrieval: 'mlflow.evaluations_review.expanded_retrieval_assessment_details_view',
+} satisfies Record<string, string>;
+
+export const ASSESSMENT_RATIONAL_HOVER_DETAILS_VIEW =
+  'mlflow.evaluations_review.assessment_rationale_hover_details_view';
+
+// Buttons
+// The component ID for the compare-to-run dropdown in the evaluations table.
+export const COMPARE_TO_RUN_DROPDOWN_COMPONENT_ID = 'mlflow.evaluations_review.table_ui.compare_to_run_combobox';
+
+// The component ID for the filter dropdown in the evaluations table.
+export const FILTER_DROPDOWN_COMPONENT_ID = 'mlflow.evaluations_review.table_ui.filter_form';
+
+// The component ID for the column selector dropdown in the evaluations table.
+export const COLUMN_SELECTOR_DROPDOWN_COMPONENT_ID = 'mlflow.evaluations_review.table_ui.column_filter_combobox';

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/utils/EvaluationsFilterUtils.ts
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/utils/EvaluationsFilterUtils.ts
@@ -1,0 +1,142 @@
+import { isNil } from 'lodash';
+
+import { ERROR_KEY } from './AggregationUtils';
+import {
+  getEvaluationResultAssessmentValue,
+  KnownEvaluationResultAssessmentName,
+} from '../components/GenAiEvaluationTracesReview.utils';
+import type { AssessmentFilter, AssessmentValueType, EvalTraceComparisonEntry } from '../types';
+import { FilterOperator } from '../types';
+
+/**
+ * Compares an assessment value against a filter value using the specified operator.
+ * For numeric comparison operators (>, <, >=, <=), both values must be numbers.
+ * For equality operators (=, !=), uses strict equality.
+ */
+function compareValues(
+  assessmentValue: AssessmentValueType,
+  filterValue: AssessmentValueType,
+  operator?: FilterOperator,
+): boolean {
+  const stringAssessmentValue = String(assessmentValue);
+  const stringFilterValue = String(filterValue);
+  // Default to equality if no operator specified
+  if (!operator || operator === FilterOperator.EQUALS) {
+    return stringAssessmentValue === stringFilterValue;
+  }
+
+  if (operator === FilterOperator.NOT_EQUALS) {
+    return stringAssessmentValue !== stringFilterValue;
+  }
+
+  // For numeric comparison operators, both values must be numbers
+  const numAssessmentValue = Number(assessmentValue);
+  const numFilterValue = Number(filterValue);
+  if (isNaN(numAssessmentValue) || isNaN(numFilterValue)) {
+    return false;
+  }
+
+  switch (operator) {
+    case FilterOperator.GREATER_THAN:
+      return numAssessmentValue > numFilterValue;
+    case FilterOperator.LESS_THAN:
+      return numAssessmentValue < numFilterValue;
+    case FilterOperator.GREATER_THAN_OR_EQUALS:
+      return numAssessmentValue >= numFilterValue;
+    case FilterOperator.LESS_THAN_OR_EQUALS:
+      return numAssessmentValue <= numFilterValue;
+    default:
+      return stringAssessmentValue === stringFilterValue;
+  }
+}
+
+function filterEval(
+  comparisonEntry: EvalTraceComparisonEntry,
+  filters: AssessmentFilter[],
+  currentRunDisplayName?: string,
+  otherRunDisplayName?: string,
+): boolean {
+  // Currently only filters on the current run value.
+  const currentRunValue = comparisonEntry?.currentRunValue;
+  const otherRunValue = comparisonEntry?.otherRunValue;
+
+  let includeEval = true;
+
+  for (const filter of filters) {
+    const assessmentName = filter.assessmentName;
+    const filterValue = filter.filterValue;
+    const run = filter.run;
+    const runValue =
+      run === currentRunDisplayName ? currentRunValue : run === otherRunDisplayName ? otherRunValue : undefined;
+    // TODO(nsthorat): Fix this logic, not clear that this is the right way to filter.
+    if (runValue === undefined) {
+      continue;
+    }
+
+    const assessments =
+      assessmentName === KnownEvaluationResultAssessmentName.OVERALL_ASSESSMENT
+        ? (runValue.overallAssessments ?? [])
+        : (runValue.responseAssessmentsByName[assessmentName] ?? []);
+
+    if (filter.filterType === 'rca') {
+      const currentIsAssessmentRootCause =
+        runValue?.overallAssessments[0]?.rootCauseAssessment?.assessmentName === assessmentName;
+      includeEval = includeEval && currentIsAssessmentRootCause;
+    } else {
+      // Filtering for undefined means we want traces with NO assessments (= undefined)
+      // or WITH assessments (!= undefined) for this name
+      // Filtering for ERROR_KEY means we want traces with assessments that have an errorMessage
+      const matchesFilter =
+        filterValue === undefined
+          ? filter.filterOperator === FilterOperator.NOT_EQUALS
+            ? assessments.length > 0
+            : assessments.length === 0
+          : filterValue === ERROR_KEY
+            ? assessments.some((assessment) => Boolean(assessment.errorMessage))
+            : assessments.some((assessment) =>
+                compareValues(getEvaluationResultAssessmentValue(assessment), filterValue, filter.filterOperator),
+              );
+      includeEval = includeEval && matchesFilter;
+    }
+  }
+  return includeEval;
+}
+
+export function filterEvaluationResults(
+  evaluationResults: EvalTraceComparisonEntry[],
+  assessmentFilters: AssessmentFilter[],
+  searchQuery?: string,
+  currentRunDisplayName?: string,
+  otherRunDisplayName?: string,
+): EvalTraceComparisonEntry[] {
+  // Filter results by the assessment filters.
+  return (
+    evaluationResults
+      .filter((entry) => {
+        return filterEval(entry, assessmentFilters, currentRunDisplayName, otherRunDisplayName);
+      })
+      // Filter results by the text search box.
+      .filter((entry) => {
+        if (isNil(searchQuery) || searchQuery === '') {
+          return true;
+        }
+        const searchQueryLower = searchQuery.toLowerCase();
+        const currentInputsContainSearchQuery = JSON.stringify(entry.currentRunValue?.inputs)
+          .toLowerCase()
+          .includes(searchQueryLower);
+        const inputsIdEqualsToSearchQuery = entry.currentRunValue?.inputsId.toLowerCase() === searchQueryLower;
+        // Also match against trace IDs: both the short backend trace_id (evaluationId)
+        // and the full V4 trace ID (fullTraceId) like trace:/catalog.schema/abc123...
+        const evaluationIdContainsSearchQuery =
+          entry.currentRunValue?.evaluationId?.toLowerCase().includes(searchQueryLower) ?? false;
+        const fullTraceIdContainsSearchQuery =
+          entry.currentRunValue?.fullTraceId?.toLowerCase().includes(searchQueryLower) ?? false;
+        return (
+          currentInputsContainSearchQuery ||
+          inputsIdEqualsToSearchQuery ||
+          evaluationIdContainsSearchQuery ||
+          fullTraceIdContainsSearchQuery
+        );
+      })
+  );
+}

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/utils/FeatureUtils.ts
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/utils/FeatureUtils.ts
@@ -1,0 +1,54 @@
+export const shouldEnableRunEvaluationReviewUIWriteFeatures = () => {
+  return false;
+};
+
+export const shouldEnableTagGrouping = () => {
+  return true;
+};
+
+export const shouldEnableUnifiedEvalTab = () => {
+  return false;
+};
+
+/**
+ * Page size for MLflow traces 3.0 search api used in eval tab
+ */
+export const getMlflowTracesSearchPageSize = () => {
+  // OSS backend limit is 500
+  return 500;
+};
+
+/**
+ * Total number of traces that will be fetched via mlflow traces 3.0 search api in eval tab
+ */
+export const getEvalTabTotalTracesLimit = () => {
+  return 1000;
+};
+
+/**
+ * Determines if traces V4 API should be used to fetch traces
+ */
+export const shouldUseTracesV4API = () => {
+  return false;
+};
+
+/**
+ * Determines if the long-running traces search API should be used.
+ * This is only applicable when V4 APIs are enabled.
+ * When enabled, trace searches will use an async polling pattern instead of synchronous requests.
+ */
+export const shouldUseLongRunningTracesAPI = () => {
+  return false;
+};
+
+export const shouldEnableSessionGrouping = () => {
+  return true;
+};
+
+/**
+ * Determines if the traces table should use infinite paginated queries
+ * instead of eagerly fetching all pages in a single query.
+ */
+export const shouldUseInfinitePaginatedTraces = () => {
+  return true;
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/utils/FetchUtils.ts
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/utils/FetchUtils.ts
@@ -1,0 +1,134 @@
+import cookie from 'cookie';
+// TODO: resolve the @mlflow/mlflow import upstream
+import { getWorkspacesEnabledSync } from '@mlflow/mlflow/src/experiment-tracking/hooks/useServerInfo';
+
+import { matchPredefinedError } from '../../errors/PredefinedErrors';
+// eslint-disable-next-line no-restricted-globals
+export const fetchFn = fetch; // use global fetch for oss
+
+const WORKSPACE_STORAGE_KEY = 'mlflow.activeWorkspace';
+
+/**
+ * Get the active workspace from localStorage, but only when the server has workspaces enabled.
+ * This prevents stale localStorage values from causing errors on servers without workspaces.
+ */
+const getActiveWorkspace = (): string | null => {
+  if (!getWorkspacesEnabledSync()) {
+    return null;
+  }
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    // eslint-disable-next-line @databricks/no-direct-storage -- OSS only use-case
+    return window.localStorage.getItem(WORKSPACE_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Parse cookies to extract request headers.
+ * Minimal implementation for shared library.
+ */
+export const getDefaultHeadersFromCookies = (cookieStr: string) => {
+  const headerCookiePrefix = 'mlflow-request-header-';
+  const parsedCookie = cookie.parse(cookieStr);
+  if (!parsedCookie || Object.keys(parsedCookie).length === 0) {
+    return {};
+  }
+  return Object.keys(parsedCookie)
+    .filter((cookieName) => cookieName.startsWith(headerCookiePrefix))
+    .reduce(
+      (acc, cookieName) => ({
+        ...acc,
+        [cookieName.substring(headerCookiePrefix.length)]: parsedCookie[cookieName],
+      }),
+      {},
+    );
+};
+
+/**
+ * Get default headers including workspace header if active.
+ * Minimal implementation for shared library.
+ */
+export const getDefaultHeaders = (cookieStr: string) => {
+  const cookieHeaders = getDefaultHeadersFromCookies(cookieStr);
+  const workspace = getActiveWorkspace();
+
+  return {
+    ...cookieHeaders,
+    ...(workspace ? { 'X-MLFLOW-WORKSPACE': workspace } : {}),
+  };
+};
+
+/**
+ * Convert relative URL to absolute if needed.
+ * Minimal implementation for shared library.
+ */
+export const getAjaxUrl = (relativeUrl: string) => {
+  if (
+    process.env['MLFLOW_USE_ABSOLUTE_AJAX_URLS'] === 'true' &&
+    typeof relativeUrl === 'string' &&
+    !relativeUrl.startsWith('/')
+  ) {
+    return '/' + relativeUrl;
+  }
+  return relativeUrl;
+};
+
+/**
+ * Helper method to make a request to the backend with workspace support.
+ * Minimal implementation for shared library.
+ */
+export const fetchAPI = async (url: string, options: Omit<RequestInit, 'body'> & { body?: any } = {}) => {
+  const { method, headers, body, ...restOptions } = options;
+
+  let cookieString = '';
+  if (typeof document !== 'undefined' && typeof document.cookie === 'string') {
+    cookieString = document.cookie || '';
+  }
+
+  const serializeBody = (payload: any) => {
+    if (payload === undefined) {
+      return undefined;
+    }
+    return typeof payload === 'string' || payload instanceof FormData || payload instanceof Blob
+      ? payload
+      : JSON.stringify(payload);
+  };
+
+  const fetchOptions: RequestInit = {
+    ...restOptions,
+    method: method || 'GET',
+    headers: {
+      ...getDefaultHeaders(cookieString),
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...headers,
+    },
+  };
+
+  if (body) {
+    fetchOptions.body = serializeBody(body);
+  }
+
+  const response = await fetchFn(url, fetchOptions);
+  if (!response.ok) {
+    const predefinedError = matchPredefinedError(response);
+    if (predefinedError) {
+      try {
+        // Attempt to use message from the response
+        const message = (await response.json()).message;
+        predefinedError.message = message ?? predefinedError.message;
+      } catch {
+        // If the message can't be parsed, use default one
+      }
+      throw predefinedError;
+    }
+  }
+  return response.json();
+};
+
+export const makeRequest = async <T>(path: string, method: 'POST' | 'GET', body?: T, signal?: AbortSignal) => {
+  return fetchAPI(path, { method, body, signal });
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/utils/MarkdownUtils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/utils/MarkdownUtils.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import sanitize from '../../html-content/sanitize';
+
+// Default to DOMPurify sanitization so that components rendered without a
+// MarkdownConverterProvider still produce safe HTML (defense-in-depth for XSS).
+const MarkdownConverterProviderContext = React.createContext({
+  makeHTML: (markdown?: string) => (markdown ? sanitize(markdown) : markdown),
+});
+
+export const MarkdownConverterProvider = ({
+  children,
+  makeHtml,
+}: {
+  children: React.ReactNode;
+  makeHtml: (markdown?: string) => string;
+}) => {
+  return (
+    <MarkdownConverterProviderContext.Provider value={{ makeHTML: makeHtml }}>
+      {children}
+    </MarkdownConverterProviderContext.Provider>
+  );
+};
+
+export const useMarkdownConverter = () => React.useContext(MarkdownConverterProviderContext);

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/utils/MlflowUtils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/utils/MlflowUtils.tsx
@@ -1,0 +1,537 @@
+/**
+ * This file is a subset of functions from mlflow/server/js/src/common/Utils.tsx
+ */
+import moment from 'moment';
+
+import type { IntlShape } from '@databricks/i18n';
+import type { ModelTraceInfoV3 } from '../../model-trace-explorer/ModelTrace.types';
+
+// eslint-disable-next-line @typescript-eslint/no-extraneous-class -- TODO(FEINF-4274)
+class MlflowUtils {
+  static runNameTag = 'mlflow.runName';
+  static sourceNameTag = 'mlflow.source.name';
+  static sourceTypeTag = 'mlflow.source.type';
+  static entryPointTag = 'mlflow.project.entryPoint';
+
+  static getEntryPointName(runTags: any) {
+    const entryPointTag = runTags[MlflowUtils.entryPointTag];
+    if (entryPointTag) {
+      return entryPointTag.value;
+    }
+    return '';
+  }
+
+  static getSourceType(runTags: any) {
+    const sourceTypeTag = runTags[MlflowUtils.sourceTypeTag];
+    if (sourceTypeTag) {
+      return sourceTypeTag.value;
+    }
+    return '';
+  }
+
+  static dropExtension(path: any) {
+    return path.replace(/(.*[^/])\.[^/.]+$/, '$1');
+  }
+
+  static baseName(path: any) {
+    const pieces = path.split('/');
+    return pieces[pieces.length - 1];
+  }
+
+  /**
+   * Renders the source name and entry point into a string. Used for sorting.
+   * @param run MlflowMessages.RunInfo
+   */
+  static formatSource(tags: any) {
+    const sourceName = MlflowUtils.getSourceName(tags);
+    const sourceType = MlflowUtils.getSourceType(tags);
+    const entryPointName = MlflowUtils.getEntryPointName(tags);
+    if (sourceType === 'PROJECT') {
+      let res = MlflowUtils.dropExtension(MlflowUtils.baseName(sourceName));
+      if (entryPointName && entryPointName !== 'main') {
+        res += ':' + entryPointName;
+      }
+      return res;
+    } else if (sourceType === 'JOB') {
+      const jobIdTag = 'mlflow.databricks.jobID';
+      const jobRunIdTag = 'mlflow.databricks.jobRunID';
+      const jobId = tags && tags[jobIdTag] && tags[jobIdTag].value;
+      const jobRunId = tags && tags[jobRunIdTag] && tags[jobRunIdTag].value;
+      if (jobId && jobRunId) {
+        return MlflowUtils.getDefaultJobRunName(jobId, jobRunId);
+      }
+      return sourceName;
+    } else {
+      return MlflowUtils.baseName(sourceName);
+    }
+  }
+
+  static getDefaultJobRunName(jobId: any, runId: any, workspaceId = null) {
+    if (!jobId) {
+      return '-';
+    }
+    let name = `job ${jobId}`;
+    if (runId) {
+      name = `run ${runId} of ` + name;
+    }
+    if (workspaceId) {
+      name = `workspace ${workspaceId}: ` + name;
+    }
+    return name;
+  }
+
+  static getSourceName(runTags: any) {
+    const sourceNameTag = runTags[MlflowUtils.sourceNameTag];
+    if (sourceNameTag) {
+      return sourceNameTag.value;
+    }
+    return '';
+  }
+
+  static getGitHubRegex() {
+    return /[@/]github.com[:/]([^/.]+)\/([^/#]+)#?(.*)/;
+  }
+
+  static getGitLabRegex() {
+    return /[@/]gitlab.com[:/]([^/.]+)\/([^/#]+)#?(.*)/;
+  }
+
+  static getBitbucketRegex() {
+    return /[@/]bitbucket.org[:/]([^/.]+)\/([^/#]+)#?(.*)/;
+  }
+
+  static getExperimentChatSessionPageRoute(experimentId: string, sessionId: string) {
+    return `/experiments/${experimentId}/chat-sessions/${sessionId}`;
+  }
+
+  static getRunPageRoute(experimentId: string, runUuid: string) {
+    return `/experiments/${experimentId}/runs/${runUuid}`;
+  }
+
+  static getLoggedModelPageRoute(experimentId: string, loggedModelId: string) {
+    return `/experiments/${experimentId}/models/${loggedModelId}`;
+  }
+
+  /**
+   * Regular expression for URLs containing the string 'git'.
+   * It can be a custom git domain (e.g. https://git.custom.in/repo/dir#file/dir).
+   * Excluding the first overall match, there are three groups:
+   *    git url, repo directory, and file directory.
+   * (e.g. group1: https://custom.git.domain, group2: repo/directory, group3: project/directory)
+   */
+  static getGitRegex() {
+    return /(.*?[@/][^?]*git.*?)[:/]([^#]+)(?:#(.*))?/;
+  }
+
+  static getGitRepoUrl(sourceName: any, branchName = 'master') {
+    const gitHubMatch = sourceName.match(MlflowUtils.getGitHubRegex());
+    const gitLabMatch = sourceName.match(MlflowUtils.getGitLabRegex());
+    const bitbucketMatch = sourceName.match(MlflowUtils.getBitbucketRegex());
+    const gitMatch = sourceName.match(MlflowUtils.getGitRegex());
+    let url = null;
+    if (gitHubMatch) {
+      url = `https://github.com/${gitHubMatch[1]}/${gitHubMatch[2].replace(/.git/, '')}`;
+      if (gitHubMatch[3]) {
+        url += `/tree/${branchName}/${gitHubMatch[3]}`;
+      }
+    } else if (gitLabMatch) {
+      url = `https://gitlab.com/${gitLabMatch[1]}/${gitLabMatch[2].replace(/.git/, '')}`;
+      if (gitLabMatch[3]) {
+        url += `/-/tree/${branchName}/${gitLabMatch[3]}`;
+      }
+    } else if (bitbucketMatch) {
+      url = `https://bitbucket.org/${bitbucketMatch[1]}/${bitbucketMatch[2].replace(/.git/, '')}`;
+      if (bitbucketMatch[3]) {
+        url += `/src/${branchName}/${bitbucketMatch[3]}`;
+      }
+    } else if (gitMatch) {
+      const [, baseUrl, repoDir, fileDir] = gitMatch;
+      url = baseUrl.replace(/git@/, 'https://') + '/' + repoDir.replace(/.git/, '');
+      if (fileDir) {
+        url += `/tree/${branchName}/${fileDir}`;
+      }
+    }
+    return url;
+  }
+
+  static getNotebookRevisionId(tags: any) {
+    const revisionIdTag = 'mlflow.databricks.notebookRevisionID';
+    return tags && tags[revisionIdTag] && tags[revisionIdTag].value;
+  }
+
+  static getNotebookId(tags: any) {
+    const notebookIdTag = 'mlflow.databricks.notebookID';
+    return tags && tags[notebookIdTag] && tags[notebookIdTag].value;
+  }
+
+  /**
+   * Check if the given workspaceId matches the current workspaceId.
+   * @param workspaceId
+   * @returns {boolean}
+   */
+  static isCurrentWorkspace(workspaceId: any) {
+    return true;
+  }
+
+  static getDefaultNotebookRevisionName(notebookId: any, revisionId: any, workspaceId = null) {
+    if (!notebookId) {
+      return '-';
+    }
+    let name = `notebook ${notebookId}`;
+    if (revisionId) {
+      name = `revision ${revisionId} of ` + name;
+    }
+    if (workspaceId) {
+      name = `workspace ${workspaceId}: ` + name;
+    }
+    return name;
+  }
+
+  /**
+   * Makes sure that the URL begins with correct scheme according
+   * to RFC3986 [https://datatracker.ietf.org/doc/html/rfc3986#section-3.1]
+   * It does not support slash-less schemes (e.g. news:abc, urn:anc).
+   * @param url URL string like "my-mlflow-server.com/#/experiments/9" or
+   *        "https://my-mlflow-server.com/#/experiments/9"
+   * @param defaultScheme scheme to add if missing in the provided URL, defaults to "https"
+   * @returns {string} the URL string with ensured default scheme
+   */
+  static ensureUrlScheme(url: any, defaultScheme = 'https') {
+    // Falsy values should yield itself
+    if (!url) return url;
+
+    // Scheme-less URL with colon and dashes
+    if (url.match(/^:\/\//i)) {
+      return `${defaultScheme}${url}`;
+    }
+
+    // URL without scheme, colon nor dashes
+    if (!url.match(/^[a-z1-9+-.]+:\/\//i)) {
+      return `${defaultScheme}://${url}`;
+    }
+
+    // Pass-through for "correct" entries
+    return url;
+  }
+
+  /**
+   * Returns a copy of the provided URL with its query parameters set to `queryParams`.
+   * @param url URL string like "http://my-mlflow-server.com/#/experiments/9.
+   * @param queryParams Optional query parameter string like "?param=12345". Query params provided
+   *        via this string will override existing query param values in `url`
+   */
+  static setQueryParams(url: any, queryParams: any) {
+    // Using new URL() is the preferred way of constructing the URL object,
+    // however according to [https://url.spec.whatwg.org/#constructors] it requires
+    // providing the protocol. We're gracefully ensuring that the scheme exists here.
+    const urlObj = new URL(MlflowUtils.ensureUrlScheme(url));
+    urlObj.search = queryParams || '';
+    return urlObj.toString();
+  }
+
+  /**
+   * Returns the URL for the notebook source.
+   */
+  static getNotebookSourceUrl(queryParams: any, notebookId: any, revisionId: any, runUuid: any, workspaceUrl = null) {
+    let url = MlflowUtils.setQueryParams(workspaceUrl || window.location.origin, queryParams);
+    url += `#notebook/${notebookId}`;
+    if (revisionId) {
+      url += `/revision/${revisionId}`;
+      if (runUuid) {
+        url += `/mlflow/run/${runUuid}`;
+      }
+    }
+    return url;
+  }
+
+  /**
+   * Renders the notebook source name and entry point into an HTML element. Used for display.
+   */
+  static renderNotebookSource(
+    queryParams: any,
+    notebookId: any,
+    revisionId: any,
+    runUuid: any,
+    sourceName: any,
+    workspaceUrl = null,
+    nameOverride: string | null = null,
+  ) {
+    // sourceName may not be present when rendering feature table notebook consumers from remote
+    // workspaces or when notebook fetcher failed to fetch the sourceName. Always provide a default
+    // notebook name in such case.
+    const baseName = sourceName
+      ? MlflowUtils.baseName(sourceName)
+      : MlflowUtils.getDefaultNotebookRevisionName(notebookId, revisionId);
+    const name = nameOverride || baseName;
+
+    if (notebookId) {
+      const url = MlflowUtils.getNotebookSourceUrl(queryParams, notebookId, revisionId, runUuid, workspaceUrl);
+      return (
+        <a
+          title={sourceName || MlflowUtils.getDefaultNotebookRevisionName(notebookId, revisionId)}
+          href={url}
+          target="_top"
+          onClick={(e) => {
+            e.stopPropagation();
+          }}
+        >
+          {name}
+        </a>
+      );
+    } else {
+      return name;
+    }
+  }
+
+  /**
+   * Set query params and returns the updated query params.
+   * @returns {string} updated query params
+   */
+  static addQueryParams(currentQueryParams: any, newQueryParams: any) {
+    if (!newQueryParams || Object.keys(newQueryParams).length === 0) {
+      return currentQueryParams;
+    }
+    const urlSearchParams = new URLSearchParams(currentQueryParams);
+    Object.entries(newQueryParams).forEach(
+      // @ts-expect-error TS(2345): Argument of type 'unknown' is not assignable to pa... Remove this comment to see the full error message
+      ([key, value]) => Boolean(key) && Boolean(value) && urlSearchParams.set(key, value),
+    );
+    const queryParams = urlSearchParams.toString();
+    if (queryParams !== '' && !queryParams.includes('?')) {
+      return `?${queryParams}`;
+    }
+    return queryParams;
+  }
+
+  /**
+   * Returns the URL for the job source.
+   */
+  static getJobSourceUrl(queryParams: any, jobId: any, jobRunId: any, workspaceUrl = null) {
+    const baseUrl = workspaceUrl || window.location.origin;
+    // eslint-disable-next-line prefer-const -- reassigned in EDGE block
+    let jobPath = jobRunId ? `/jobs/${jobId}/runs/${jobRunId}` : `/jobs/${jobId}`;
+    return MlflowUtils.setQueryParams(baseUrl + jobPath, queryParams);
+  }
+
+  /**
+   * Renders the job source name and entry point into an HTML element. Used for display.
+   */
+  static renderJobSource(
+    queryParams: any,
+    jobId: any,
+    jobRunId: any,
+    jobName: any,
+    workspaceUrl = null,
+    nameOverride: string | null = null,
+  ) {
+    // jobName may not be present when rendering feature table job consumers from remote
+    // workspaces or when getJob API failed to fetch the jobName. Always provide a default
+    // job name in such case.
+    const reformatJobName = jobName || MlflowUtils.getDefaultJobRunName(jobId, jobRunId);
+    const name = nameOverride || reformatJobName;
+
+    if (jobId) {
+      const url = MlflowUtils.getJobSourceUrl(queryParams, jobId, jobRunId, workspaceUrl);
+      return (
+        <a
+          title={reformatJobName}
+          href={url}
+          target="_top"
+          onClick={(e) => {
+            e.stopPropagation();
+          }}
+        >
+          {name}
+        </a>
+      );
+    } else {
+      return name;
+    }
+  }
+
+  /**
+   * Renders the source name and entry point into an HTML element. Used for display.
+   * @param tags Object containing tag key value pairs.
+   * @param queryParams Query params to add to certain source type links.
+   * @param runUuid ID of the MLflow run to add to certain source (revision) links.
+   */
+  static renderSource(tags: any, queryParams: any, runUuid: any, branchName = 'master') {
+    const sourceName = MlflowUtils.getSourceName(tags);
+    let res = MlflowUtils.formatSource(tags);
+    const gitRepoUrlOrNull = MlflowUtils.getGitRepoUrl(sourceName, branchName);
+    if (gitRepoUrlOrNull) {
+      res = (
+        <a
+          target="_top"
+          href={gitRepoUrlOrNull}
+          onClick={(e) => {
+            e.stopPropagation();
+          }}
+        >
+          {res}
+        </a>
+      );
+    }
+    const sourceType = MlflowUtils.getSourceType(tags);
+    if (sourceType === 'NOTEBOOK') {
+      const revisionId = MlflowUtils.getNotebookRevisionId(tags);
+      const notebookId = MlflowUtils.getNotebookId(tags);
+      const workspaceIdTag = 'mlflow.databricks.workspaceID';
+      const workspaceId = tags && tags[workspaceIdTag] && tags[workspaceIdTag].value;
+      if (MlflowUtils.isCurrentWorkspace(workspaceId)) {
+        return MlflowUtils.renderNotebookSource(queryParams, notebookId, revisionId, runUuid, sourceName, null);
+      } else {
+        const workspaceUrlTag = 'mlflow.databricks.workspaceURL';
+        const workspaceUrl = tags && tags[workspaceUrlTag] && tags[workspaceUrlTag].value;
+        const notebookQueryParams = MlflowUtils.addQueryParams(queryParams, { o: workspaceId });
+        return MlflowUtils.renderNotebookSource(
+          notebookQueryParams,
+          notebookId,
+          revisionId,
+          runUuid,
+          sourceName,
+          workspaceUrl,
+        );
+      }
+    }
+    if (sourceType === 'JOB') {
+      const jobIdTag = 'mlflow.databricks.jobID';
+      const jobRunIdTag = 'mlflow.databricks.jobRunID';
+      const jobId = tags && tags[jobIdTag] && tags[jobIdTag].value;
+      const jobRunId = tags && tags[jobRunIdTag] && tags[jobRunIdTag].value;
+      const workspaceIdTag = 'mlflow.databricks.workspaceID';
+      const workspaceId = tags && tags[workspaceIdTag] && tags[workspaceIdTag].value;
+      if (MlflowUtils.isCurrentWorkspace(workspaceId)) {
+        return MlflowUtils.renderJobSource(queryParams, jobId, jobRunId, res, null);
+      } else {
+        const workspaceUrlTag = 'mlflow.databricks.workspaceURL';
+        const workspaceUrl = tags && tags[workspaceUrlTag] && tags[workspaceUrlTag].value;
+        const jobQueryParams = MlflowUtils.addQueryParams(queryParams, { o: workspaceId });
+        return MlflowUtils.renderJobSource(jobQueryParams, jobId, jobRunId, res, workspaceUrl);
+      }
+    }
+    return res;
+  }
+
+  static renderSourceFromMetadata(traceInfoV3: ModelTraceInfoV3) {
+    const sourceName = traceInfoV3.trace_metadata?.[MlflowUtils.sourceNameTag];
+    const sourceType = traceInfoV3.trace_metadata?.[MlflowUtils.sourceTypeTag];
+    let res = sourceName ? MlflowUtils.baseName(sourceName) : '';
+
+    // Handle git repository links using explicit git metadata
+    const gitRepoUrl = traceInfoV3.trace_metadata?.['mlflow.source.git.repoURL'];
+    const gitBranch = traceInfoV3.trace_metadata?.['mlflow.source.git.branch'];
+    const gitCommit = traceInfoV3.trace_metadata?.['mlflow.source.git.commit'];
+
+    if (gitRepoUrl) {
+      // Convert SSH URL to HTTPS if needed
+      const httpsUrl = gitRepoUrl
+        .replace('git@github.com:', 'https://github.com/')
+        .replace('git@gitlab.com:', 'https://gitlab.com/')
+        .replace('git@bitbucket.org:', 'https://bitbucket.org/')
+        .replace('.git', '');
+
+      // Use commit hash if available, otherwise use branch
+      const ref = gitCommit || gitBranch || 'master';
+      const filePath = sourceName ? `/${sourceName}` : '';
+
+      // Construct URL based on the git host
+      let url = httpsUrl;
+      if (httpsUrl.includes('github.com')) {
+        url = `${httpsUrl}/tree/${ref}${filePath}`;
+      } else if (httpsUrl.includes('gitlab.com')) {
+        url = `${httpsUrl}/-/tree/${ref}${filePath}`;
+      } else if (httpsUrl.includes('bitbucket.org')) {
+        url = `${httpsUrl}/src/${ref}${filePath}`;
+      } else {
+        // For other git hosts, just append the ref and file path
+        url = `${httpsUrl}/tree/${ref}${filePath}`;
+      }
+
+      res = (
+        <a
+          target="_blank"
+          rel="noopener noreferrer"
+          href={url}
+          onClick={(e) => {
+            e.stopPropagation();
+          }}
+        >
+          {res}
+        </a>
+      );
+    }
+
+    if (sourceType === 'NOTEBOOK') {
+      const revisionId = traceInfoV3.trace_metadata?.['mlflow.databricks.notebookRevisionID'];
+      const notebookId = traceInfoV3.trace_metadata?.['mlflow.databricks.notebookID'];
+      const workspaceId = traceInfoV3.trace_metadata?.['mlflow.databricks.workspaceID'];
+
+      if (MlflowUtils.isCurrentWorkspace(workspaceId)) {
+        return MlflowUtils.renderNotebookSource(null, notebookId, revisionId, null, sourceName, null);
+      } else {
+        const workspaceUrlTag = 'mlflow.databricks.workspaceURL';
+        const workspaceUrl: any = traceInfoV3.trace_metadata?.[workspaceUrlTag] || undefined;
+        const notebookQueryParams = MlflowUtils.addQueryParams(null, { o: workspaceId });
+        return MlflowUtils.renderNotebookSource(
+          notebookQueryParams,
+          notebookId,
+          revisionId,
+          null,
+          sourceName,
+          workspaceUrl,
+        );
+      }
+    }
+
+    if (sourceType === 'JOB') {
+      const jobId = traceInfoV3.trace_metadata?.['mlflow.databricks.jobID'];
+      const jobRunId = traceInfoV3.trace_metadata?.['mlflow.databricks.jobRunID'];
+      const workspaceId = traceInfoV3.trace_metadata?.['mlflow.databricks.workspaceID'];
+
+      if (MlflowUtils.isCurrentWorkspace(workspaceId)) {
+        return MlflowUtils.renderJobSource(null, jobId, jobRunId, res, null);
+      } else {
+        const workspaceUrlTag = 'mlflow.databricks.workspaceURL';
+        const workspaceUrl: any = traceInfoV3.trace_metadata?.[workspaceUrlTag] || undefined;
+        const jobQueryParams = MlflowUtils.addQueryParams(null, { o: workspaceId });
+        return MlflowUtils.renderJobSource(jobQueryParams, jobId, jobRunId, res, workspaceUrl);
+      }
+    }
+
+    return res;
+  }
+
+  static formatDuration(duration: any) {
+    if (duration < 500) {
+      return duration + 'ms';
+    } else if (duration < 1000 * 60) {
+      return (duration / 1000).toFixed(1) + 's';
+    } else if (duration < 1000 * 60 * 60) {
+      return (duration / 1000 / 60).toFixed(1) + 'min';
+    } else if (duration < 1000 * 60 * 60 * 24) {
+      return (duration / 1000 / 60 / 60).toFixed(1) + 'h';
+    } else {
+      return (duration / 1000 / 60 / 60 / 24).toFixed(1) + 'd';
+    }
+  }
+
+  static formatTimestamp(timestamp: any, intl?: IntlShape) {
+    const d = new Date(0);
+    d.setUTCMilliseconds(timestamp);
+
+    if (intl) {
+      return intl.formatDate(d, {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+      });
+    }
+    return moment(d).format('YYYY-MM-DD HH:mm:ss');
+  }
+}
+
+export default MlflowUtils;

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/utils/RoutingTestUtils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/utils/RoutingTestUtils.tsx
@@ -1,0 +1,54 @@
+import type { ComponentProps } from 'react';
+import React from 'react';
+
+import { MemoryRouter, Route, Routes } from './RoutingUtils';
+
+/**
+ * A dummy router to be used in jest tests. Usage:
+ *
+ * @example
+ * ```ts
+ *  import { testRoute, TestRouter } from '../RoutingTestUtils';
+ *  import { setupTestRouter, waitForRoutesToBeRendered } from '../RoutingTestUtils';
+ *
+ *  describe('ComponentUnderTest', () => {
+ *    it('renders', async () => {
+ *      render(<Router history={history} routes={[testRoute(<ComponentUnderTest props={...}/>)]}/>);
+ *
+ *      expect(...);
+ *    });
+ *  });
+ * ```
+ *
+ */
+export const TestRouter = ({ routes, history, initialEntries }: TestRouterProps) => {
+  return (
+    <MemoryRouter initialEntries={initialEntries ?? ['/']}>
+      <Routes>
+        {routes.map(({ element, path = '*', pageId }: any) => (
+          <Route element={element} key={pageId || path} path={path} />
+        ))}
+      </Routes>
+    </MemoryRouter>
+  );
+};
+
+type TestRouteReturnValue = {
+  element: React.ReactElement;
+  path?: string;
+  pageId?: string;
+};
+interface TestRouterProps {
+  routes: TestRouteReturnValue[];
+  history?: any;
+  initialEntries?: string[];
+}
+
+export const testRoute = (element: React.ReactNode, path = '*', pageId = ''): TestRouteReturnValue => {
+  return { element, path, pageId } as any;
+};
+
+export const setupTestRouter = () => ({ history: {} });
+export const waitForRoutesToBeRendered = async () => {
+  return Promise.resolve();
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/utils/RoutingUtils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/utils/RoutingUtils.tsx
@@ -1,0 +1,326 @@
+/**
+ * This file re-exports the appropriate package for routing based on the environment.
+ *
+ * Duplicate of mlflow/server/js/src/common/utils/RoutingUtils.tsx, because unfortunately
+ * this package is located in web-shared and we can't directly access it from here.
+ */
+/* eslint-disable no-restricted-imports */
+import type { ComponentProps } from 'react';
+import React, { useCallback, useMemo } from 'react';
+import {
+  DesignSystemEventProviderAnalyticsEventTypes,
+  DesignSystemEventProviderComponentTypes,
+  useDesignSystemEventComponentCallbacks,
+} from '@databricks/design-system';
+/**
+ * Import React Router V6 parts
+ */
+import {
+  BrowserRouter,
+  MemoryRouter,
+  HashRouter,
+  matchPath,
+  generatePath,
+  Navigate,
+  Route,
+  Outlet as OutletDirect,
+  Link as LinkDirect,
+  useNavigate as useNavigateDirect,
+  useLocation as useLocationDirect,
+  useParams as useParamsDirect,
+  useSearchParams as useSearchParamsDirect,
+  createHashRouter,
+  RouterProvider,
+  Routes,
+  type To,
+  type NavigateOptions,
+  type Location,
+  type NavigateFunction,
+  type Params,
+} from 'react-router-dom';
+
+/**
+ * Workspace utilities — minimal self-contained copies for web-shared.
+ * These mirror the functions in mlflow/server/js/src/workspaces/utils/WorkspaceUtils.ts
+ * and mlflow/server/js/src/common/utils/ServerFeaturesContext.tsx but cannot be imported
+ * directly due to the web-shared package boundary.
+ */
+
+const WORKSPACE_STORAGE_KEY = 'mlflow.activeWorkspace';
+const WORKSPACE_QUERY_PARAM = 'workspace';
+
+/**
+ * Get the currently active workspace from localStorage.
+ * Mirrors getActiveWorkspace() from WorkspaceUtils.ts — uses the same storage key
+ * that the main app writes to, so it reads the correct value at runtime.
+ */
+const getActiveWorkspace = (): string | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    // eslint-disable-next-line @databricks/no-direct-storage -- OSS only use-case
+    return window.localStorage.getItem(WORKSPACE_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+};
+
+const isAbsoluteUrl = (value: string) => /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(value);
+
+/**
+ * Routes that never have workspace context. Root '/' is contextual.
+ * Kept as an extension point for any future workspace-agnostic routes.
+ */
+const ALWAYS_GLOBAL_ROUTES: string[] = [];
+
+/** Check if pathname is always global (workspace-agnostic). */
+const isGlobalRoute = (pathname: string): boolean => {
+  const normalizedPath = pathname.split('?')[0].split('#')[0];
+  return ALWAYS_GLOBAL_ROUTES.some((route) => normalizedPath === route || normalizedPath.startsWith(route + '/'));
+};
+
+/** Add workspace query param to URL, preserving existing params and hash. */
+const addWorkspaceQueryParam = (url: string, workspace: string): string => {
+  const hashPrefix = url.startsWith('#') ? '#' : '';
+  const urlWithoutHashPrefix = hashPrefix ? url.slice(1) : url;
+
+  let pathname = urlWithoutHashPrefix;
+  let existingQuery = '';
+  let hashFragment = '';
+
+  const hashIndex = pathname.indexOf('#');
+  if (hashIndex >= 0) {
+    hashFragment = pathname.slice(hashIndex);
+    pathname = pathname.slice(0, hashIndex);
+  }
+
+  const queryIndex = pathname.indexOf('?');
+  if (queryIndex >= 0) {
+    existingQuery = pathname.slice(queryIndex + 1);
+    pathname = pathname.slice(0, queryIndex);
+  }
+
+  const params = new URLSearchParams(existingQuery);
+  params.set(WORKSPACE_QUERY_PARAM, workspace);
+
+  return `${hashPrefix}${pathname}?${params.toString()}${hashFragment}`;
+};
+
+/** Remove workspace query param from URL. */
+const removeWorkspaceQueryParam = (url: string): string => {
+  const hashPrefix = url.startsWith('#') ? '#' : '';
+  const urlWithoutHashPrefix = hashPrefix ? url.slice(1) : url;
+
+  let pathname = urlWithoutHashPrefix;
+  let existingQuery = '';
+  let hashFragment = '';
+
+  const hashIndex = pathname.indexOf('#');
+  if (hashIndex >= 0) {
+    hashFragment = pathname.slice(hashIndex);
+    pathname = pathname.slice(0, hashIndex);
+  }
+
+  const queryIndex = pathname.indexOf('?');
+  if (queryIndex >= 0) {
+    existingQuery = pathname.slice(queryIndex + 1);
+    pathname = pathname.slice(0, queryIndex);
+  }
+
+  const params = new URLSearchParams(existingQuery);
+  params.delete(WORKSPACE_QUERY_PARAM);
+
+  const queryString = params.toString();
+  return `${hashPrefix}${pathname}${queryString ? '?' + queryString : ''}${hashFragment}`;
+};
+
+/**
+ * Prefix route with workspace query param. Removes workspace from global routes.
+ * Relative paths unchanged. Root '/' is contextual based on workspace param.
+ */
+const prefixRouteWithWorkspace = (to: string): string => {
+  if (typeof to !== 'string' || to.length === 0) {
+    return to;
+  }
+
+  if (isAbsoluteUrl(to)) {
+    return to;
+  }
+
+  const hashPrefix = to.startsWith('#') ? '#' : '';
+  const urlWithoutHashPrefix = hashPrefix ? to.slice(1) : to;
+
+  const isAbsoluteNavigation = hashPrefix !== '' || urlWithoutHashPrefix.startsWith('/');
+  if (!isAbsoluteNavigation) {
+    return to;
+  }
+
+  let pathname = urlWithoutHashPrefix;
+  let existingQuery = '';
+  const hashIndex = pathname.indexOf('#');
+  if (hashIndex >= 0) {
+    pathname = pathname.slice(0, hashIndex);
+  }
+  const queryIndex = pathname.indexOf('?');
+  if (queryIndex >= 0) {
+    existingQuery = pathname.slice(queryIndex + 1);
+    pathname = pathname.slice(0, queryIndex);
+  }
+
+  const existingParams = new URLSearchParams(existingQuery);
+  const hasExplicitWorkspace = existingParams.has(WORKSPACE_QUERY_PARAM);
+
+  if (isGlobalRoute(pathname || '/')) {
+    return removeWorkspaceQueryParam(to);
+  }
+
+  if (hasExplicitWorkspace) {
+    return to;
+  }
+
+  const workspace = getActiveWorkspace();
+  if (!workspace) {
+    return to;
+  }
+
+  return addWorkspaceQueryParam(to, workspace);
+};
+
+/**
+ * Add workspace query param to a To object (used by Link/NavLink/navigate).
+ * Handles both string and object forms of To.
+ */
+const prefixRouteWithWorkspaceForTo = (to: To): To => {
+  // String form - delegate to prefixRouteWithWorkspace
+  if (typeof to === 'string') {
+    return prefixRouteWithWorkspace(to);
+  }
+
+  // Object form - need to handle pathname and search separately
+  if (typeof to === 'object' && to !== null) {
+    const pathname = 'pathname' in to ? to.pathname : undefined;
+
+    if (typeof pathname !== 'string') {
+      return to;
+    }
+
+    // Skip workspace param for global routes
+    if (isGlobalRoute(pathname)) {
+      // Remove workspace param if present in existing search
+      if (to.search) {
+        const params = new URLSearchParams(to.search);
+        params.delete(WORKSPACE_QUERY_PARAM);
+        const newSearch = params.toString();
+        return {
+          ...to,
+          search: newSearch ? `?${newSearch}` : undefined,
+        };
+      }
+      return to;
+    }
+
+    // Add workspace query param
+    const workspace = getActiveWorkspace();
+    if (!workspace) {
+      return to;
+    }
+
+    // Merge workspace into existing search params
+    const existingSearch = to.search || '';
+    const params = new URLSearchParams(existingSearch.startsWith('?') ? existingSearch.slice(1) : existingSearch);
+    params.set(WORKSPACE_QUERY_PARAM, workspace);
+
+    return {
+      ...to,
+      search: `?${params.toString()}`,
+    };
+  }
+
+  return to;
+};
+
+const useLocation = useLocationDirect;
+
+const useSearchParams = useSearchParamsDirect;
+
+const useParams = useParamsDirect;
+
+type UseNavigateOptions = {
+  bypassWorkspacePrefix?: boolean;
+};
+
+const useNavigate = (options: UseNavigateOptions = { bypassWorkspacePrefix: false }): NavigateFunction => {
+  const { bypassWorkspacePrefix } = options;
+  const navigate = useNavigateDirect();
+  const wrappedNavigate = useCallback(
+    (to: To | number, options?: NavigateOptions) => {
+      if (typeof to === 'number') {
+        navigate(to);
+        return;
+      }
+      navigate(bypassWorkspacePrefix ? to : prefixRouteWithWorkspaceForTo(to), options);
+    },
+    [navigate, bypassWorkspacePrefix],
+  );
+
+  return wrappedNavigate as NavigateFunction;
+};
+
+const Outlet = OutletDirect;
+
+const Link = React.forwardRef<
+  HTMLAnchorElement,
+  ComponentProps<typeof LinkDirect> & { disableWorkspacePrefix?: boolean; componentId: string }
+>(function Link(props, ref) {
+  const { to, disableWorkspacePrefix, componentId, onClick, ...rest } = props;
+  const finalTo = disableWorkspacePrefix ? to : prefixRouteWithWorkspaceForTo(to);
+  const events = useMemo(() => [DesignSystemEventProviderAnalyticsEventTypes.OnClick], []);
+  const eventContext = useDesignSystemEventComponentCallbacks({
+    componentType: DesignSystemEventProviderComponentTypes.Button,
+    componentId,
+    analyticsEvents: events,
+  });
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent<HTMLAnchorElement>) => {
+      eventContext?.onClick(e);
+      onClick?.(e);
+    },
+    [eventContext, onClick],
+  );
+
+  return <LinkDirect ref={ref} to={finalTo} onClick={handleClick} {...rest} />;
+});
+
+export {
+  // React Router V6 API exports
+  BrowserRouter,
+  MemoryRouter,
+  HashRouter,
+  Link,
+  useNavigate,
+  useLocation,
+  useParams,
+  useSearchParams,
+  generatePath,
+  matchPath,
+  Navigate,
+  Route,
+  Routes,
+  Outlet,
+
+  // Exports used to build hash-based data router
+  createHashRouter,
+  RouterProvider,
+};
+
+export const createLazyRouteElement = (
+  // Load the module's default export and turn it into React Element
+  componentLoader: () => Promise<{ default: React.ComponentType<React.PropsWithChildren<any>> }>,
+  // eslint-disable-next-line @databricks/react-lazy-only-at-top-level
+) => React.createElement(React.lazy(componentLoader));
+export const createRouteElement = (component: React.ComponentType<React.PropsWithChildren<any>>) =>
+  React.createElement(component);
+
+export type { Location, NavigateFunction, Params, To, NavigateOptions };

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/utils/SessionAggregationUtils.ts
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/utils/SessionAggregationUtils.ts
@@ -1,0 +1,158 @@
+import { isSessionLevelAssessment } from '../../model-trace-explorer/ModelTraceExplorer.utils';
+import type { ModelTraceInfoV3 } from '../../model-trace-explorer/ModelTrace.types';
+
+import { isAssessmentPassing } from '../components/EvaluationsReviewAssessmentTag';
+import type { AssessmentInfo } from '../types';
+
+/**
+ * Result of aggregating pass/fail assessment values across multiple traces
+ */
+export interface PassFailAggregationResult {
+  passCount: number;
+  totalCount: number;
+  errorCount: number;
+}
+
+/**
+ * Result of aggregating numeric assessment values across multiple traces
+ */
+export interface NumericAggregationResult {
+  average: number | null;
+  count: number;
+}
+
+/**
+ * Result of aggregating string assessment values across multiple traces
+ */
+export interface StringAggregationResult {
+  valueCounts: Map<string, number>;
+  totalCount: number;
+}
+
+/**
+ * Filters assessments from a trace by name, excluding session-level and invalid assessments.
+ */
+function getValidAssessments(trace: ModelTraceInfoV3, assessmentName: string) {
+  return (
+    trace.assessments?.filter(
+      (a) => a.assessment_name === assessmentName && !isSessionLevelAssessment(a) && a.valid !== false,
+    ) ?? []
+  );
+}
+
+/**
+ * Aggregates assessment pass/fail counts across multiple traces for a given assessment.
+ * A trace can have multiple assessments with the same name, and they all count toward the total.
+ *
+ * @param traces - Array of trace info objects to aggregate
+ * @param assessmentInfo - The assessment metadata including name and dtype
+ * @returns Object containing passCount and totalCount
+ */
+export function aggregatePassFailAssessments(
+  traces: ModelTraceInfoV3[],
+  assessmentInfo: AssessmentInfo,
+): PassFailAggregationResult {
+  let passCount = 0;
+  let totalCount = 0;
+  let errorCount = 0;
+
+  for (const trace of traces) {
+    const assessments = getValidAssessments(trace, assessmentInfo.name);
+
+    for (const assessment of assessments) {
+      if (!('feedback' in assessment)) {
+        continue;
+      }
+
+      if (assessment.feedback.error?.error_message) {
+        errorCount++;
+        continue;
+      }
+
+      const feedbackValue = assessment.feedback.value;
+      const isPassing = isAssessmentPassing(assessmentInfo, feedbackValue);
+
+      if (isPassing === undefined) {
+        continue;
+      }
+
+      totalCount++;
+      if (isPassing) {
+        passCount++;
+      }
+    }
+  }
+
+  return { passCount, totalCount, errorCount };
+}
+
+/**
+ * Aggregates numeric assessment values across multiple traces.
+ * Returns the average and count of all numeric values.
+ *
+ * @param traces - Array of trace info objects to aggregate
+ * @param assessmentName - The name of the assessment to aggregate
+ * @returns Object containing average (or null if no values) and count
+ */
+export function aggregateNumericAssessments(
+  traces: ModelTraceInfoV3[],
+  assessmentName: string,
+): NumericAggregationResult {
+  let sum = 0;
+  let count = 0;
+
+  for (const trace of traces) {
+    const assessments = getValidAssessments(trace, assessmentName);
+
+    for (const assessment of assessments) {
+      if (!('feedback' in assessment)) {
+        continue;
+      }
+
+      const feedbackValue = assessment.feedback.value;
+      if (typeof feedbackValue === 'number' && !isNaN(feedbackValue)) {
+        sum += feedbackValue;
+        count++;
+      }
+    }
+  }
+
+  return {
+    average: count > 0 ? sum / count : null,
+    count,
+  };
+}
+
+/**
+ * Aggregates string assessment values across multiple traces.
+ * Returns unique values with their counts.
+ *
+ * @param traces - Array of trace info objects to aggregate
+ * @param assessmentName - The name of the assessment to aggregate
+ * @returns Object containing valueCounts map and totalCount
+ */
+export function aggregateStringAssessments(
+  traces: ModelTraceInfoV3[],
+  assessmentName: string,
+): StringAggregationResult {
+  const valueCounts = new Map<string, number>();
+  let totalCount = 0;
+
+  for (const trace of traces) {
+    const assessments = getValidAssessments(trace, assessmentName);
+
+    for (const assessment of assessments) {
+      if (!('feedback' in assessment)) {
+        continue;
+      }
+
+      const feedbackValue = assessment.feedback.value;
+      if (typeof feedbackValue === 'string') {
+        valueCounts.set(feedbackValue, (valueCounts.get(feedbackValue) ?? 0) + 1);
+        totalCount++;
+      }
+    }
+  }
+
+  return { valueCounts, totalCount };
+}

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/utils/SessionGroupingUtils.ts
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/utils/SessionGroupingUtils.ts
@@ -1,0 +1,250 @@
+import { SESSION_ID_METADATA_KEY } from '../../model-trace-explorer/constants';
+import type { ModelTraceInfoV3 } from '../../model-trace-explorer/ModelTrace.types';
+
+import type { EvalTraceComparisonEntry } from '../types';
+import { shouldEnableSessionGrouping } from './FeatureUtils';
+
+export interface SessionHeaderRowData {
+  type: 'sessionHeader';
+  sessionId: string;
+  otherSessionId?: string;
+  traces: ModelTraceInfoV3[];
+  otherTraces?: ModelTraceInfoV3[];
+  goal?: string;
+  persona?: string;
+}
+
+export type GroupedTraceTableRowData =
+  | { type: 'trace'; data: EvalTraceComparisonEntry; sessionId?: string }
+  | SessionHeaderRowData;
+
+export const SIMULATION_GOAL_KEY = 'mlflow.simulation.goal';
+export const SIMULATION_PERSONA_KEY = 'mlflow.simulation.persona';
+
+/**
+ * Extract session ID from a ModelTraceInfoV3.
+ */
+const getSessionIdFromTrace = (trace: ModelTraceInfoV3): string | null => {
+  return trace.trace_metadata?.[SESSION_ID_METADATA_KEY] ?? null;
+};
+
+/**
+ * Get a matching key for sessions. Sessions are matched by goal and persona metadata
+ * when in comparison mode (and session grouping is enabled), falling back to session ID
+ * otherwise. This allows sessions with different IDs but the same goal/persona to be
+ * grouped together during comparison.
+ *
+ * @param trace - The trace to get the match key for
+ * @param isComparing - Whether we're in comparison mode (goal/persona matching only applies here)
+ */
+const getSessionMatchKey = (trace: ModelTraceInfoV3, isComparing?: boolean): string => {
+  // Only use goal/persona matching when in comparison mode AND session grouping is enabled
+  if (isComparing && shouldEnableSessionGrouping()) {
+    const goal = trace.trace_metadata?.[SIMULATION_GOAL_KEY];
+    const persona = trace.trace_metadata?.[SIMULATION_PERSONA_KEY];
+
+    // Prefer matching by goal/persona since session IDs are often unique per run
+    if (goal && persona) {
+      return `metadata:${goal}:${persona}`;
+    }
+  }
+
+  // Fallback to session ID if no goal/persona available, not comparing, or feature is disabled
+  const sessionId = getSessionIdFromTrace(trace);
+  if (sessionId) {
+    return `session:${sessionId}`;
+  }
+
+  return `unmatched:${trace.trace_id}`;
+};
+
+interface SessionData {
+  sessionId: string;
+  otherSessionId?: string;
+  matchKey: string;
+  currentTraces: ModelTraceInfoV3[];
+  otherTraces: ModelTraceInfoV3[];
+  goal?: string;
+  persona?: string;
+}
+
+/**
+ * Groups traces by session for display in a table.
+ * Returns a flattened array where each session is represented by:
+ * 1. A sessionHeader row containing all traces in that session
+ * 2. Individual trace rows for each trace in the session (only if session is expanded)
+ *
+ * When comparing runs, sessions are matched by session ID or by goal/persona metadata.
+ * Traces without a session ID are appended at the end as standalone trace rows.
+ *
+ * @param currentEvaluationResults - The evaluation entries to group
+ * @param expandedSessions - Set of session IDs that are expanded (show trace rows)
+ * @param isComparing - Whether we're in comparison mode
+ */
+export const groupTracesBySessionForTable = (
+  currentEvaluationResults: EvalTraceComparisonEntry[],
+  expandedSessions: Set<string>,
+  isComparing?: boolean,
+): { groupedRows: GroupedTraceTableRowData[]; traceIdToTurnMap: Record<string, number> } => {
+  const sessionDataMap: Record<string, SessionData> = {};
+  const standaloneEntries: EvalTraceComparisonEntry[] = [];
+  const processedOtherTraceIds = new Set<string>();
+
+  // First pass: Group all current run traces by their match key
+  currentEvaluationResults.forEach((entry) => {
+    const traceInfo = entry.currentRunValue?.traceInfo;
+    if (!traceInfo) {
+      return;
+    }
+
+    const matchKey = getSessionMatchKey(traceInfo, isComparing);
+    const sessionId = getSessionIdFromTrace(traceInfo);
+
+    // Handle traces without session ID or goal/persona as standalone
+    if (!sessionId && !matchKey.startsWith('metadata:')) {
+      standaloneEntries.push(entry);
+      return;
+    }
+
+    if (!sessionDataMap[matchKey]) {
+      const goal = traceInfo.trace_metadata?.[SIMULATION_GOAL_KEY];
+      const persona = traceInfo.trace_metadata?.[SIMULATION_PERSONA_KEY];
+      sessionDataMap[matchKey] = {
+        sessionId: sessionId || matchKey,
+        matchKey,
+        currentTraces: [],
+        otherTraces: [],
+        goal,
+        persona,
+      };
+    }
+    sessionDataMap[matchKey].currentTraces.push(traceInfo);
+  });
+
+  // Second pass: Group all other run traces by their match key and match to existing sessions
+  if (isComparing) {
+    currentEvaluationResults.forEach((entry) => {
+      const otherTraceInfo = entry.otherRunValue?.traceInfo;
+      if (!otherTraceInfo) {
+        return;
+      }
+
+      const traceId = otherTraceInfo.trace_id;
+      if (processedOtherTraceIds.has(traceId)) {
+        return;
+      }
+      processedOtherTraceIds.add(traceId);
+
+      const matchKey = getSessionMatchKey(otherTraceInfo, isComparing);
+      const sessionId = getSessionIdFromTrace(otherTraceInfo);
+
+      // Handle traces without session ID or goal/persona as standalone
+      if (!sessionId && !matchKey.startsWith('metadata:')) {
+        // Only add to standalone if not already added via currentRunValue
+        if (!entry.currentRunValue?.traceInfo) {
+          standaloneEntries.push(entry);
+        }
+        return;
+      }
+
+      // Check if this session already exists (matched by key)
+      if (sessionDataMap[matchKey]) {
+        // Add to existing session and track the other session ID if different
+        sessionDataMap[matchKey].otherTraces.push(otherTraceInfo);
+        if (sessionId && sessionId !== sessionDataMap[matchKey].sessionId) {
+          sessionDataMap[matchKey].otherSessionId = sessionId;
+        }
+      } else {
+        // Create new session for other run traces only
+        const goal = otherTraceInfo.trace_metadata?.[SIMULATION_GOAL_KEY];
+        const persona = otherTraceInfo.trace_metadata?.[SIMULATION_PERSONA_KEY];
+        sessionDataMap[matchKey] = {
+          sessionId: sessionId || matchKey,
+          matchKey,
+          currentTraces: [],
+          otherTraces: [otherTraceInfo],
+          goal,
+          persona,
+        };
+      }
+    });
+  }
+
+  const result: GroupedTraceTableRowData[] = [];
+  const traceIdToTurnMap: Record<string, number> = {};
+
+  // Process each session: add header followed by trace rows (if expanded)
+  Object.values(sessionDataMap).forEach((sessionData) => {
+    const { sessionId, otherSessionId, currentTraces, otherTraces, goal, persona } = sessionData;
+
+    if (currentTraces.length === 0 && otherTraces.length === 0) {
+      return;
+    }
+
+    // Sort traces by request time ascending within the session (first turn to last turn)
+    const sortedCurrentTraces = currentTraces.toSorted((a, b) => {
+      const aTime = a.request_time ?? '';
+      const bTime = b.request_time ?? '';
+      return aTime.localeCompare(bTime);
+    });
+
+    const sortedOtherTraces = otherTraces.toSorted((a, b) => {
+      const aTime = a.request_time ?? '';
+      const bTime = b.request_time ?? '';
+      return aTime.localeCompare(bTime);
+    });
+
+    // Add session header
+    result.push({
+      type: 'sessionHeader',
+      sessionId,
+      otherSessionId,
+      traces: sortedCurrentTraces,
+      otherTraces: isComparing ? sortedOtherTraces : undefined,
+      goal,
+      persona,
+    });
+
+    // Add individual trace rows only if session is expanded and not comparing
+    // In comparison mode with session grouping, sessions are not expandable
+    if (expandedSessions.has(sessionId) && !isComparing) {
+      // Create a map of trace_id -> sorted index for ordering
+      const traceIdToSortIndex = new Map(sortedCurrentTraces.map((t, idx) => [t.trace_id, idx]));
+
+      // Find the original entries for these traces and sort them to match sortedCurrentTraces order
+      const entriesForSession = currentEvaluationResults
+        .filter((entry) => {
+          const traceId = entry.currentRunValue?.traceInfo?.trace_id;
+          return traceId && traceIdToSortIndex.has(traceId);
+        })
+        .toSorted((a, b) => {
+          const aIdx = traceIdToSortIndex.get(a.currentRunValue?.traceInfo?.trace_id ?? '') ?? 0;
+          const bIdx = traceIdToSortIndex.get(b.currentRunValue?.traceInfo?.trace_id ?? '') ?? 0;
+          return aIdx - bIdx;
+        });
+
+      entriesForSession.forEach((entry, index) => {
+        result.push({
+          type: 'trace',
+          data: entry,
+          sessionId,
+        });
+
+        const traceId = entry.currentRunValue?.traceInfo?.trace_id;
+        if (traceId) {
+          traceIdToTurnMap[traceId] = index + 1;
+        }
+      });
+    }
+  });
+
+  // Add standalone traces at the end
+  standaloneEntries.forEach((entry) => {
+    result.push({
+      type: 'trace',
+      data: entry,
+    });
+  });
+
+  return { groupedRows: result, traceIdToTurnMap };
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/utils/TraceLocationUtils.ts
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/utils/TraceLocationUtils.ts
@@ -1,0 +1,84 @@
+import type {
+  ModelTraceLocationMlflowExperiment,
+  ModelTraceLocationUcSchema,
+  ModelTraceLocationUcTablePrefix,
+  ModelTrace,
+  ModelTraceInfoV3,
+} from '../../model-trace-explorer/ModelTrace.types';
+import { isV3ModelTraceInfo } from '../../model-trace-explorer/ModelTraceExplorer.utils';
+
+/**
+ * Helper utility: creates experiment trace location descriptor based on provided experiment ID.
+ */
+export const createTraceLocationForExperiment = (experimentId: string): ModelTraceLocationMlflowExperiment => ({
+  type: 'MLFLOW_EXPERIMENT',
+  mlflow_experiment: {
+    experiment_id: experimentId,
+  },
+});
+
+export const createTraceLocationForUCSchema = (ucSchemaFullPath: string): ModelTraceLocationUcSchema => {
+  const [catalog_name, schema_name] = ucSchemaFullPath.split('.');
+  return {
+    type: 'UC_SCHEMA',
+    uc_schema: {
+      catalog_name,
+      schema_name,
+    },
+  };
+};
+
+export const createTraceLocationForUCTablePrefix = (fullPath: string): ModelTraceLocationUcTablePrefix => {
+  const [catalog_name, schema_name, table_prefix] = fullPath.split('.');
+  return {
+    type: 'UC_TABLE_PREFIX',
+    uc_table_prefix: {
+      catalog_name,
+      schema_name,
+      table_prefix,
+    },
+  };
+};
+
+/**
+ * Returns true if the given trace location uses a V4-compatible type (UC_SCHEMA or UC_TABLE_PREFIX).
+ */
+export const isV4TraceLocation = (location: { type: string }): boolean =>
+  location.type === 'UC_SCHEMA' || location.type === 'UC_TABLE_PREFIX';
+
+/**
+ * Returns true if the destination path has 3 dot-separated parts (catalog.schema.prefix),
+ * indicating a UC table prefix location rather than a UC schema location.
+ */
+export const isTablePrefixDestinationPath = (path: string): boolean => {
+  return path.split('.').length === 3;
+};
+
+/**
+ * Auto-detects the location type from a destination path string:
+ * - 2 parts (catalog.schema) -> UC_SCHEMA
+ * - 3 parts (catalog.schema.prefix) -> UC_TABLE_PREFIX
+ */
+export const createTraceLocationForDestinationPath = (
+  destinationPath: string,
+): ModelTraceLocationUcSchema | ModelTraceLocationUcTablePrefix => {
+  if (isTablePrefixDestinationPath(destinationPath)) {
+    return createTraceLocationForUCTablePrefix(destinationPath);
+  }
+  return createTraceLocationForUCSchema(destinationPath);
+};
+
+/**
+ * Determines if a trace (by provided info object) supports being queried using V4 API.
+ * UC_SCHEMA and UC_TABLE_PREFIX located traces are supported.
+ */
+export const doesTraceSupportV4API = (
+  traceInfo?: ModelTrace['info'] | Pick<ModelTraceInfoV3, 'trace_location' | 'trace_id'>,
+) => {
+  return Boolean(
+    traceInfo &&
+    isV3ModelTraceInfo(traceInfo) &&
+    traceInfo.trace_location &&
+    isV4TraceLocation(traceInfo.trace_location),
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/regression-test-table/utils/TraceUtils.ts
+++ b/mlflow/server/js/src/shared/web-shared/regression-test-table/utils/TraceUtils.ts
@@ -1,0 +1,523 @@
+import { isNil, uniq } from 'lodash';
+
+import type {
+  Assessment,
+  ExpectationAssessment,
+  FeedbackAssessment,
+  IssueReferenceAssessment,
+  ModelTrace,
+  ModelTraceLocation,
+  ModelTraceSpan,
+  ModelTraceInfoV3,
+  RetrieverDocument,
+} from '../../model-trace-explorer/ModelTrace.types';
+import { createTraceV4LongIdentifier } from '../../model-trace-explorer/ModelTraceExplorer.utils';
+import { getAssessmentValue } from '../../model-trace-explorer/assessments-pane/utils';
+import { ModelTraceSpanType } from '../../model-trace-explorer/ModelTrace.types';
+
+import { doesTraceSupportV4API } from './TraceLocationUtils';
+import {
+  MLFLOW_ASSESSMENT_SOURCE_RUN_ID,
+  MLFLOW_TRACE_SOURCE_SCORER_NAME_TAG,
+} from '../../model-trace-explorer/constants';
+import { stringifyValue, tryExtractUserMessageContent } from '../components/GenAiEvaluationTracesReview.utils';
+import { KnownEvaluationResultAssessmentName } from '../enum';
+import { CUSTOM_METADATA_COLUMN_ID, TAGS_COLUMN_ID } from '../hooks/useTableColumns';
+import type {
+  AssessmentType,
+  RunEvaluationResultAssessment,
+  RunEvaluationResultAssessmentSource,
+  RunEvaluationTracesDataEntry,
+  RunEvaluationTracesRetrievalChunk,
+} from '../types';
+
+// This is the key used by the eval harness to record
+// which chunk a given retrieval assessment corresponds to.
+const MLFLOW_SPAN_OUTPUT_KEY = 'span_output_key';
+
+const MLFLOW_ASSESSMENT_ROOT_CAUSE_ASSESSMENT = 'root_cause_assessment';
+const MLFLOW_ASSESSMENT_ROOT_CAUSE_RATIONALE = 'root_cause_rationale';
+const MLFLOW_ASSESSMENT_SUGGESTED_ACTION = 'suggested_action';
+export const MLFLOW_SOURCE_RUN_KEY = 'mlflow.sourceRun';
+
+export const MLFLOW_INTERNAL_PREFIX = 'mlflow.';
+
+export const DEFAULT_RUN_PLACEHOLDER_NAME = 'monitor';
+
+const SPANS_LOCATION_TAG_KEY = 'mlflow.trace.spansLocation';
+export const TRACKING_STORE_SPANS_LOCATION = 'TRACKING_STORE';
+
+/**
+ * Extracts the experiment ID from a trace location, if it is an MLflow experiment location.
+ */
+export const getExperimentIdFromTraceLocation = (location?: ModelTraceLocation): string | undefined => {
+  if (location?.type === 'MLFLOW_EXPERIMENT') {
+    return location.mlflow_experiment.experiment_id;
+  }
+  return undefined;
+};
+
+export const getRowIdFromEvaluation = (evaluation?: RunEvaluationTracesDataEntry) => {
+  return evaluation?.evaluationId || '';
+};
+
+export const getRowIdFromTrace = (trace?: ModelTraceInfoV3) => {
+  return trace?.trace_id || '';
+};
+
+export const getTagKeyFromColumnId = (columnId: string) => {
+  return columnId.split(':').pop();
+};
+
+export const getCustomMetadataKeyFromColumnId = (columnId: string) => {
+  return columnId.split(':').pop();
+};
+
+export const createTagColumnId = (tagKey: string) => {
+  return `${TAGS_COLUMN_ID}:${tagKey}`;
+};
+
+export const createCustomMetadataColumnId = (metadataKey: string) => {
+  return `${CUSTOM_METADATA_COLUMN_ID}:${metadataKey}`;
+};
+
+export const getTracesTagKeys = (traces: ModelTraceInfoV3[]): string[] => {
+  return uniq(
+    traces
+      .map((result) => {
+        return Object.keys(result.tags || {}).filter((key) => key && !key.startsWith(MLFLOW_INTERNAL_PREFIX));
+      })
+      .flat(),
+  );
+};
+
+/**
+ * Filter out the traces that are not created by the given evaluation run.
+ *
+ * NB: This utility is also used for the general trace view in a Run Detail page.
+ *
+ * @param traces - The traces to filter.
+ * @param runUuid - The run UUID to filter by.
+ * @returns The filtered traces.
+ */
+export const filterTracesByAssessmentSourceRunId = (
+  traces: ModelTraceInfoV3[] | undefined,
+  runUuid?: string | null,
+): ModelTraceInfoV3[] | undefined => {
+  if (!traces || !runUuid) {
+    return traces;
+  }
+
+  return traces.reduce<ModelTraceInfoV3[]>((acc, trace) => {
+    const assessments = trace.assessments || [];
+
+    // Filter assessments to those that are created by this evaluation run.
+    const filteredAssessments = assessments.filter((assessment) => {
+      const sourceRunId = assessment.metadata?.[MLFLOW_ASSESSMENT_SOURCE_RUN_ID];
+      return !sourceRunId || sourceRunId === runUuid;
+    });
+
+    // Filter out the scorer traces.
+    const sourceScorerName = trace.tags?.[MLFLOW_TRACE_SOURCE_SCORER_NAME_TAG];
+    if (sourceScorerName) {
+      return acc;
+    }
+
+    // Early return to avoid the overhead of copying the trace and assessments below.
+    if (filteredAssessments.length === assessments.length) {
+      acc.push(trace);
+      return acc;
+    }
+
+    // Render only the assessments that are created by this evaluation run. This is to avoid showing
+    // feedbacks logged from other runs in the evaluation results.
+    acc.push({
+      ...trace,
+      assessments: filteredAssessments,
+    });
+    return acc;
+  }, []);
+};
+
+// This function checks if the traceInfo field is present in the first entry of the evalResults array.
+// We assume that all entries in evalResults will either contain traceInfo or not.
+export const shouldUseTraceInfoV3 = (evalResults: RunEvaluationTracesDataEntry[]): boolean => {
+  return evalResults.length > 0 && Boolean(evalResults[0].traceInfo);
+};
+
+const safelyParseValue = <T>(val: string): string | T => {
+  try {
+    return JSON.parse(val);
+  } catch {
+    return val;
+  }
+};
+
+export const getTraceInfoInputs = (traceInfo: ModelTraceInfoV3) => {
+  return traceInfo.request_preview || traceInfo.request || traceInfo.trace_metadata?.['mlflow.traceInputs'] || '';
+};
+
+export const getTraceInfoOutputs = (traceInfo: ModelTraceInfoV3) => {
+  return traceInfo.response_preview || traceInfo.response || traceInfo.trace_metadata?.['mlflow.traceOutputs'] || '';
+};
+
+/**
+ * Returns the "spans location" tag value if present.
+ */
+export function getSpansLocation(traceInfo?: ModelTraceInfoV3): string | undefined {
+  return traceInfo?.tags?.[SPANS_LOCATION_TAG_KEY] || undefined;
+}
+
+const isExpectationAssessment = (assessment: Assessment): assessment is ExpectationAssessment => {
+  return Boolean('expectation' in assessment && assessment.expectation);
+};
+
+const isFeedbackAssessment = (assessment: Assessment): assessment is FeedbackAssessment => {
+  return Boolean('feedback' in assessment && assessment.feedback);
+};
+
+const isIssueReferenceAssessment = (assessment: Assessment): assessment is IssueReferenceAssessment => {
+  return Boolean('issue' in assessment && assessment.issue);
+};
+
+const LIST_TRACES_IGNORE_ASSESSMENTS = ['agent/latency_seconds'];
+
+function processExpectationAssessment(assessment: ExpectationAssessment, targets: Record<string, any>): void {
+  const assessmentName = assessment.assessment_name;
+  const assessmentValue = getAssessmentValue(assessment);
+
+  if (Array.isArray(assessmentValue)) {
+    // Parse string elements if possible, otherwise keep original values (booleans, numbers, objects, etc.)
+    targets[assessmentName] = assessmentValue.map((val) => (typeof val === 'string' ? safelyParseValue(val) : val));
+  } else if (typeof assessmentValue === 'string') {
+    // Parse JSON-encoded strings like "true", "42", "{...}", etc.
+    targets[assessmentName] = safelyParseValue(assessmentValue);
+  } else {
+    // Preserve non-string primitives and objects (boolean, number, null, plain objects)
+    targets[assessmentName] = assessmentValue;
+  }
+}
+
+function processFeedbackAssessment(
+  assessment: FeedbackAssessment,
+  overallAssessments: RunEvaluationResultAssessment[],
+  responseAssessmentsByName: Record<string, RunEvaluationResultAssessment[]>,
+): void {
+  const assessmentName = assessment.assessment_name;
+  const evalResultAssessment = convertFeedbackAssessmentToRunEvalAssessment(assessment);
+
+  if (assessmentName === KnownEvaluationResultAssessmentName.OVERALL_ASSESSMENT) {
+    overallAssessments.push(evalResultAssessment);
+  }
+  if (!responseAssessmentsByName[assessmentName]) {
+    responseAssessmentsByName[assessmentName] = [];
+  }
+
+  responseAssessmentsByName[assessmentName].push(evalResultAssessment);
+}
+
+const convertAssessmentV3Source = (assessment: Assessment): RunEvaluationResultAssessmentSource | undefined => {
+  if (!assessment.source?.source_type) {
+    return undefined;
+  }
+  const sourceType = assessment.source?.source_type;
+
+  let runEvalSourceType: AssessmentType;
+  if (sourceType === 'LLM_JUDGE') {
+    runEvalSourceType = 'AI_JUDGE';
+  } else {
+    runEvalSourceType = sourceType as AssessmentType;
+  }
+
+  return {
+    sourceType: runEvalSourceType,
+    sourceId: assessment.source?.source_id || '',
+    metadata: {},
+  };
+};
+
+export const convertFeedbackAssessmentToRunEvalAssessment = (
+  assessment: FeedbackAssessment,
+): RunEvaluationResultAssessment => {
+  const assessmentValue = assessment.feedback?.value;
+  const isOverallAssessment = assessment.assessment_name === KnownEvaluationResultAssessmentName.OVERALL_ASSESSMENT;
+  const source = convertAssessmentV3Source(assessment);
+  const error = assessment.feedback?.error || assessment.error;
+  return {
+    name: assessment.assessment_name,
+    stringValue: typeof assessmentValue === 'string' ? assessmentValue : undefined,
+    booleanValue: typeof assessmentValue === 'boolean' ? assessmentValue : undefined,
+    numericValue: typeof assessmentValue === 'number' ? assessmentValue : undefined,
+    errorCode: error?.error_code,
+    errorMessage: error?.error_message,
+    rationale: assessment.metadata?.[MLFLOW_ASSESSMENT_ROOT_CAUSE_RATIONALE] || assessment.rationale,
+    source,
+    rootCauseAssessment: isOverallAssessment
+      ? {
+          assessmentName: assessment.metadata?.[MLFLOW_ASSESSMENT_ROOT_CAUSE_ASSESSMENT] || '',
+          suggestedActions: assessment.metadata?.[MLFLOW_ASSESSMENT_SUGGESTED_ACTION],
+        }
+      : undefined,
+    metadata: assessment.metadata,
+  };
+};
+
+export const convertTraceInfoV3ToRunEvalEntry = (traceInfo: ModelTraceInfoV3): RunEvaluationTracesDataEntry => {
+  const evaluationId = getRowIdFromTrace(traceInfo);
+
+  // Prepare containers for our assessments.
+  const overallAssessments: RunEvaluationResultAssessment[] = [];
+  const responseAssessmentsByName: Record<string, RunEvaluationResultAssessment[]> = {};
+  const targets: Record<string, any> = {};
+  const issues: { id: string; name: string }[] = [];
+
+  traceInfo.assessments?.forEach((assessment) => {
+    const assessmentName = assessment.assessment_name;
+
+    if (LIST_TRACES_IGNORE_ASSESSMENTS.includes(assessmentName)) {
+      return;
+    }
+
+    if (assessment.valid === false) {
+      return;
+    }
+
+    if (isExpectationAssessment(assessment)) {
+      processExpectationAssessment(assessment, targets);
+    } else if (isFeedbackAssessment(assessment)) {
+      processFeedbackAssessment(assessment, overallAssessments, responseAssessmentsByName);
+    } else if (isIssueReferenceAssessment(assessment)) {
+      const issueName = assessment.issue.issue_name || assessmentName;
+      // assessmentName is the issue_id
+      issues.push({ id: assessmentName, name: issueName });
+    }
+  });
+
+  // Regression-test view: synthesize a single "Result" assessment per trace -- a
+  // test passes iff *all* its assertions pass. Rendered as one pass-fail column
+  // with the standard assessment header graph (overall test pass rate); the
+  // individual scorer columns are hidden by the table's default column selection.
+  const scorerResults = Object.entries(responseAssessmentsByName)
+    .filter(([name]) => name !== KnownEvaluationResultAssessmentName.OVERALL_ASSESSMENT)
+    .map(([, arr]) => arr[0])
+    .filter(Boolean);
+  if (scorerResults.length > 0) {
+    const passes = (a: RunEvaluationResultAssessment) =>
+      typeof a.booleanValue === 'boolean'
+        ? a.booleanValue
+        : typeof a.numericValue === 'number'
+          ? a.numericValue >= 0.5
+          : typeof a.stringValue === 'string'
+            ? ['yes', 'pass', 'true'].includes(a.stringValue.trim().toLowerCase())
+            : false;
+    const passedCount = scorerResults.filter(passes).length;
+    responseAssessmentsByName['Result'] = [
+      {
+        name: 'Result',
+        // Use the canonical pass-fail string ('yes'/'no') so the column is
+        // detected as a pass-fail assessment and renders the pass/fail graph.
+        stringValue: passedCount === scorerResults.length ? 'yes' : 'no',
+        rationale: `${passedCount}/${scorerResults.length} assertions passed`,
+        source: scorerResults[0].source,
+        timestamp: scorerResults[0].timestamp,
+      },
+    ];
+  }
+
+  // trace server has input/output in request/response field, and mlflow tracking server has it in the metadata
+  const rawInputs = getTraceInfoInputs(traceInfo);
+  const rawOutputs = getTraceInfoOutputs(traceInfo);
+
+  let inputsTitle = rawInputs;
+  let inputs: Record<string, any> = {};
+  let outputs: Record<string, any> = {};
+  try {
+    inputs = JSON.parse(rawInputs);
+
+    // Try to parse OpenAI messages first (most common case)
+    const messages = inputs['messages'];
+    if (Array.isArray(messages) && !isNil(messages[0]?.content)) {
+      inputsTitle = messages[messages.length - 1]?.content;
+    } else {
+      // Try to extract user message content from various chat formats (openai, langchain, anthropic)
+      const extractedContent = tryExtractUserMessageContent(inputs);
+      inputsTitle = extractedContent ?? stringifyValue(inputs);
+    }
+  } catch {
+    inputs = {
+      request: rawInputs,
+    };
+  }
+
+  try {
+    outputs = { response: JSON.parse(rawOutputs) };
+  } catch {
+    outputs = { response: rawOutputs };
+  }
+  return {
+    evaluationId,
+    requestId: traceInfo.client_request_id || evaluationId,
+    inputsId: evaluationId,
+    inputsTitle,
+    inputs,
+    outputs,
+    targets,
+    overallAssessments,
+    responseAssessmentsByName,
+    metrics: {},
+    traceInfo,
+    fullTraceId: createTraceV4LongIdentifier(traceInfo),
+    issues: issues.length > 0 ? issues : undefined,
+  };
+};
+
+export const applyTraceInfoV3ToEvalEntry = (
+  evalResults: RunEvaluationTracesDataEntry[],
+): RunEvaluationTracesDataEntry[] => {
+  if (!shouldUseTraceInfoV3(evalResults)) {
+    return evalResults;
+  }
+  return evalResults.map((result) => {
+    if (!result.traceInfo) {
+      return result;
+    }
+    // Convert the single TraceInfo to a single RunEvaluationTracesDataEntry
+    const converted = convertTraceInfoV3ToRunEvalEntry(result.traceInfo);
+    // Merge the newly converted fields with the existing data
+    return {
+      ...result,
+      ...converted,
+    };
+  });
+};
+
+export const isTraceExportable = (entry: RunEvaluationTracesDataEntry) => {
+  let responseJson;
+  try {
+    responseJson = JSON.parse(entry.outputs['response']);
+  } catch {
+    if (!entry.outputs['response']) {
+      return false;
+    }
+    // entry.outputs.response may already be parsed in case of external monitors
+    // so try using it directly here.
+    responseJson = entry.outputs['response'];
+  }
+  if (isNil(responseJson)) {
+    return false;
+  }
+
+  const responseIsChatCompletion =
+    (Array.isArray(responseJson['messages']) && !isNil(responseJson['messages']?.[0]?.['content'])) ||
+    (Array.isArray(responseJson['choices']) && !isNil(responseJson['choices']?.[0]?.['message']?.['content']));
+
+  return responseIsChatCompletion;
+};
+
+export function getRetrievedContextFromTrace(
+  responseAssessmentsByName: Record<string, RunEvaluationResultAssessment[]>,
+  trace: ModelTrace | undefined,
+): RunEvaluationTracesRetrievalChunk[] | undefined {
+  if (isNil(trace)) {
+    return undefined;
+  }
+  let docUriKey = 'doc_uri';
+  const tags = trace.info.tags as Record<string, string> | undefined;
+  if (tags?.['retrievers']) {
+    const retrieverInfos = safelyParseValue<{ doc_uri: string; chunk_id: string }[]>(tags['retrievers']);
+    if (typeof retrieverInfos === 'object' && retrieverInfos.length > 0) {
+      docUriKey = retrieverInfos[0].doc_uri;
+    }
+  }
+
+  const retrievalSpans = trace.data.spans.filter(
+    (span) =>
+      getSpanAttribute(span.attributes, 'mlflow.spanType') &&
+      safelyParseValue(getSpanAttribute(span.attributes, 'mlflow.spanType') as string) === ModelTraceSpanType.RETRIEVER,
+  );
+  if (retrievalSpans.length === 0) {
+    return [];
+  }
+
+  // Return the last retrieval span chronologically since it is the one analyzed by our judges.
+  const spanOutputs = getSpanAttribute(retrievalSpans.at(-1)?.attributes, 'mlflow.spanOutputs');
+  if (!spanOutputs) {
+    return [];
+  }
+
+  const outputs = safelyParseValue(spanOutputs) as RetrieverDocument[];
+  if (!Array.isArray(outputs)) {
+    return [];
+  }
+
+  const retrievalChunks = outputs.map((doc, index) => {
+    return {
+      docUrl: doc.metadata?.[docUriKey],
+      content: doc.page_content,
+      retrievalAssessmentsByName: getRetrievalAssessmentsByName(responseAssessmentsByName, index),
+    };
+  });
+
+  return retrievalChunks;
+}
+
+const getRetrievalAssessmentsByName = (
+  responseAssessmentsByName: Record<string, RunEvaluationResultAssessment[]>,
+  chunkIndex: number,
+): Record<string, RunEvaluationResultAssessment[]> => {
+  const filteredResponseAssessmentsByName = Object.fromEntries(
+    Object.entries(responseAssessmentsByName)
+      .map(([key, assessments]) => [
+        key,
+        assessments.filter((assessment) => Number(assessment?.metadata?.[MLFLOW_SPAN_OUTPUT_KEY]) === chunkIndex),
+      ])
+      .filter(([key, filteredAssessments]) => filteredAssessments.length > 0),
+  );
+
+  return filteredResponseAssessmentsByName;
+};
+
+/**
+ * Extract an attribute value from span attributes.
+ * V3 traces have flat objects: { 'mlflow.spanInputs': '{"x": 10}' }
+ * V4 traces have arrays: [{ key: 'mlflow.spanInputs', value: { string_value: '{"x":10}' } }]
+ */
+export const getSpanAttribute = (
+  attributes: ModelTraceSpan['attributes'],
+  attributeKey: string,
+): string | undefined => {
+  if (!attributes) {
+    return undefined;
+  }
+
+  // V3: attributes is a flat object
+  if (!Array.isArray(attributes)) {
+    return attributes[attributeKey];
+  }
+
+  // V4: attributes is an array - find the matching key
+  const attribute = attributes.find((attr) => attr.key === attributeKey);
+  if (!attribute?.value) {
+    return undefined;
+  }
+
+  // V4 values are typed - return whichever type is present
+  return attribute.value.string_value ?? attribute.value.int_value ?? attribute.value.bool_value;
+};
+
+/**
+ * V4 UC traces: trace:/catalog_name.schema_name/trace_id
+ * V3 traces or others: trace_id as-is
+ * Both V3 and V4 traces have the same traceInfo schema; what's different is the trace location
+ */
+export const formatTraceId = (traceInfo: ModelTraceInfoV3 | undefined, fallbackId?: string): string => {
+  const traceId = traceInfo?.trace_id || fallbackId;
+
+  // Check if this is a V4 UC schema trace
+  // TODO: Support other trace locations
+  if (traceInfo && doesTraceSupportV4API(traceInfo)) {
+    return createTraceV4LongIdentifier(traceInfo);
+  }
+
+  return traceId || '';
+};

--- a/uv.lock
+++ b/uv.lock
@@ -36,7 +36,7 @@ excludes = ["uv"]
 [[package]]
 name = "absl-py"
 version = "2.4.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/64/c7/8de93764ad66968d19329a7e0c147a2bb3c7054c554d4a119111b8f9440f/absl_py-2.4.0.tar.gz", hash = "sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4", size = 116543, upload-time = "2026-01-28T10:17:05.322Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl", hash = "sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d", size = 135750, upload-time = "2026-01-28T10:17:04.19Z" },
@@ -45,7 +45,7 @@ wheels = [
 [[package]]
 name = "adal"
 version = "1.2.7"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "pyjwt" },
@@ -60,7 +60,7 @@ wheels = [
 [[package]]
 name = "aiofile"
 version = "3.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 resolution-markers = [
     "python_full_version < '3.11'",
 ]
@@ -75,7 +75,7 @@ wheels = [
 [[package]]
 name = "aiofile"
 version = "3.11.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
     "python_full_version == '3.13.*'",
@@ -93,7 +93,7 @@ wheels = [
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/33/c6/61a2d7b7572279226bb2e7f61d7a19ca7c90da0329c93fa0d560cbf288d8/aiohappyeyeballs-2.6.2.tar.gz", hash = "sha256:e202810ee718bd01fc6ef49e8ea53d023d5cb6b581076d7925aa499fa55dbe64", size = 22591, upload-time = "2026-05-20T15:12:24.631Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5f/fc/a7bf5b6e4e617b45f90f2d9d2a68519c249c81dd4fc2658c7a2a61c4f4b7/aiohappyeyeballs-2.6.2-py3-none-any.whl", hash = "sha256:4708045e2d7a6c6bdf8aafa8ed39649eaf926a4543b54560659129e3365953c4", size = 15062, upload-time = "2026-05-20T15:12:23.328Z" },
@@ -102,7 +102,7 @@ wheels = [
 [[package]]
 name = "aiohttp"
 version = "3.13.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "aiohappyeyeballs" },
     { name = "aiosignal" },
@@ -222,7 +222,7 @@ wheels = [
 [[package]]
 name = "aiosignal"
 version = "1.4.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "frozenlist" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
@@ -235,7 +235,7 @@ wheels = [
 [[package]]
 name = "alabaster"
 version = "0.7.16"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c9/3e/13dd8e5ed9094e734ac430b5d0eb4f2bb001708a8b7856cbf8e084e001ba/alabaster-0.7.16.tar.gz", hash = "sha256:75a8b99c28a5dad50dd7f8ccdd447a121ddb3892da9e53d1ca5cca3106d58d65", size = 23776, upload-time = "2024-01-10T00:56:10.189Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/34/d4e1c02d3bee589efb5dfa17f88ea08bdb3e3eac12bc475462aec52ed223/alabaster-0.7.16-py3-none-any.whl", hash = "sha256:b46733c07dce03ae4e150330b975c75737fa60f0a7c591b6c8bf4928a28e2c92", size = 13511, upload-time = "2024-01-10T00:56:08.388Z" },
@@ -244,7 +244,7 @@ wheels = [
 [[package]]
 name = "alembic"
 version = "1.18.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "mako" },
     { name = "sqlalchemy" },
@@ -259,7 +259,7 @@ wheels = [
 [[package]]
 name = "aliyun-python-sdk-core"
 version = "2.11.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "pycryptodome" },
 ]
@@ -268,7 +268,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/cc/ad/e32feeaaef73ed320
 [[package]]
 name = "aliyun-python-sdk-core-v3"
 version = "2.11.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "pycryptodome" },
 ]
@@ -277,7 +277,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/e2/04/6176b46909f17953c
 [[package]]
 name = "aliyun-python-sdk-kms"
 version = "2.16.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "aliyun-python-sdk-core" },
 ]
@@ -289,7 +289,7 @@ wheels = [
 [[package]]
 name = "aliyunstoreplugin"
 version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "mlflow" },
     { name = "oss2" },
@@ -302,7 +302,7 @@ wheels = [
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
@@ -311,7 +311,7 @@ wheels = [
 [[package]]
 name = "annotated-types"
 version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
@@ -320,7 +320,7 @@ wheels = [
 [[package]]
 name = "anyio"
 version = "4.13.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "idna" },
@@ -334,7 +334,7 @@ wheels = [
 [[package]]
 name = "appdirs"
 version = "1.4.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/d8/05696357e0311f5b5c316d7b95f46c669dd9c15aaeecbb48c7d0aeb88c40/appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41", size = 13470, upload-time = "2020-05-11T07:59:51.037Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/00/2344469e2084fb287c2e0b57b72910309874c3245463acd6cf5e3db69324/appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128", size = 9566, upload-time = "2020-05-11T07:59:49.499Z" },
@@ -343,7 +343,7 @@ wheels = [
 [[package]]
 name = "argcomplete"
 version = "3.6.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/38/61/0b9ae6399dd4a58d8c1b1dc5a27d6f2808023d0b5dd3104bb99f45a33ff6/argcomplete-3.6.3.tar.gz", hash = "sha256:62e8ed4fd6a45864acc8235409461b72c9a28ee785a2011cc5eb78318786c89c", size = 73754, upload-time = "2025-10-20T03:33:34.741Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/74/f5/9373290775639cb67a2fce7f629a1c240dce9f12fe927bc32b2736e16dfc/argcomplete-3.6.3-py3-none-any.whl", hash = "sha256:f5007b3a600ccac5d25bbce33089211dfd49eab4a7718da3f10e3082525a92ce", size = 43846, upload-time = "2025-10-20T03:33:33.021Z" },
@@ -352,7 +352,7 @@ wheels = [
 [[package]]
 name = "astunparse"
 version = "1.6.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "six" },
     { name = "wheel" },
@@ -365,7 +365,7 @@ wheels = [
 [[package]]
 name = "async-timeout"
 version = "5.0.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
@@ -374,7 +374,7 @@ wheels = [
 [[package]]
 name = "attrs"
 version = "26.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
@@ -383,7 +383,7 @@ wheels = [
 [[package]]
 name = "authlib"
 version = "1.7.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "joserfc" },
@@ -396,7 +396,7 @@ wheels = [
 [[package]]
 name = "azure-common"
 version = "1.1.28"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3e/71/f6f71a276e2e69264a97ad39ef850dca0a04fce67b12570730cb38d0ccac/azure-common-1.1.28.zip", hash = "sha256:4ac0cd3214e36b6a1b6a442686722a5d8cc449603aa833f3f0f40bda836704a3", size = 20914, upload-time = "2022-02-03T19:39:44.373Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/55/7f118b9c1b23ec15ca05d15a578d8207aa1706bc6f7c87218efffbbf875d/azure_common-1.1.28-py2.py3-none-any.whl", hash = "sha256:5c12d3dcf4ec20599ca6b0d3e09e86e146353d443e7fcc050c9a19c1f9df20ad", size = 14462, upload-time = "2022-02-03T19:39:42.417Z" },
@@ -405,7 +405,7 @@ wheels = [
 [[package]]
 name = "azure-core"
 version = "1.41.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "requests" },
     { name = "typing-extensions" },
@@ -418,7 +418,7 @@ wheels = [
 [[package]]
 name = "azure-graphrbac"
 version = "0.61.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "azure-common" },
     { name = "msrest" },
@@ -432,7 +432,7 @@ wheels = [
 [[package]]
 name = "azure-identity"
 version = "1.25.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "azure-core" },
     { name = "cryptography" },
@@ -448,7 +448,7 @@ wheels = [
 [[package]]
 name = "azure-mgmt-authorization"
 version = "4.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "azure-common" },
     { name = "azure-mgmt-core" },
@@ -462,7 +462,7 @@ wheels = [
 [[package]]
 name = "azure-mgmt-containerregistry"
 version = "14.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "azure-common" },
     { name = "azure-mgmt-core" },
@@ -477,7 +477,7 @@ wheels = [
 [[package]]
 name = "azure-mgmt-core"
 version = "1.6.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "azure-core" },
 ]
@@ -489,7 +489,7 @@ wheels = [
 [[package]]
 name = "azure-mgmt-keyvault"
 version = "11.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "azure-common" },
     { name = "azure-mgmt-core" },
@@ -504,7 +504,7 @@ wheels = [
 [[package]]
 name = "azure-mgmt-network"
 version = "30.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "azure-mgmt-core" },
     { name = "msrest" },
@@ -518,7 +518,7 @@ wheels = [
 [[package]]
 name = "azure-mgmt-resource"
 version = "24.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "azure-common" },
     { name = "azure-mgmt-core" },
@@ -533,7 +533,7 @@ wheels = [
 [[package]]
 name = "azure-mgmt-storage"
 version = "24.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "azure-mgmt-core" },
     { name = "msrest" },
@@ -547,7 +547,7 @@ wheels = [
 [[package]]
 name = "azure-storage-blob"
 version = "12.29.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "azure-core" },
     { name = "cryptography" },
@@ -562,7 +562,7 @@ wheels = [
 [[package]]
 name = "azure-storage-file-datalake"
 version = "12.24.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "azure-core" },
     { name = "azure-storage-blob" },
@@ -577,7 +577,7 @@ wheels = [
 [[package]]
 name = "azureml-core"
 version = "1.61.0.post3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "adal" },
     { name = "argcomplete" },
@@ -621,7 +621,7 @@ wheels = [
 [[package]]
 name = "babel"
 version = "2.18.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
@@ -630,7 +630,7 @@ wheels = [
 [[package]]
 name = "backoff"
 version = "2.2.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
@@ -639,7 +639,7 @@ wheels = [
 [[package]]
 name = "backports-asyncio-runner"
 version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
@@ -648,7 +648,7 @@ wheels = [
 [[package]]
 name = "backports-tarfile"
 version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz", hash = "sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991", size = 86406, upload-time = "2024-05-28T17:01:54.731Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl", hash = "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34", size = 30181, upload-time = "2024-05-28T17:01:53.112Z" },
@@ -657,7 +657,7 @@ wheels = [
 [[package]]
 name = "backports-tempfile"
 version = "1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "backports-weakref" },
 ]
@@ -669,7 +669,7 @@ wheels = [
 [[package]]
 name = "backports-weakref"
 version = "1.0.post1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/12/ab/cf35cf43a4a6215e3255cf2e49c77d5ba1e9c733af2aa3ec1ca9c4d02592/backports.weakref-1.0.post1.tar.gz", hash = "sha256:bc4170a29915f8b22c9e7c4939701859650f2eb84184aee80da329ac0b9825c2", size = 10574, upload-time = "2017-09-17T20:58:21.892Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/ec/f598b633c3d5ffe267aaada57d961c94fdfa183c5c3ebda2b6d151943db6/backports.weakref-1.0.post1-py2.py3-none-any.whl", hash = "sha256:81bc9b51c0abc58edc76aefbbc68c62a787918ffe943a37947e162c3f8e19e82", size = 5237, upload-time = "2017-09-17T20:58:26.557Z" },
@@ -678,7 +678,7 @@ wheels = [
 [[package]]
 name = "bcrypt"
 version = "5.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d4/36/3329e2518d70ad8e2e5817d5a4cac6bba05a47767ec416c7d020a965f408/bcrypt-5.0.0.tar.gz", hash = "sha256:f748f7c2d6fd375cc93d3fba7ef4a9e3a092421b8dbf34d8d4dc06be9492dfdd", size = 25386, upload-time = "2025-09-25T19:50:47.829Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/13/85/3e65e01985fddf25b64ca67275bb5bdb4040bd1a53b66d355c6c37c8a680/bcrypt-5.0.0-cp313-cp313t-macosx_10_12_universal2.whl", hash = "sha256:f3c08197f3039bec79cee59a606d62b96b16669cff3949f21e74796b6e3cd2be", size = 481806, upload-time = "2025-09-25T19:49:05.102Z" },
@@ -748,7 +748,7 @@ wheels = [
 [[package]]
 name = "beartype"
 version = "0.22.9"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/94/1009e248bbfbab11397abca7193bea6626806be9a327d399810d523a07cb/beartype-0.22.9.tar.gz", hash = "sha256:8f82b54aa723a2848a56008d18875f91c1db02c32ef6a62319a002e3e25a975f", size = 1608866, upload-time = "2025-12-13T06:50:30.72Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl", hash = "sha256:d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2", size = 1333658, upload-time = "2025-12-13T06:50:28.266Z" },
@@ -757,7 +757,7 @@ wheels = [
 [[package]]
 name = "beautifulsoup4"
 version = "4.14.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "soupsieve" },
     { name = "typing-extensions" },
@@ -770,7 +770,7 @@ wheels = [
 [[package]]
 name = "bleach"
 version = "6.3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "webencodings" },
 ]
@@ -787,7 +787,7 @@ css = [
 [[package]]
 name = "blinker"
 version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
@@ -796,7 +796,7 @@ wheels = [
 [[package]]
 name = "boto3"
 version = "1.43.18"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
@@ -810,7 +810,7 @@ wheels = [
 [[package]]
 name = "botocore"
 version = "1.43.18"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
@@ -824,7 +824,7 @@ wheels = [
 [[package]]
 name = "build"
 version = "1.5.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "colorama", marker = "os_name == 'nt'" },
     { name = "importlib-metadata", marker = "python_full_version < '3.10.2'" },
@@ -840,7 +840,7 @@ wheels = [
 [[package]]
 name = "cachetools"
 version = "7.1.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f4/8b/0d3945a13955303b81272f759a0331e54c5c793da455e6f5706b89d2639c/cachetools-7.1.4.tar.gz", hash = "sha256:437f55a4e0c1b01a4f3077cc470e6991d47430970e36fbcb77e2be0df4fc1cd6", size = 40085, upload-time = "2026-05-21T22:40:43.376Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8c/7b/1fc1c09cc0756cf25861a3be10565915953876da48bb228fb9a672b20a42/cachetools-7.1.4-py3-none-any.whl", hash = "sha256:323dc4127934744db5b54eb4924482d7edafbf9554e820d1531c2e08c0e4ef54", size = 16761, upload-time = "2026-05-21T22:40:41.845Z" },
@@ -849,7 +849,7 @@ wheels = [
 [[package]]
 name = "caio"
 version = "0.9.25"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/92/88/b8527e1b00c1811db339a1df8bd1ae49d146fcea9d6a5c40e3a80aaeb38d/caio-0.9.25.tar.gz", hash = "sha256:16498e7f81d1d0f5a4c0ad3f2540e65fe25691376e0a5bd367f558067113ed10", size = 26781, upload-time = "2025-12-26T15:21:36.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/80/ea4ead0c5d52a9828692e7df20f0eafe8d26e671ce4883a0a146bb91049e/caio-0.9.25-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ca6c8ecda611478b6016cb94d23fd3eb7124852b985bdec7ecaad9f3116b9619", size = 36836, upload-time = "2025-12-26T15:22:04.662Z" },
@@ -878,7 +878,7 @@ wheels = [
 [[package]]
 name = "certifi"
 version = "2026.5.20"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
@@ -887,7 +887,7 @@ wheels = [
 [[package]]
 name = "cffi"
 version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
@@ -969,7 +969,7 @@ wheels = [
 [[package]]
 name = "cfgv"
 version = "3.5.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
@@ -978,7 +978,7 @@ wheels = [
 [[package]]
 name = "charset-normalizer"
 version = "3.4.7"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/26/08/0f303cb0b529e456bb116f2d50565a482694fbb94340bf56d44677e7ed03/charset_normalizer-3.4.7-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cdd68a1fb318e290a2077696b7eb7a21a49163c455979c639bf5a5dcdc46617d", size = 315182, upload-time = "2026-04-02T09:25:40.673Z" },
@@ -1083,7 +1083,7 @@ wheels = [
 [[package]]
 name = "check-jsonschema"
 version = "0.37.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "click" },
     { name = "jsonschema" },
@@ -1100,7 +1100,7 @@ wheels = [
 [[package]]
 name = "click"
 version = "8.3.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
@@ -1127,7 +1127,7 @@ requires-dist = [
 [[package]]
 name = "cloudpickle"
 version = "3.1.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
@@ -1136,7 +1136,7 @@ wheels = [
 [[package]]
 name = "colorama"
 version = "0.4.6"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
@@ -1145,7 +1145,7 @@ wheels = [
 [[package]]
 name = "contextlib2"
 version = "21.6.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/13/37ea7805ae3057992e96ecb1cffa2fa35c2ef4498543b846f90dd2348d8f/contextlib2-21.6.0.tar.gz", hash = "sha256:ab1e2bfe1d01d968e1b7e8d9023bc51ef3509bba217bb730cee3827e1ee82869", size = 43795, upload-time = "2021-06-27T06:54:40.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/56/6d6872f79d14c0cb02f1646cbb4592eef935857c0951a105874b7b62a0c3/contextlib2-21.6.0-py2.py3-none-any.whl", hash = "sha256:3fbdb64466afd23abaf6c977627b75b6139a5a3e8ce38405c5b413aed7a0471f", size = 13277, upload-time = "2021-06-27T06:54:20.972Z" },
@@ -1154,12 +1154,12 @@ wheels = [
 [[package]]
 name = "contourpy"
 version = "1.3.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -1224,7 +1224,7 @@ wheels = [
 [[package]]
 name = "contourpy"
 version = "1.3.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
     "python_full_version == '3.13.*'",
@@ -1232,7 +1232,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -1312,7 +1312,7 @@ wheels = [
 [[package]]
 name = "coverage"
 version = "7.14.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/54/fd/0ab2772530e946e1be1abd0bc09e647ec9b02e88f0867857601fefca8953/coverage-7.14.1.tar.gz", hash = "sha256:30c08f7d90415aa98b3c990385dea2939b0da55f38515e5b369b83655f8523be", size = 920132, upload-time = "2026-05-26T20:41:36.783Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/92/69/0d2ef01ff4b8fcecd4cba920d11e92fa4f96ae412441d3b56a90a258e69b/coverage-7.14.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3e3680291c4a1d0dadfa84a2c459576a4af5133abb617905714339a0c73138cf", size = 219722, upload-time = "2026-05-26T20:38:14.002Z" },
@@ -1430,13 +1430,13 @@ toml = [
 [[package]]
 name = "crcmod"
 version = "1.7"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6b/b0/e595ce2a2527e169c3bcd6c33d2473c1918e0b7f6826a043ca1245dd4e5b/crcmod-1.7.tar.gz", hash = "sha256:dc7051a0db5f2bd48665a990d3ec1cc305a466a77358ca4492826f41f283601e", size = 89670, upload-time = "2010-06-27T14:35:29.538Z" }
 
 [[package]]
 name = "cryptography"
 version = "46.0.7"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
@@ -1496,7 +1496,7 @@ wheels = [
 [[package]]
 name = "cycler"
 version = "0.12.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c", size = 7615, upload-time = "2023-10-07T05:32:18.335Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30", size = 8321, upload-time = "2023-10-07T05:32:16.783Z" },
@@ -1505,7 +1505,7 @@ wheels = [
 [[package]]
 name = "cyclopts"
 version = "4.16.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "docstring-parser" },
@@ -1522,7 +1522,7 @@ wheels = [
 [[package]]
 name = "databricks-agents"
 version = "1.10.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "boto3" },
     { name = "botocore" },
@@ -1531,8 +1531,8 @@ dependencies = [
     { name = "googleapis-common-protos" },
     { name = "jinja2" },
     { name = "mlflow-skinny" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pandas" },
     { name = "pydantic" },
     { name = "tenacity" },
@@ -1548,7 +1548,7 @@ wheels = [
 [[package]]
 name = "databricks-sdk"
 version = "0.112.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "google-auth" },
     { name = "protobuf" },
@@ -1562,7 +1562,7 @@ wheels = [
 [[package]]
 name = "dataclasses-json"
 version = "0.6.7"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "marshmallow" },
     { name = "typing-inspect" },
@@ -1575,7 +1575,7 @@ wheels = [
 [[package]]
 name = "datasets"
 version = "4.8.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "dill" },
     { name = "filelock" },
@@ -1583,8 +1583,8 @@ dependencies = [
     { name = "httpx" },
     { name = "huggingface-hub" },
     { name = "multiprocess" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "packaging" },
     { name = "pandas" },
     { name = "pyarrow" },
@@ -1601,7 +1601,7 @@ wheels = [
 [[package]]
 name = "deepeval"
 version = "4.0.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "click" },
@@ -1640,7 +1640,7 @@ wheels = [
 [[package]]
 name = "defusedxml"
 version = "0.7.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
@@ -1649,7 +1649,7 @@ wheels = [
 [[package]]
 name = "deprecated"
 version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "wrapt" },
 ]
@@ -1661,7 +1661,7 @@ wheels = [
 [[package]]
 name = "dill"
 version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
@@ -1670,7 +1670,7 @@ wheels = [
 [[package]]
 name = "diskcache"
 version = "5.6.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc", size = 67916, upload-time = "2023-08-31T06:12:00.316Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19", size = 45550, upload-time = "2023-08-31T06:11:58.822Z" },
@@ -1679,7 +1679,7 @@ wheels = [
 [[package]]
 name = "distlib"
 version = "0.4.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
@@ -1688,7 +1688,7 @@ wheels = [
 [[package]]
 name = "distro"
 version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
@@ -1697,7 +1697,7 @@ wheels = [
 [[package]]
 name = "dnspython"
 version = "2.8.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
@@ -1706,7 +1706,7 @@ wheels = [
 [[package]]
 name = "docker"
 version = "7.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "requests" },
@@ -1720,7 +1720,7 @@ wheels = [
 [[package]]
 name = "docstring-parser"
 version = "0.18.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
@@ -1729,7 +1729,7 @@ wheels = [
 [[package]]
 name = "docutils"
 version = "0.16"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2f/e0/3d435b34abd2d62e8206171892f174b180cd37b09d57b924ca5c2ef2219d/docutils-0.16.tar.gz", hash = "sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc", size = 1962041, upload-time = "2020-01-12T13:55:25.917Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/44/8a15e45ffa96e6cf82956dd8d7af9e666357e16b0d93b253903475ee947f/docutils-0.16-py2.py3-none-any.whl", hash = "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af", size = 548181, upload-time = "2020-01-12T13:55:21.393Z" },
@@ -1738,7 +1738,7 @@ wheels = [
 [[package]]
 name = "durationpy"
 version = "0.10"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9d/a4/e44218c2b394e31a6dd0d6b095c4e1f32d0be54c2a4b250032d717647bab/durationpy-0.10.tar.gz", hash = "sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba", size = 3335, upload-time = "2025-05-17T13:52:37.26Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/0d/9feae160378a3553fa9a339b0e9c1a048e147a4127210e286ef18b730f03/durationpy-0.10-py3-none-any.whl", hash = "sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286", size = 3922, upload-time = "2025-05-17T13:52:36.463Z" },
@@ -1747,7 +1747,7 @@ wheels = [
 [[package]]
 name = "email-validator"
 version = "2.3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "dnspython" },
     { name = "idna" },
@@ -1760,7 +1760,7 @@ wheels = [
 [[package]]
 name = "exceptiongroup"
 version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
@@ -1772,7 +1772,7 @@ wheels = [
 [[package]]
 name = "execnet"
 version = "2.1.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
@@ -1781,7 +1781,7 @@ wheels = [
 [[package]]
 name = "fastapi"
 version = "0.136.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "annotated-doc" },
     { name = "pydantic" },
@@ -1797,7 +1797,7 @@ wheels = [
 [[package]]
 name = "fastjsonschema"
 version = "2.21.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/20/b5/23b216d9d985a956623b6bd12d4086b60f0059b27799f23016af04a74ea1/fastjsonschema-2.21.2.tar.gz", hash = "sha256:b1eb43748041c880796cd077f1a07c3d94e93ae84bba5ed36800a33554ae05de", size = 374130, upload-time = "2025-08-14T18:49:36.666Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e47de6d9e2e40fd4a9d2f7c4b6ef974babd482a59743694/fastjsonschema-2.21.2-py3-none-any.whl", hash = "sha256:1c797122d0a86c5cace2e54bf4e819c36223b552017172f32c5c024a6b77e463", size = 24024, upload-time = "2025-08-14T18:49:34.776Z" },
@@ -1806,7 +1806,7 @@ wheels = [
 [[package]]
 name = "fastmcp"
 version = "3.3.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "fastmcp-slim", extra = ["client", "server"] },
 ]
@@ -1818,7 +1818,7 @@ wheels = [
 [[package]]
 name = "fastmcp-slim"
 version = "3.3.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "platformdirs" },
     { name = "pydantic", extra = ["email"] },
@@ -1866,7 +1866,7 @@ server = [
 [[package]]
 name = "filelock"
 version = "3.29.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
@@ -1875,7 +1875,7 @@ wheels = [
 [[package]]
 name = "filetype"
 version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bb/29/745f7d30d47fe0f251d3ad3dc2978a23141917661998763bebb6da007eb1/filetype-1.2.0.tar.gz", hash = "sha256:66b56cd6474bf41d8c54660347d37afcc3f7d1970648de365c102ef77548aadb", size = 998020, upload-time = "2022-11-02T17:34:04.141Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/79/1b8fa1bb3568781e84c9200f951c735f3f157429f44be0495da55894d620/filetype-1.2.0-py2.py3-none-any.whl", hash = "sha256:7ce71b6880181241cf7ac8697a2f1eb6a8bd9b429f7ad6d27b8db9ba5f1c2d25", size = 19970, upload-time = "2022-11-02T17:34:01.425Z" },
@@ -1884,7 +1884,7 @@ wheels = [
 [[package]]
 name = "flask"
 version = "3.1.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "blinker" },
     { name = "click" },
@@ -1901,7 +1901,7 @@ wheels = [
 [[package]]
 name = "flask-cors"
 version = "6.0.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "flask" },
     { name = "werkzeug" },
@@ -1914,7 +1914,7 @@ wheels = [
 [[package]]
 name = "flask-wtf"
 version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "flask" },
     { name = "itsdangerous" },
@@ -1928,7 +1928,7 @@ wheels = [
 [[package]]
 name = "flatbuffers"
 version = "25.12.19"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
 ]
@@ -1965,7 +1965,7 @@ dev = [{ name = "pytest" }]
 [[package]]
 name = "fonttools"
 version = "4.63.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/84/69/c97f2c18e0db87d2c7b15da1974dace76ae938f1cfa22e2727a648b7ed43/fonttools-4.63.0.tar.gz", hash = "sha256:caeb583deeb5168e694b65cda8b4ee62abedfa66cf88488734466f2366b9c4e0", size = 3597189, upload-time = "2026-05-14T12:04:30.958Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f2/c9/4141c90a90db20f807c7e10bfd689fe53eb8f7f4caff58ee4d4dfe46919f/fonttools-4.63.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e3297a6a4059b4acc3a1e9a8b04741f240a80044eef08ebd32e8b5bcdddce75b", size = 2884632, upload-time = "2026-05-14T12:02:38.56Z" },
@@ -2022,7 +2022,7 @@ wheels = [
 [[package]]
 name = "frozenlist"
 version = "1.8.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2d/f5/c831fac6cc817d26fd54c7eaccd04ef7e0288806943f7cc5bbf69f3ac1f0/frozenlist-1.8.0.tar.gz", hash = "sha256:3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad", size = 45875, upload-time = "2025-10-06T05:38:17.865Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/4a/557715d5047da48d54e659203b9335be7bfaafda2c3f627b7c47e0b3aaf3/frozenlist-1.8.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b37f6d31b3dcea7deb5e9696e529a6aa4a898adc33db82da12e4c60a7c4d2011", size = 86230, upload-time = "2025-10-06T05:35:23.699Z" },
@@ -2143,7 +2143,7 @@ wheels = [
 [[package]]
 name = "fsspec"
 version = "2026.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/51/7c/f60c259dcbf4f0c47cc4ddb8f7720d2dcdc8888c8e5ad84c73ea4531cc5b/fsspec-2026.2.0.tar.gz", hash = "sha256:6544e34b16869f5aacd5b90bdf1a71acb37792ea3ddf6125ee69a22a53fb8bff", size = 313441, upload-time = "2026-02-05T21:50:53.743Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl", hash = "sha256:98de475b5cb3bd66bedd5c4679e87b4fdfe1a3bf4d707b151b3c07e58c9a2437", size = 202505, upload-time = "2026-02-05T21:50:51.819Z" },
@@ -2157,7 +2157,7 @@ http = [
 [[package]]
 name = "gast"
 version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/91/f6/e73969782a2ecec280f8a176f2476149dd9dba69d5f8779ec6108a7721e6/gast-0.7.0.tar.gz", hash = "sha256:0bb14cd1b806722e91ddbab6fb86bba148c22b40e7ff11e248974e04c8adfdae", size = 33630, upload-time = "2025-11-29T15:30:05.266Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1d/33/f1c6a276de27b7d7339a34749cc33fa87f077f921969c47185d34a887ae2/gast-0.7.0-py3-none-any.whl", hash = "sha256:99cbf1365633a74099f69c59bd650476b96baa5ef196fec88032b00b31ba36f7", size = 22966, upload-time = "2025-11-29T15:30:03.983Z" },
@@ -2166,7 +2166,7 @@ wheels = [
 [[package]]
 name = "gitdb"
 version = "4.0.12"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "smmap" },
 ]
@@ -2178,7 +2178,7 @@ wheels = [
 [[package]]
 name = "gitpython"
 version = "3.1.50"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
@@ -2190,7 +2190,7 @@ wheels = [
 [[package]]
 name = "google-api-core"
 version = "2.30.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "google-auth" },
     { name = "googleapis-common-protos" },
@@ -2206,7 +2206,7 @@ wheels = [
 [[package]]
 name = "google-auth"
 version = "2.53.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "pyasn1-modules" },
@@ -2219,7 +2219,7 @@ wheels = [
 [[package]]
 name = "google-cloud-core"
 version = "2.6.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "google-api-core" },
     { name = "google-auth" },
@@ -2232,7 +2232,7 @@ wheels = [
 [[package]]
 name = "google-cloud-storage"
 version = "3.10.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "google-api-core" },
     { name = "google-auth" },
@@ -2249,7 +2249,7 @@ wheels = [
 [[package]]
 name = "google-crc32c"
 version = "1.8.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz", hash = "sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79", size = 14192, upload-time = "2025-12-16T00:35:25.142Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/95/ac/6f7bc93886a823ab545948c2dd48143027b2355ad1944c7cf852b338dc91/google_crc32c-1.8.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:0470b8c3d73b5f4e3300165498e4cf25221c7eb37f1159e221d1825b6df8a7ff", size = 31296, upload-time = "2025-12-16T00:19:07.261Z" },
@@ -2284,7 +2284,7 @@ wheels = [
 [[package]]
 name = "google-pasta"
 version = "0.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "six" },
 ]
@@ -2296,7 +2296,7 @@ wheels = [
 [[package]]
 name = "google-resumable-media"
 version = "2.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "google-crc32c" },
 ]
@@ -2308,7 +2308,7 @@ wheels = [
 [[package]]
 name = "googleapis-common-protos"
 version = "1.75.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
@@ -2320,7 +2320,7 @@ wheels = [
 [[package]]
 name = "graphene"
 version = "3.4.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "graphql-core" },
     { name = "graphql-relay" },
@@ -2335,7 +2335,7 @@ wheels = [
 [[package]]
 name = "graphql-core"
 version = "3.2.8"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/68/c5/36aa96205c3ecbb3d34c7c24189e4553c7ca2ebc7e1dd07432339b980272/graphql_core-3.2.8.tar.gz", hash = "sha256:015457da5d996c924ddf57a43f4e959b0b94fb695b85ed4c29446e508ed65cf3", size = 513181, upload-time = "2026-03-05T19:55:37.332Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/86/41/cb887d9afc5dabd78feefe6ccbaf83ff423c206a7a1b7aeeac05120b2125/graphql_core-3.2.8-py3-none-any.whl", hash = "sha256:cbee07bee1b3ed5e531723685369039f32ff815ef60166686e0162f540f1520c", size = 207349, upload-time = "2026-03-05T19:55:35.911Z" },
@@ -2344,7 +2344,7 @@ wheels = [
 [[package]]
 name = "graphql-relay"
 version = "3.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "graphql-core" },
 ]
@@ -2356,7 +2356,7 @@ wheels = [
 [[package]]
 name = "greenlet"
 version = "3.5.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6d/6e/802acd792aebb2256fbbee8cacf2727faaeb6f240ac11008f09eae4414bc/greenlet-3.5.1.tar.gz", hash = "sha256:5a56aeb7d5d9cc4b3a735efb5095bd4b4f6f0e4f93e5ca876d0e2315137b7829", size = 197356, upload-time = "2026-05-20T15:05:03.917Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1d/21/117c8710abb7f146d804a124c07eb5964a60b90d02b72452885aecc18efa/greenlet-3.5.1-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:7eacb17a9d41538a2bc4912eba5ef13823c83cb69e4d141d0813debe7163187f", size = 283510, upload-time = "2026-05-20T13:12:26.475Z" },
@@ -2426,7 +2426,7 @@ wheels = [
 [[package]]
 name = "griffelib"
 version = "2.0.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
@@ -2435,7 +2435,7 @@ wheels = [
 [[package]]
 name = "grpcio"
 version = "1.80.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
@@ -2496,7 +2496,7 @@ wheels = [
 [[package]]
 name = "gunicorn"
 version = "26.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "packaging" },
 ]
@@ -2508,7 +2508,7 @@ wheels = [
 [[package]]
 name = "h11"
 version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
@@ -2517,10 +2517,10 @@ wheels = [
 [[package]]
 name = "h5py"
 version = "3.14.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5d/57/dfb3c5c3f1bf5f5ef2e59a22dec4ff1f3d7408b55bfcefcfb0ea69ef21c6/h5py-3.14.0.tar.gz", hash = "sha256:2372116b2e0d5d3e5e705b7f663f7c8d96fa79a4052d250484ef91d24d6a08f4", size = 424323, upload-time = "2025-06-06T14:06:15.01Z" }
 wheels = [
@@ -2549,7 +2549,7 @@ wheels = [
 [[package]]
 name = "haystack-ai"
 version = "2.29.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "docstring-parser" },
     { name = "filetype" },
@@ -2560,10 +2560,10 @@ dependencies = [
     { name = "lazy-imports" },
     { name = "markupsafe" },
     { name = "more-itertools" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "openai" },
     { name = "posthog" },
     { name = "pydantic" },
@@ -2581,7 +2581,7 @@ wheels = [
 [[package]]
 name = "haystack-experimental"
 version = "0.19.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "haystack-ai" },
 ]
@@ -2593,7 +2593,7 @@ wheels = [
 [[package]]
 name = "hf-xet"
 version = "1.5.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/74/d8/5c06fc76461418326a7decf8367480c35be11a41fd938633929c60a9ec6b/hf_xet-1.5.0.tar.gz", hash = "sha256:e0fb0a34d9f406eed88233e829a67ec016bec5af19e480eac65a233ea289a948", size = 837196, upload-time = "2026-05-06T06:18:15.583Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/9b/6912c99070915a4f28119e3c5b52a9abd1eec0ad5cb293b8c967a0c6f5a2/hf_xet-1.5.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:7d70fe2ce97b9db73b9c9b9c81fe3693640aec83416a966c446afea54acfae3c", size = 4023383, upload-time = "2026-05-06T06:17:53.947Z" },
@@ -2625,7 +2625,7 @@ wheels = [
 [[package]]
 name = "httpcore"
 version = "1.0.9"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "h11" },
@@ -2638,7 +2638,7 @@ wheels = [
 [[package]]
 name = "httptools"
 version = "0.8.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/43/e5/d471fcb0e14523fe1c3f4ba58ca52480e7bd70ad7109a3846bc75892f7fb/httptools-0.8.0.tar.gz", hash = "sha256:6b2a32f18d97e16e90827d7a819ffa8dbd8cc245fc4e1fa9d1095b54ef4bd999", size = 271342, upload-time = "2026-05-25T22:17:48.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/40/b9/be66eb0decd730d89b9c94f930e4b8d87787b05724bb84af98bfd825f72c/httptools-0.8.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:bf3b6f807c8541503cecfbb8a8dffb385640d0d96102f3d112aa8740f9b7c826", size = 208805, upload-time = "2026-05-25T22:16:50.434Z" },
@@ -2688,7 +2688,7 @@ wheels = [
 [[package]]
 name = "httpx"
 version = "0.28.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "certifi" },
@@ -2703,7 +2703,7 @@ wheels = [
 [[package]]
 name = "httpx-sse"
 version = "0.4.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
@@ -2712,7 +2712,7 @@ wheels = [
 [[package]]
 name = "huey"
 version = "3.0.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e1/01/5f0fb711585af22412baee31a9a6a88975c33a58c57ec618e09be20bcc88/huey-3.0.1.tar.gz", hash = "sha256:83ca54fa77c4ee27349393212fc13088142244f491be903f620a9e46e8fca4ce", size = 253328, upload-time = "2026-05-14T15:35:02.809Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/37/1056e57ffb9d0fa1b859e02c9e5f7cf1e8276c8f5b610050e2a755f5c060/huey-3.0.1-py3-none-any.whl", hash = "sha256:5de8ff852021da670efe8d4d78db8719c0255ebbde0772766a0114f997ea61f6", size = 86331, upload-time = "2026-05-14T15:35:01.314Z" },
@@ -2721,7 +2721,7 @@ wheels = [
 [[package]]
 name = "huggingface-hub"
 version = "1.16.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "fsspec" },
@@ -2741,7 +2741,7 @@ wheels = [
 [[package]]
 name = "humanfriendly"
 version = "10.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "pyreadline3", marker = "sys_platform == 'win32'" },
 ]
@@ -2753,7 +2753,7 @@ wheels = [
 [[package]]
 name = "identify"
 version = "2.6.19"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
@@ -2762,7 +2762,7 @@ wheels = [
 [[package]]
 name = "idna"
 version = "3.17"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b9/28/99c51f664567218d824af024c0251650fb27e4ca066df188dab0769c5b91/idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f", size = 196048, upload-time = "2026-05-28T14:32:38.55Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c", size = 65316, upload-time = "2026-05-28T14:32:37.035Z" },
@@ -2771,7 +2771,7 @@ wheels = [
 [[package]]
 name = "imagesize"
 version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6c/e6/7bf14eeb8f8b7251141944835abd42eb20a658d89084b7e1f3e5fe394090/imagesize-2.0.0.tar.gz", hash = "sha256:8e8358c4a05c304f1fccf7ff96f036e7243a189e9e42e90851993c558cfe9ee3", size = 1773045, upload-time = "2026-03-03T14:18:29.941Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5f/53/fb7122b71361a0d121b669dcf3d31244ef75badbbb724af388948de543e2/imagesize-2.0.0-py2.py3-none-any.whl", hash = "sha256:5667c5bbb57ab3f1fa4bc366f4fbc971db3d5ed011fd2715fd8001f782718d96", size = 9441, upload-time = "2026-03-03T14:18:27.892Z" },
@@ -2780,7 +2780,7 @@ wheels = [
 [[package]]
 name = "importlib-metadata"
 version = "9.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "zipp" },
 ]
@@ -2792,7 +2792,7 @@ wheels = [
 [[package]]
 name = "iniconfig"
 version = "2.3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
@@ -2801,7 +2801,7 @@ wheels = [
 [[package]]
 name = "instructor"
 version = "1.15.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "docstring-parser" },
@@ -2823,7 +2823,7 @@ wheels = [
 [[package]]
 name = "isodate"
 version = "0.7.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload-time = "2024-10-08T23:04:11.5Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload-time = "2024-10-08T23:04:09.501Z" },
@@ -2832,7 +2832,7 @@ wheels = [
 [[package]]
 name = "itsdangerous"
 version = "2.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
@@ -2841,7 +2841,7 @@ wheels = [
 [[package]]
 name = "jaraco-classes"
 version = "3.4.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "more-itertools" },
 ]
@@ -2853,7 +2853,7 @@ wheels = [
 [[package]]
 name = "jaraco-context"
 version = "6.1.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "backports-tarfile", marker = "python_full_version < '3.12'" },
 ]
@@ -2865,7 +2865,7 @@ wheels = [
 [[package]]
 name = "jaraco-functools"
 version = "4.5.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "more-itertools" },
 ]
@@ -2877,7 +2877,7 @@ wheels = [
 [[package]]
 name = "jeepney"
 version = "0.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
@@ -2886,7 +2886,7 @@ wheels = [
 [[package]]
 name = "jinja2"
 version = "3.1.6"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
@@ -2898,7 +2898,7 @@ wheels = [
 [[package]]
 name = "jiter"
 version = "0.13.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0d/5e/4ec91646aee381d01cdb9974e30882c9cd3b8c5d1079d6b5ff4af522439a/jiter-0.13.0.tar.gz", hash = "sha256:f2839f9c2c7e2dffc1bc5929a510e14ce0a946be9365fd1219e7ef342dae14f4", size = 164847, upload-time = "2026-02-02T12:37:56.441Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/5a/41da76c5ea07bec1b0472b6b2fdb1b651074d504b19374d7e130e0cdfb25/jiter-0.13.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:2ffc63785fd6c7977defe49b9824ae6ce2b2e2b77ce539bdaf006c26da06342e", size = 311164, upload-time = "2026-02-02T12:35:17.688Z" },
@@ -2995,7 +2995,7 @@ wheels = [
 [[package]]
 name = "jmespath"
 version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
@@ -3004,7 +3004,7 @@ wheels = [
 [[package]]
 name = "joblib"
 version = "1.5.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
@@ -3013,7 +3013,7 @@ wheels = [
 [[package]]
 name = "joserfc"
 version = "1.6.8"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
@@ -3025,7 +3025,7 @@ wheels = [
 [[package]]
 name = "jsonpatch"
 version = "1.33"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "jsonpointer" },
 ]
@@ -3037,7 +3037,7 @@ wheels = [
 [[package]]
 name = "jsonpickle"
 version = "4.1.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8d/c0/dde9b4b42cc415b9579573f967f12efbb034e427a2a37e93ad5139891d87/jsonpickle-4.1.2.tar.gz", hash = "sha256:8afed18aa189fd81e2e833b426bb4af485594921f0b1d36c2001fc5637a2f210", size = 319120, upload-time = "2026-05-28T03:50:11.892Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a1/7b/fd3c7a09649aea9da1d3587aea624d8f9b29963dfd84a1bdb2aa93b36dac/jsonpickle-4.1.2-py3-none-any.whl", hash = "sha256:7ffe34426bc797684dbf1dc84185558bd864cd25b1ff5fb01b7405e392d0a937", size = 47203, upload-time = "2026-05-28T03:50:10.605Z" },
@@ -3046,7 +3046,7 @@ wheels = [
 [[package]]
 name = "jsonpointer"
 version = "3.1.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/18/c7/af399a2e7a67fd18d63c40c5e62d3af4e67b836a2107468b6a5ea24c4304/jsonpointer-3.1.1.tar.gz", hash = "sha256:0b801c7db33a904024f6004d526dcc53bbb8a4a0f4e32bfd10beadf60adf1900", size = 9068, upload-time = "2026-03-23T22:32:32.458Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/6a/a83720e953b1682d2d109d3c2dbb0bc9bf28cc1cbc205be4ef4be5da709d/jsonpointer-3.1.1-py3-none-any.whl", hash = "sha256:8ff8b95779d071ba472cf5bc913028df06031797532f08a7d5b602d8b2a488ca", size = 7659, upload-time = "2026-03-23T22:32:31.568Z" },
@@ -3055,7 +3055,7 @@ wheels = [
 [[package]]
 name = "jsonref"
 version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/aa/0d/c1f3277e90ccdb50d33ed5ba1ec5b3f0a242ed8c1b1a85d3afeb68464dca/jsonref-1.1.0.tar.gz", hash = "sha256:32fe8e1d85af0fdefbebce950af85590b22b60f9e95443176adbde4e1ecea552", size = 8814, upload-time = "2023-01-16T16:10:04.455Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/ec/e1db9922bceb168197a558a2b8c03a7963f1afe93517ddd3cf99f202f996/jsonref-1.1.0-py3-none-any.whl", hash = "sha256:590dc7773df6c21cbf948b5dac07a72a251db28b0238ceecce0a2abfa8ec30a9", size = 9425, upload-time = "2023-01-16T16:10:02.255Z" },
@@ -3064,13 +3064,13 @@ wheels = [
 [[package]]
 name = "jsonschema"
 version = "4.26.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "jsonschema-specifications" },
     { name = "referencing" },
-    { name = "rpds-py", version = "0.30.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "rpds-py", version = "2026.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "rpds-py", version = "0.30.0", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "rpds-py", version = "2026.5.1", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
 wheels = [
@@ -3080,7 +3080,7 @@ wheels = [
 [[package]]
 name = "jsonschema-path"
 version = "0.5.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "pathable" },
@@ -3095,7 +3095,7 @@ wheels = [
 [[package]]
 name = "jsonschema-specifications"
 version = "2025.9.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "referencing" },
 ]
@@ -3107,7 +3107,7 @@ wheels = [
 [[package]]
 name = "jupyter-client"
 version = "8.8.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "jupyter-core" },
     { name = "python-dateutil" },
@@ -3123,7 +3123,7 @@ wheels = [
 [[package]]
 name = "jupyter-core"
 version = "5.9.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "platformdirs" },
     { name = "traitlets" },
@@ -3136,7 +3136,7 @@ wheels = [
 [[package]]
 name = "jupyterlab-pygments"
 version = "0.3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/90/51/9187be60d989df97f5f0aba133fa54e7300f17616e065d1ada7d7646b6d6/jupyterlab_pygments-0.3.0.tar.gz", hash = "sha256:721aca4d9029252b11cfa9d185e5b5af4d54772bb8072f9b7036f4170054d35d", size = 512900, upload-time = "2023-11-23T09:26:37.44Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/dd/ead9d8ea85bf202d90cc513b533f9c363121c7792674f78e0d8a854b63b4/jupyterlab_pygments-0.3.0-py3-none-any.whl", hash = "sha256:841a89020971da1d8693f1a99997aefc5dc424bb1b251fd6322462a1b8842780", size = 15884, upload-time = "2023-11-23T09:26:34.325Z" },
@@ -3145,7 +3145,7 @@ wheels = [
 [[package]]
 name = "keras"
 version = "3.12.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 resolution-markers = [
     "python_full_version < '3.11'",
 ]
@@ -3154,7 +3154,7 @@ dependencies = [
     { name = "h5py", marker = "python_full_version < '3.11'" },
     { name = "ml-dtypes", marker = "python_full_version < '3.11'" },
     { name = "namex", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version < '3.11'" },
     { name = "optree", marker = "python_full_version < '3.11'" },
     { name = "packaging", marker = "python_full_version < '3.11'" },
     { name = "rich", marker = "python_full_version < '3.11'" },
@@ -3167,7 +3167,7 @@ wheels = [
 [[package]]
 name = "keras"
 version = "3.14.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
     "python_full_version == '3.13.*'",
@@ -3179,7 +3179,7 @@ dependencies = [
     { name = "h5py", marker = "python_full_version >= '3.11'" },
     { name = "ml-dtypes", marker = "python_full_version >= '3.11'" },
     { name = "namex", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "optree", marker = "python_full_version >= '3.11'" },
     { name = "packaging", marker = "python_full_version >= '3.11'" },
     { name = "rich", marker = "python_full_version >= '3.11'" },
@@ -3192,7 +3192,7 @@ wheels = [
 [[package]]
 name = "keyring"
 version = "25.7.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
     { name = "jaraco-classes" },
@@ -3210,7 +3210,7 @@ wheels = [
 [[package]]
 name = "kiwisolver"
 version = "1.5.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d0/67/9c61eccb13f0bdca9307614e782fec49ffdde0f7a2314935d489fa93cd9c/kiwisolver-1.5.0.tar.gz", hash = "sha256:d4193f3d9dc3f6f79aaed0e5637f45d98850ebf01f7ca20e69457f3e8946b66a", size = 103482, upload-time = "2026-03-09T13:15:53.382Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/f8/06549565caa026e540b7e7bab5c5a90eb7ca986015f4c48dace243cd24d9/kiwisolver-1.5.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:32cc0a5365239a6ea0c6ed461e8838d053b57e397443c0ca894dcc8e388d4374", size = 122802, upload-time = "2026-03-09T13:12:37.515Z" },
@@ -3334,7 +3334,7 @@ wheels = [
 [[package]]
 name = "knack"
 version = "0.12.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "argcomplete" },
     { name = "jmespath" },
@@ -3351,7 +3351,7 @@ wheels = [
 [[package]]
 name = "kubernetes"
 version = "36.0.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "certifi" },
@@ -3372,7 +3372,7 @@ wheels = [
 [[package]]
 name = "langchain"
 version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
@@ -3386,7 +3386,7 @@ wheels = [
 [[package]]
 name = "langchain-classic"
 version = "1.0.7"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "langchain-core", marker = "python_full_version >= '3.11'" },
     { name = "langchain-text-splitters", marker = "python_full_version >= '3.11'" },
@@ -3404,7 +3404,7 @@ wheels = [
 [[package]]
 name = "langchain-community"
 version = "0.3.31"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 resolution-markers = [
     "python_full_version < '3.11'",
 ]
@@ -3415,7 +3415,7 @@ dependencies = [
     { name = "langchain", marker = "python_full_version < '3.11'" },
     { name = "langchain-core", marker = "python_full_version < '3.11'" },
     { name = "langsmith", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version < '3.11'" },
     { name = "pydantic-settings", marker = "python_full_version < '3.11'" },
     { name = "pyyaml", marker = "python_full_version < '3.11'" },
     { name = "requests", marker = "python_full_version < '3.11'" },
@@ -3430,7 +3430,7 @@ wheels = [
 [[package]]
 name = "langchain-community"
 version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
     "python_full_version == '3.13.*'",
@@ -3443,7 +3443,7 @@ dependencies = [
     { name = "langchain-classic", marker = "python_full_version >= '3.11'" },
     { name = "langchain-core", marker = "python_full_version >= '3.11'" },
     { name = "langsmith", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pydantic-settings", marker = "python_full_version >= '3.11'" },
     { name = "pyyaml", marker = "python_full_version >= '3.11'" },
     { name = "requests", marker = "python_full_version >= '3.11'" },
@@ -3458,7 +3458,7 @@ wheels = [
 [[package]]
 name = "langchain-core"
 version = "1.4.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "jsonpatch" },
     { name = "langchain-protocol" },
@@ -3478,7 +3478,7 @@ wheels = [
 [[package]]
 name = "langchain-openai"
 version = "1.2.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "openai" },
@@ -3492,7 +3492,7 @@ wheels = [
 [[package]]
 name = "langchain-protocol"
 version = "0.0.16"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
@@ -3504,7 +3504,7 @@ wheels = [
 [[package]]
 name = "langchain-text-splitters"
 version = "1.1.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "langchain-core", marker = "python_full_version >= '3.11'" },
 ]
@@ -3516,7 +3516,7 @@ wheels = [
 [[package]]
 name = "langgraph"
 version = "1.2.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
@@ -3533,7 +3533,7 @@ wheels = [
 [[package]]
 name = "langgraph-checkpoint"
 version = "4.1.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "ormsgpack" },
@@ -3546,7 +3546,7 @@ wheels = [
 [[package]]
 name = "langgraph-prebuilt"
 version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
@@ -3559,7 +3559,7 @@ wheels = [
 [[package]]
 name = "langgraph-sdk"
 version = "0.3.15"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "orjson" },
@@ -3572,7 +3572,7 @@ wheels = [
 [[package]]
 name = "langsmith"
 version = "0.8.8"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "orjson", marker = "platform_python_implementation != 'PyPy'" },
@@ -3593,7 +3593,7 @@ wheels = [
 [[package]]
 name = "lazy-imports"
 version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/25/67/04432aae0c1e2729bff14e1841f4a3fb63a9e354318e66622251487760c3/lazy_imports-1.2.0.tar.gz", hash = "sha256:3c546b3c1e7c4bf62a07f897f6179d9feda6118e71ef6ecc47a339cab3d2e2d9", size = 24470, upload-time = "2025-12-28T13:51:51.218Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cd/62/60ed24fa8707f10c1c5aef94791252b820be3dd6bdfc6e2fcdb08bc8912f/lazy_imports-1.2.0-py3-none-any.whl", hash = "sha256:97134d6552e2ba16f1a278e316f05313ab73b360e848e40d593d08a5c2406fdf", size = 18681, upload-time = "2025-12-28T13:51:49.802Z" },
@@ -3602,7 +3602,7 @@ wheels = [
 [[package]]
 name = "libclang"
 version = "18.1.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6e/5c/ca35e19a4f142adffa27e3d652196b7362fa612243e2b916845d801454fc/libclang-18.1.1.tar.gz", hash = "sha256:a1214966d08d73d971287fc3ead8dfaf82eb07fb197680d8b3859dbbbbf78250", size = 39612, upload-time = "2024-03-17T16:04:37.434Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4b/49/f5e3e7e1419872b69f6f5e82ba56e33955a74bd537d8a1f5f1eff2f3668a/libclang-18.1.1-1-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:0b2e143f0fac830156feb56f9231ff8338c20aecfe72b4ffe96f19e5a1dbb69a", size = 25836045, upload-time = "2024-06-30T17:40:31.646Z" },
@@ -3619,7 +3619,7 @@ wheels = [
 [[package]]
 name = "limits"
 version = "5.8.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "deprecated" },
     { name = "packaging" },
@@ -3633,7 +3633,7 @@ wheels = [
 [[package]]
 name = "mako"
 version = "1.3.12"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
@@ -3645,7 +3645,7 @@ wheels = [
 [[package]]
 name = "markdown-it-py"
 version = "4.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "mdurl" },
 ]
@@ -3657,7 +3657,7 @@ wheels = [
 [[package]]
 name = "markupsafe"
 version = "3.0.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e8/4b/3541d44f3937ba468b75da9eebcae497dcf67adb65caa16760b0a6807ebb/markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559", size = 11631, upload-time = "2025-09-27T18:36:05.558Z" },
@@ -3742,7 +3742,7 @@ wheels = [
 [[package]]
 name = "marshmallow"
 version = "3.26.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "packaging" },
 ]
@@ -3754,15 +3754,15 @@ wheels = [
 [[package]]
 name = "matplotlib"
 version = "3.10.9"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
-    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "cycler" },
     { name = "fonttools" },
     { name = "kiwisolver" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "packaging" },
     { name = "pillow" },
     { name = "pyparsing" },
@@ -3829,7 +3829,7 @@ wheels = [
 [[package]]
 name = "mcp"
 version = "1.27.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "httpx" },
@@ -3854,7 +3854,7 @@ wheels = [
 [[package]]
 name = "mdurl"
 version = "0.1.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
@@ -3863,7 +3863,7 @@ wheels = [
 [[package]]
 name = "mistune"
 version = "3.2.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
@@ -3875,10 +3875,10 @@ wheels = [
 [[package]]
 name = "ml-dtypes"
 version = "0.5.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/4a/c27b42ed9b1c7d13d9ba8b6905dece787d6259152f2309338aed29b2447b/ml_dtypes-0.5.4.tar.gz", hash = "sha256:8ab06a50fb9bf9666dd0fe5dfb4676fa2b0ac0f31ecff72a6c3af8e22c063453", size = 692314, upload-time = "2025-11-17T22:32:31.031Z" }
 wheels = [
@@ -3940,8 +3940,8 @@ dependencies = [
     { name = "huey" },
     { name = "importlib-metadata" },
     { name = "matplotlib" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-proto" },
     { name = "opentelemetry-sdk" },
@@ -3953,10 +3953,10 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "requests" },
-    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "skops" },
     { name = "sqlalchemy" },
     { name = "sqlparse" },
@@ -4080,10 +4080,10 @@ docs = [
     { name = "flask-wtf" },
     { name = "haystack-ai" },
     { name = "instructor" },
-    { name = "keras", version = "3.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "keras", version = "3.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "langchain-community", version = "0.3.31", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "langchain-community", version = "0.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "keras", version = "3.12.2", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "keras", version = "3.14.1", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "langchain-community", version = "0.3.31", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "langchain-community", version = "0.4.2", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "nbconvert" },
     { name = "nbformat" },
     { name = "openai" },
@@ -4092,8 +4092,8 @@ docs = [
     { name = "pyspark" },
     { name = "ragas" },
     { name = "sphinx" },
-    { name = "sphinx-autobuild", version = "2024.10.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "sphinx-autobuild", version = "2025.8.25", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "sphinx-autobuild", version = "2024.10.3", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx-autobuild", version = "2025.8.25", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinx-click" },
     { name = "sphinx-reredirects" },
     { name = "sphinx-tabs" },
@@ -4338,7 +4338,7 @@ test = [
 [[package]]
 name = "mlflow-dbstore"
 version = "1.0.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "mlflow" },
 ]
@@ -4350,7 +4350,7 @@ wheels = [
 [[package]]
 name = "mlflow-jfrog-plugin"
 version = "1.0.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "mlflow" },
     { name = "requests" },
@@ -4363,7 +4363,7 @@ wheels = [
 [[package]]
 name = "mlflow-skinny"
 version = "3.12.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "cachetools" },
     { name = "click" },
@@ -4399,7 +4399,7 @@ source = { editable = "tests/resources/mlflow-test-plugin" }
 [[package]]
 name = "more-itertools"
 version = "11.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/de/1d/f4da6f02cdffe04d6362210b807146a26044c88d839208aec273bb0d9184/more_itertools-11.1.0.tar.gz", hash = "sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d", size = 145772, upload-time = "2026-05-22T14:14:29.909Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl", hash = "sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192", size = 72226, upload-time = "2026-05-22T14:14:28.824Z" },
@@ -4408,7 +4408,7 @@ wheels = [
 [[package]]
 name = "msal"
 version = "1.37.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "pyjwt", extra = ["crypto"] },
@@ -4422,7 +4422,7 @@ wheels = [
 [[package]]
 name = "msal-extensions"
 version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "msal" },
 ]
@@ -4434,7 +4434,7 @@ wheels = [
 [[package]]
 name = "msrest"
 version = "0.7.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "azure-core" },
     { name = "certifi" },
@@ -4450,7 +4450,7 @@ wheels = [
 [[package]]
 name = "msrestazure"
 version = "0.6.4.post1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "adal" },
     { name = "msrest" },
@@ -4464,7 +4464,7 @@ wheels = [
 [[package]]
 name = "multidict"
 version = "6.7.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
@@ -4602,7 +4602,7 @@ wheels = [
 [[package]]
 name = "multiprocess"
 version = "0.70.19"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "dill" },
 ]
@@ -4625,7 +4625,7 @@ wheels = [
 [[package]]
 name = "mypy"
 version = "1.17.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "mypy-extensions" },
     { name = "pathspec" },
@@ -4670,7 +4670,7 @@ wheels = [
 [[package]]
 name = "mypy-extensions"
 version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
@@ -4679,7 +4679,7 @@ wheels = [
 [[package]]
 name = "namex"
 version = "0.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0c/c0/ee95b28f029c73f8d49d8f52edaed02a1d4a9acb8b69355737fdb1faa191/namex-0.1.0.tar.gz", hash = "sha256:117f03ccd302cc48e3f5c58a296838f6b89c83455ab8683a1e85f2a430aa4306", size = 6649, upload-time = "2025-05-26T23:17:38.918Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/bc/465daf1de06409cdd4532082806770ee0d8d7df434da79c76564d0f69741/namex-0.1.0-py3-none-any.whl", hash = "sha256:e2012a474502f1e2251267062aae3114611f07df4224b6e06334c57b0f2ce87c", size = 5905, upload-time = "2025-05-26T23:17:37.695Z" },
@@ -4688,7 +4688,7 @@ wheels = [
 [[package]]
 name = "narwhals"
 version = "2.21.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cf/a0/6198c56d42ef2f3c6ed0c42ba30dbcefdc86a91262d7d449010770ae085b/narwhals-2.21.2.tar.gz", hash = "sha256:5c5b2d0b47aef7c73ea412cfcbcd467f2f2d5be73e3c2ab19d78f4a97718790a", size = 632176, upload-time = "2026-05-16T08:49:08.314Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1d/77/928ea2e70641ca177a11140062cc5840d421795f2e82749d408d0cce900a/narwhals-2.21.2-py3-none-any.whl", hash = "sha256:7bb57c3700486039215455b9bf2d64261915cc0fd845cc30272d631df696b251", size = 451201, upload-time = "2026-05-16T08:49:05.536Z" },
@@ -4697,7 +4697,7 @@ wheels = [
 [[package]]
 name = "nbclient"
 version = "0.10.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "jupyter-client" },
     { name = "jupyter-core" },
@@ -4712,7 +4712,7 @@ wheels = [
 [[package]]
 name = "nbconvert"
 version = "7.17.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
     { name = "bleach", extra = ["css"] },
@@ -4737,7 +4737,7 @@ wheels = [
 [[package]]
 name = "nbformat"
 version = "5.10.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "fastjsonschema" },
     { name = "jsonschema" },
@@ -4752,7 +4752,7 @@ wheels = [
 [[package]]
 name = "ndg-httpsclient"
 version = "0.5.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "pyasn1" },
     { name = "pyopenssl" },
@@ -4765,7 +4765,7 @@ wheels = [
 [[package]]
 name = "nest-asyncio"
 version = "1.6.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
@@ -4774,7 +4774,7 @@ wheels = [
 [[package]]
 name = "networkx"
 version = "3.4.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 resolution-markers = [
     "python_full_version < '3.11'",
 ]
@@ -4786,7 +4786,7 @@ wheels = [
 [[package]]
 name = "networkx"
 version = "3.6.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
     "python_full_version == '3.13.*'",
@@ -4801,7 +4801,7 @@ wheels = [
 [[package]]
 name = "nodeenv"
 version = "1.10.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
@@ -4810,7 +4810,7 @@ wheels = [
 [[package]]
 name = "numpy"
 version = "2.2.6"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 resolution-markers = [
     "python_full_version < '3.11'",
 ]
@@ -4875,7 +4875,7 @@ wheels = [
 [[package]]
 name = "numpy"
 version = "2.4.6"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
     "python_full_version == '3.13.*'",
@@ -4960,7 +4960,7 @@ wheels = [
 [[package]]
 name = "oauthlib"
 version = "3.3.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
@@ -4969,7 +4969,7 @@ wheels = [
 [[package]]
 name = "openai"
 version = "2.38.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "distro" },
@@ -4988,7 +4988,7 @@ wheels = [
 [[package]]
 name = "openapi-pydantic"
 version = "0.5.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "pydantic" },
 ]
@@ -5000,7 +5000,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-api"
 version = "1.42.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
@@ -5012,7 +5012,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-common"
 version = "1.42.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "opentelemetry-proto" },
 ]
@@ -5024,7 +5024,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-grpc"
 version = "1.42.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
     { name = "grpcio" },
@@ -5042,7 +5042,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-http"
 version = "1.42.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
     { name = "opentelemetry-api" },
@@ -5060,7 +5060,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-proto"
 version = "1.42.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
@@ -5072,7 +5072,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-sdk"
 version = "1.42.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-semantic-conventions" },
@@ -5086,7 +5086,7 @@ wheels = [
 [[package]]
 name = "opentelemetry-semantic-conventions"
 version = "0.63b1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "typing-extensions" },
@@ -5099,7 +5099,7 @@ wheels = [
 [[package]]
 name = "opt-einsum"
 version = "3.4.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8c/b9/2ac072041e899a52f20cf9510850ff58295003aa75525e58343591b0cbfb/opt_einsum-3.4.0.tar.gz", hash = "sha256:96ca72f1b886d148241348783498194c577fa30a8faac108586b14f1ba4473ac", size = 63004, upload-time = "2024-09-26T14:33:24.483Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl", hash = "sha256:69bb92469f86a1565195ece4ac0323943e83477171b91d24c35afe028a90d7cd", size = 71932, upload-time = "2024-09-26T14:33:23.039Z" },
@@ -5108,7 +5108,7 @@ wheels = [
 [[package]]
 name = "optree"
 version = "0.19.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
@@ -5206,7 +5206,7 @@ wheels = [
 [[package]]
 name = "orjson"
 version = "3.11.9"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7e/0c/964746fcafbd16f8ff53219ad9f6b412b34f345c75f384ad434ceaadb538/orjson-3.11.9.tar.gz", hash = "sha256:4fef17e1f8722c11587a6ef18e35902450221da0028e65dbaaa543619e68e48f", size = 5599163, upload-time = "2026-05-06T15:11:08.309Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/5d/b95ca542a001135cc250a49370f282f578c8f4e46cc8617d73775297eea8/orjson-3.11.9-cp310-cp310-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:135869ef917b8704ea0a94e01620e0c05021c15c52036e4663baffe75e72f8ce", size = 228986, upload-time = "2026-05-06T15:09:14.765Z" },
@@ -5287,7 +5287,7 @@ wheels = [
 [[package]]
 name = "ormsgpack"
 version = "1.12.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/12/0c/f1761e21486942ab9bb6feaebc610fa074f7c5e496e6962dea5873348077/ormsgpack-1.12.2.tar.gz", hash = "sha256:944a2233640273bee67521795a73cf1e959538e0dfb7ac635505010455e53b33", size = 39031, upload-time = "2026-01-18T20:55:28.023Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/93/fa/a91f70829ebccf6387c4946e0a1a109f6ba0d6a28d65f628bedfad94b890/ormsgpack-1.12.2-cp310-cp310-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:c1429217f8f4d7fcb053523bbbac6bed5e981af0b85ba616e6df7cce53c19657", size = 378262, upload-time = "2026-01-18T20:55:22.284Z" },
@@ -5343,7 +5343,7 @@ wheels = [
 [[package]]
 name = "oss2"
 version = "2.13.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "aliyun-python-sdk-core-v3" },
     { name = "aliyun-python-sdk-kms" },
@@ -5357,7 +5357,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/ee/95/64d63ba18d07e5903
 [[package]]
 name = "packaging"
 version = "25.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
@@ -5366,10 +5366,10 @@ wheels = [
 [[package]]
 name = "pandas"
 version = "2.3.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "python-dateutil" },
     { name = "pytz" },
     { name = "tzdata" },
@@ -5428,7 +5428,7 @@ wheels = [
 [[package]]
 name = "pandocfilters"
 version = "1.5.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/70/6f/3dd4940bbe001c06a65f88e36bad298bc7a0de5036115639926b0c5c0458/pandocfilters-1.5.1.tar.gz", hash = "sha256:002b4a555ee4ebc03f8b66307e287fa492e4a77b4ea14d3f934328297bb4939e", size = 8454, upload-time = "2024-01-18T20:08:13.726Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/af/4fbc8cab944db5d21b7e2a5b8e9211a03a79852b1157e2c102fcc61ac440/pandocfilters-1.5.1-py2.py3-none-any.whl", hash = "sha256:93be382804a9cdb0a7267585f157e5d1731bbe5545a85b268d6f5fe6232de2bc", size = 8663, upload-time = "2024-01-18T20:08:11.28Z" },
@@ -5437,7 +5437,7 @@ wheels = [
 [[package]]
 name = "paramiko"
 version = "3.5.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "bcrypt" },
     { name = "cryptography" },
@@ -5451,7 +5451,7 @@ wheels = [
 [[package]]
 name = "pathable"
 version = "0.6.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/66/f3/5a20387de9bcd0607871bfc2198ee0e15836da7baa4592ccd7f24c27c986/pathable-0.6.0.tar.gz", hash = "sha256:6404b8b82aef5ff0fd478934137128b99b12212ba35afdde5525ca4f8388ea58", size = 18970, upload-time = "2026-05-19T18:15:11.911Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/e8/6d75ffd9784bce2e93d1ae4415649427e39a53bb172d4672b2b59c6f0a7b/pathable-0.6.0-py3-none-any.whl", hash = "sha256:82c4ca6c98c502ad12e0d4e9779b6210afee93c38990988c8c5d1b49bdcdf566", size = 18983, upload-time = "2026-05-19T18:15:10.728Z" },
@@ -5460,7 +5460,7 @@ wheels = [
 [[package]]
 name = "pathspec"
 version = "0.12.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
@@ -5469,7 +5469,7 @@ wheels = [
 [[package]]
 name = "pillow"
 version = "12.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/aa/d0b28e1c811cd4d5f5c2bfe2e022292bd255ae5744a3b9ac7d6c8f72dd75/pillow-12.2.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:a4e8f36e677d3336f35089648c8955c51c6d386a13cf6ee9c189c5f5bd713a9f", size = 5354355, upload-time = "2026-04-01T14:42:15.402Z" },
@@ -5567,7 +5567,7 @@ wheels = [
 [[package]]
 name = "pip"
 version = "26.1.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
@@ -5576,7 +5576,7 @@ wheels = [
 [[package]]
 name = "pkginfo"
 version = "1.12.1.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/03/e26bf3d6453b7fda5bd2b84029a426553bb373d6277ef6b5ac8863421f87/pkginfo-1.12.1.2.tar.gz", hash = "sha256:5cd957824ac36f140260964eba3c6be6442a8359b8c48f4adf90210f33a04b7b", size = 451828, upload-time = "2025-02-19T15:27:37.188Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/3d/f4f2ba829efb54b6cd2d91349c7463316a9cc55a43fc980447416c88540f/pkginfo-1.12.1.2-py3-none-any.whl", hash = "sha256:c783ac885519cab2c34927ccfa6bf64b5a704d7c69afaea583dd9b7afe969343", size = 32717, upload-time = "2025-02-19T15:27:33.071Z" },
@@ -5585,7 +5585,7 @@ wheels = [
 [[package]]
 name = "platformdirs"
 version = "4.10.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
@@ -5594,7 +5594,7 @@ wheels = [
 [[package]]
 name = "plotly"
 version = "6.7.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "narwhals" },
     { name = "packaging" },
@@ -5607,7 +5607,7 @@ wheels = [
 [[package]]
 name = "pluggy"
 version = "1.6.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
@@ -5616,7 +5616,7 @@ wheels = [
 [[package]]
 name = "polars"
 version = "1.41.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "polars-runtime-32" },
 ]
@@ -5628,7 +5628,7 @@ wheels = [
 [[package]]
 name = "polars-runtime-32"
 version = "1.41.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/56/54e3ea0e9b64f327179049e4742241cc6b1d3e8fa414b05a057dd26df367/polars_runtime_32-1.41.2.tar.gz", hash = "sha256:7af09ec1ab053da2c9669e8d15f809a4083a29be05db57111688b8051062af56", size = 2989474, upload-time = "2026-05-29T17:39:17.257Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d6/9b/fe72a3811c0357cdb06c67bdc7695fa1623ad47948fc523195f5ac31037f/polars_runtime_32-1.41.2-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:95a08346dac337357cdb825c8076df7d36da54c4caa59a5cb41d0a30691c5edd", size = 52265283, upload-time = "2026-05-29T17:37:09.407Z" },
@@ -5644,7 +5644,7 @@ wheels = [
 [[package]]
 name = "portalocker"
 version = "3.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "pywin32", marker = "sys_platform == 'win32'" },
 ]
@@ -5656,7 +5656,7 @@ wheels = [
 [[package]]
 name = "posthog"
 version = "7.16.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "backoff" },
     { name = "distro" },
@@ -5671,7 +5671,7 @@ wheels = [
 [[package]]
 name = "pre-commit"
 version = "4.0.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "cfgv" },
     { name = "identify" },
@@ -5687,7 +5687,7 @@ wheels = [
 [[package]]
 name = "prettytable"
 version = "3.17.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "wcwidth" },
 ]
@@ -5699,7 +5699,7 @@ wheels = [
 [[package]]
 name = "prometheus-client"
 version = "0.25.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
@@ -5708,7 +5708,7 @@ wheels = [
 [[package]]
 name = "prometheus-flask-exporter"
 version = "0.23.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "flask" },
     { name = "prometheus-client" },
@@ -5721,7 +5721,7 @@ wheels = [
 [[package]]
 name = "propcache"
 version = "0.5.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ec/44/c87281c333769159c50594f22610f77398a47ccbfbbf23074e744e86f87c/propcache-0.5.2.tar.gz", hash = "sha256:01c4fc7480cd0598bb4b57022df55b9ca296da7fc5a8760bd8451a7e63a7d427", size = 50208, upload-time = "2026-05-08T21:02:12.199Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/56/030b7b4719d53085722893e0009dffb9236aa10bca1b12121bdc5626ef16/propcache-0.5.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d5a81be28596d6559f6131ef33e10200de6e17643b3c74ce03f9eb103be6ae8b", size = 93417, upload-time = "2026-05-08T20:59:15.597Z" },
@@ -5849,7 +5849,7 @@ wheels = [
 [[package]]
 name = "proto-plus"
 version = "1.28.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
@@ -5861,7 +5861,7 @@ wheels = [
 [[package]]
 name = "protobuf"
 version = "6.33.6"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
@@ -5876,7 +5876,7 @@ wheels = [
 [[package]]
 name = "psutil"
 version = "7.2.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
@@ -5904,7 +5904,7 @@ wheels = [
 [[package]]
 name = "psycopg2-binary"
 version = "2.9.12"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2a/60/a3624f79acea344c16fbef3a94d28b89a8042ddfb8f3e4ca83f538671409/psycopg2_binary-2.9.12.tar.gz", hash = "sha256:5ac9444edc768c02a6b6a591f070b8aae28ff3a99be57560ac996001580f294c", size = 379686, upload-time = "2026-04-21T09:40:34.304Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/80/49bacf9e51617d8309f6f0123e29edc793f6f5f6700c7d1f1b20782fbb37/psycopg2_binary-2.9.12-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9b818ceff717f98851a64bffd4c5eb5b3059ae280276dcecc52ac658dcf006a4", size = 3712314, upload-time = "2026-04-20T23:33:31.363Z" },
@@ -5967,7 +5967,7 @@ wheels = [
 [[package]]
 name = "py-cpuinfo"
 version = "9.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716, upload-time = "2022-10-25T20:38:06.303Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335, upload-time = "2022-10-25T20:38:27.636Z" },
@@ -5976,7 +5976,7 @@ wheels = [
 [[package]]
 name = "py-key-value-aio"
 version = "0.4.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "beartype" },
     { name = "typing-extensions" },
@@ -5988,8 +5988,8 @@ wheels = [
 
 [package.optional-dependencies]
 filetree = [
-    { name = "aiofile", version = "3.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "aiofile", version = "3.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "aiofile", version = "3.9.0", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "aiofile", version = "3.11.1", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "anyio" },
 ]
 keyring = [
@@ -6002,7 +6002,7 @@ memory = [
 [[package]]
 name = "py4j"
 version = "0.10.9.9"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/38/31/0b210511177070c8d5d3059556194352e5753602fa64b85b7ab81ec1a009/py4j-0.10.9.9.tar.gz", hash = "sha256:f694cad19efa5bd1dee4f3e5270eb406613c974394035e5bfc4ec1aba870b879", size = 761089, upload-time = "2025-01-15T03:53:18.624Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/db/ea0203e495be491c85af87b66e37acfd3bf756fd985f87e46fc5e3bf022c/py4j-0.10.9.9-py2.py3-none-any.whl", hash = "sha256:c7c26e4158defb37b0bb124933163641a2ff6e3a3913f7811b0ddbe07ed61533", size = 203008, upload-time = "2025-01-15T03:53:15.648Z" },
@@ -6011,7 +6011,7 @@ wheels = [
 [[package]]
 name = "pyarrow"
 version = "24.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/91/13/13e1069b351bdc3881266e11147ffccf687505dbb0ea74036237f5d454a5/pyarrow-24.0.0.tar.gz", hash = "sha256:85fe721a14dd823aca09127acbb06c3ca723efbd436c004f16bca601b04dcc83", size = 1180261, upload-time = "2026-04-21T10:51:25.837Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/bf/a34fee1d624152124fa8355c42f34195ad5fe5233ce5bb87946432047d52/pyarrow-24.0.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:7c2b98645d576a0b9616892ead22b64a83a5f043c5e2ca15ebcefcb5b70c80cb", size = 35076681, upload-time = "2026-04-21T08:51:46.845Z" },
@@ -6068,7 +6068,7 @@ wheels = [
 [[package]]
 name = "pyasn1"
 version = "0.6.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
@@ -6077,7 +6077,7 @@ wheels = [
 [[package]]
 name = "pyasn1-modules"
 version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "pyasn1" },
 ]
@@ -6089,7 +6089,7 @@ wheels = [
 [[package]]
 name = "pycparser"
 version = "3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
@@ -6098,7 +6098,7 @@ wheels = [
 [[package]]
 name = "pycryptodome"
 version = "3.23.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8e/a6/8452177684d5e906854776276ddd34eca30d1b1e15aa1ee9cefc289a33f5/pycryptodome-3.23.0.tar.gz", hash = "sha256:447700a657182d60338bab09fdb27518f8856aecd80ae4c6bdddb67ff5da44ef", size = 4921276, upload-time = "2025-05-17T17:21:45.242Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/5d/bdb09489b63cd34a976cc9e2a8d938114f7a53a74d3dd4f125ffa49dce82/pycryptodome-3.23.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:0011f7f00cdb74879142011f95133274741778abba114ceca229adbf8e62c3e4", size = 2495152, upload-time = "2025-05-17T17:20:20.833Z" },
@@ -6133,7 +6133,7 @@ wheels = [
 [[package]]
 name = "pydantic"
 version = "2.13.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "annotated-types" },
     { name = "pydantic-core" },
@@ -6153,7 +6153,7 @@ email = [
 [[package]]
 name = "pydantic-core"
 version = "2.46.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
@@ -6269,7 +6269,7 @@ wheels = [
 [[package]]
 name = "pydantic-settings"
 version = "2.14.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
@@ -6283,7 +6283,7 @@ wheels = [
 [[package]]
 name = "pyfiglet"
 version = "1.0.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c8/e3/0a86276ad2c383ce08d76110a8eec2fe22e7051c4b8ba3fa163a0b08c428/pyfiglet-1.0.4.tar.gz", hash = "sha256:db9c9940ed1bf3048deff534ed52ff2dafbbc2cd7610b17bb5eca1df6d4278ef", size = 1560615, upload-time = "2025-08-15T18:32:47.302Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9f/5c/fe9f95abd5eaedfa69f31e450f7e2768bef121dbdf25bcddee2cd3087a16/pyfiglet-1.0.4-py3-none-any.whl", hash = "sha256:65b57b7a8e1dff8a67dc8e940a117238661d5e14c3e49121032bd404d9b2b39f", size = 1806118, upload-time = "2025-08-15T18:32:45.556Z" },
@@ -6292,7 +6292,7 @@ wheels = [
 [[package]]
 name = "pygments"
 version = "2.20.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
@@ -6301,7 +6301,7 @@ wheels = [
 [[package]]
 name = "pyjwt"
 version = "2.13.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
@@ -6318,7 +6318,7 @@ crypto = [
 [[package]]
 name = "pymssql"
 version = "2.3.13"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7a/cc/843c044b7f71ee329436b7327c578383e2f2499313899f88ad267cdf1f33/pymssql-2.3.13.tar.gz", hash = "sha256:2137e904b1a65546be4ccb96730a391fcd5a85aab8a0632721feb5d7e39cfbce", size = 203153, upload-time = "2026-02-14T05:00:36.865Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/b5/77d2af3cab1a129891f75a4223a145664ec0443a340ee737518b499b4edb/pymssql-2.3.13-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:476f6f06b2ae5dfbfa0b169a6ecdd0d9ddfedb07f2d6dc97d2dd630ff2d6789a", size = 3173361, upload-time = "2026-02-14T04:59:16.582Z" },
@@ -6361,7 +6361,7 @@ wheels = [
 [[package]]
 name = "pymysql"
 version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c9/bc/1c6a92f385940f727daeecf3bacaf186e03875dff57197801046c583bcf0/pymysql-1.2.0.tar.gz", hash = "sha256:6c7b17ca686988104d7426c27895b455cdeea3e9d3ceb1270f0c3704fead8c33", size = 49021, upload-time = "2026-05-19T08:26:22.302Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c4/bd/2534e130295c8cfd4f0a2e31623baab7502278f1e97bcfe61db75656a77f/pymysql-1.2.0-py3-none-any.whl", hash = "sha256:62169ce6d5510f08e140c5e7990ee884a9764024e4a9a27b2cc11f1099322ae0", size = 45716, upload-time = "2026-05-19T08:26:20.974Z" },
@@ -6370,7 +6370,7 @@ wheels = [
 [[package]]
 name = "pynacl"
 version = "1.6.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
@@ -6405,7 +6405,7 @@ wheels = [
 [[package]]
 name = "pyopenssl"
 version = "25.3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
@@ -6418,7 +6418,7 @@ wheels = [
 [[package]]
 name = "pyparsing"
 version = "3.3.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
@@ -6427,7 +6427,7 @@ wheels = [
 [[package]]
 name = "pyperclip"
 version = "1.11.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/52/d87eba7cb129b81563019d1679026e7a112ef76855d6159d24754dbd2a51/pyperclip-1.11.0.tar.gz", hash = "sha256:244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6", size = 12185, upload-time = "2025-09-26T14:40:37.245Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl", hash = "sha256:299403e9ff44581cb9ba2ffeed69c7aa96a008622ad0c46cb575ca75b5b84273", size = 11063, upload-time = "2025-09-26T14:40:36.069Z" },
@@ -6451,7 +6451,7 @@ requires-dist = [
 [[package]]
 name = "pyproject-hooks"
 version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
@@ -6460,7 +6460,7 @@ wheels = [
 [[package]]
 name = "pyreadline3"
 version = "3.5.6"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b6/6d/f94028646d7bbe6d9d873c47ee7c246f2d29129d253f0d96cb6fcab70733/pyreadline3-3.5.6.tar.gz", hash = "sha256:61e53218b99656091ddb077df9e71f25850e72e030b6183b39c9b7e6e4f4a9bf", size = 100368, upload-time = "2026-05-14T17:55:04.471Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/5e/35c856e186b74678c24927847ad9895a51f1bc02a0c6126477a6c6040064/pyreadline3-3.5.6-py3-none-any.whl", hash = "sha256:8449b734232e42a5dcd74048e39b60db2839a4c38cf3ae2bf7707d58b5389c0d", size = 85243, upload-time = "2026-05-14T17:55:03.262Z" },
@@ -6469,7 +6469,7 @@ wheels = [
 [[package]]
 name = "pysftp"
 version = "0.2.9"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "paramiko" },
 ]
@@ -6478,7 +6478,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/36/60/45f30390a38b1f92e
 [[package]]
 name = "pysocks"
 version = "1.7.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0", size = 284429, upload-time = "2019-09-20T02:07:35.714Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5", size = 16725, upload-time = "2019-09-20T02:06:22.938Z" },
@@ -6487,7 +6487,7 @@ wheels = [
 [[package]]
 name = "pyspark"
 version = "4.0.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "py4j" },
 ]
@@ -6496,7 +6496,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/96/89/408b42c803db71f4a
 [[package]]
 name = "pytest"
 version = "9.0.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
@@ -6514,7 +6514,7 @@ wheels = [
 [[package]]
 name = "pytest-asyncio"
 version = "1.4.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
     { name = "pytest" },
@@ -6528,7 +6528,7 @@ wheels = [
 [[package]]
 name = "pytest-benchmark"
 version = "5.2.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "py-cpuinfo" },
     { name = "pytest" },
@@ -6541,7 +6541,7 @@ wheels = [
 [[package]]
 name = "pytest-cov"
 version = "7.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "coverage", extra = ["toml"] },
     { name = "pluggy" },
@@ -6555,7 +6555,7 @@ wheels = [
 [[package]]
 name = "pytest-repeat"
 version = "0.9.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "pytest" },
 ]
@@ -6567,7 +6567,7 @@ wheels = [
 [[package]]
 name = "pytest-rerunfailures"
 version = "16.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "packaging" },
     { name = "pytest" },
@@ -6580,7 +6580,7 @@ wheels = [
 [[package]]
 name = "pytest-timeout"
 version = "2.4.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "pytest" },
 ]
@@ -6592,7 +6592,7 @@ wheels = [
 [[package]]
 name = "pytest-xdist"
 version = "3.8.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "execnet" },
     { name = "pytest" },
@@ -6605,7 +6605,7 @@ wheels = [
 [[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "six" },
 ]
@@ -6617,7 +6617,7 @@ wheels = [
 [[package]]
 name = "python-discovery"
 version = "1.4.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "platformdirs" },
@@ -6630,7 +6630,7 @@ wheels = [
 [[package]]
 name = "python-dotenv"
 version = "1.2.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
@@ -6639,7 +6639,7 @@ wheels = [
 [[package]]
 name = "python-multipart"
 version = "0.0.30"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4b/82/c8cd43a6e0719bf5a3b034f6726dd701f75829c08944c83d4b95d02ed0e8/python_multipart-0.0.30.tar.gz", hash = "sha256:0edfe0475c1f46ddd3ff7785a626f6118af32bdcf359bb21260367313bb32118", size = 46316, upload-time = "2026-05-31T19:24:55.198Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1c/fd/0318007beb234790993d3ec5afd051d1dbceb733e81e3afe2b981ece3f37/python_multipart-0.0.30-py3-none-any.whl", hash = "sha256:830964def8c90607ac5daa00514e3987815865713ade8d20febc9177ac0c3c5b", size = 29730, upload-time = "2026-05-31T19:24:53.814Z" },
@@ -6648,7 +6648,7 @@ wheels = [
 [[package]]
 name = "pytz"
 version = "2026.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ff/46/dd499ec9038423421951e4fad73051febaa13d2df82b4064f87af8b8c0c3/pytz-2026.2.tar.gz", hash = "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a", size = 320861, upload-time = "2026-05-04T01:35:29.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/dd/96da98f892250475bdf2328112d7468abdd4acc7b902b6af23f4ed958ea0/pytz-2026.2-py2.py3-none-any.whl", hash = "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126", size = 510141, upload-time = "2026-05-04T01:35:27.408Z" },
@@ -6657,7 +6657,7 @@ wheels = [
 [[package]]
 name = "pywin32"
 version = "311"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/40/44efbb0dfbd33aca6a6483191dae0716070ed99e2ecb0c53683f400a0b4f/pywin32-311-cp310-cp310-win32.whl", hash = "sha256:d03ff496d2a0cd4a5893504789d4a15399133fe82517455e78bad62efbb7f0a3", size = 8760432, upload-time = "2025-07-14T20:13:05.9Z" },
     { url = "https://files.pythonhosted.org/packages/5e/bf/360243b1e953bd254a82f12653974be395ba880e7ec23e3731d9f73921cc/pywin32-311-cp310-cp310-win_amd64.whl", hash = "sha256:797c2772017851984b97180b0bebe4b620bb86328e8a884bb626156295a63b3b", size = 9590103, upload-time = "2025-07-14T20:13:07.698Z" },
@@ -6679,7 +6679,7 @@ wheels = [
 [[package]]
 name = "pywin32-ctypes"
 version = "0.2.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
@@ -6688,7 +6688,7 @@ wheels = [
 [[package]]
 name = "pyyaml"
 version = "6.0.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/a0/39350dd17dd6d6c6507025c0e53aef67a9293a6d37d3511f23ea510d5800/pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b", size = 184227, upload-time = "2025-09-25T21:31:46.04Z" },
@@ -6752,7 +6752,7 @@ wheels = [
 [[package]]
 name = "pyzmq"
 version = "27.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "cffi", marker = "implementation_name == 'pypy'" },
 ]
@@ -6825,22 +6825,22 @@ wheels = [
 [[package]]
 name = "ragas"
 version = "0.4.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "appdirs" },
     { name = "datasets" },
     { name = "diskcache" },
     { name = "instructor" },
     { name = "langchain" },
-    { name = "langchain-community", version = "0.3.31", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "langchain-community", version = "0.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "langchain-community", version = "0.3.31", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "langchain-community", version = "0.4.2", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "langchain-core" },
     { name = "langchain-openai" },
     { name = "nest-asyncio" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "openai" },
     { name = "pillow" },
     { name = "pydantic" },
@@ -6858,11 +6858,11 @@ wheels = [
 [[package]]
 name = "referencing"
 version = "0.37.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "attrs" },
-    { name = "rpds-py", version = "0.30.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "rpds-py", version = "2026.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "rpds-py", version = "0.30.0", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "rpds-py", version = "2026.5.1", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
@@ -6873,7 +6873,7 @@ wheels = [
 [[package]]
 name = "regex"
 version = "2026.5.9"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/dc/0e/49aee608ad09480e7fd276898c99ec6192985fa331abe4eb3a986094490b/regex-2026.5.9.tar.gz", hash = "sha256:a8234aa23ec39894bfe4a3f1b85616a7032481964a13ac6fc9f10de4f6fca270", size = 416074, upload-time = "2026-05-09T23:15:19.37Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/ed/0ad2c8edf634918eb4484365d3819fa7bd7f58daf807fe7fb21812c316e5/regex-2026.5.9-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a9e1328e17c84c1a5d22ec9f785ecef4a967fab9a42b6a8dc3bcbebd0a0c9e44", size = 489438, upload-time = "2026-05-09T23:11:29.374Z" },
@@ -6994,7 +6994,7 @@ wheels = [
 [[package]]
 name = "regress"
 version = "2025.10.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/02/bf/faa406189856f9b566fa1c42d173188d3e86cd5116484a663922365e0004/regress-2025.10.1.tar.gz", hash = "sha256:dcc0a8af0cdbc3d6e0d4725f113335d0a5ffbba86ae3ca18d2b5b352c5f2c8ed", size = 11567, upload-time = "2025-10-09T07:09:48.397Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/48/f5/a11f2f523c1c861579596fcece76feb26cf996f085f21c6da9f729e8ed07/regress-2025.10.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:590abc9fa10255dcf84b4469f08cad9787001c38600080a033cd7a71f51cae02", size = 447475, upload-time = "2025-10-09T07:07:24.153Z" },
@@ -7120,7 +7120,7 @@ wheels = [
 [[package]]
 name = "requests"
 version = "2.34.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "charset-normalizer" },
@@ -7140,7 +7140,7 @@ socks = [
 [[package]]
 name = "requests-auth-aws-sigv4"
 version = "0.7"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "requests" },
 ]
@@ -7152,7 +7152,7 @@ wheels = [
 [[package]]
 name = "requests-oauthlib"
 version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "oauthlib" },
     { name = "requests" },
@@ -7165,7 +7165,7 @@ wheels = [
 [[package]]
 name = "requests-toolbelt"
 version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "requests" },
 ]
@@ -7177,7 +7177,7 @@ wheels = [
 [[package]]
 name = "rich"
 version = "14.3.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
@@ -7190,7 +7190,7 @@ wheels = [
 [[package]]
 name = "rich-rst"
 version = "2.0.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "pygments" },
     { name = "rich" },
@@ -7203,7 +7203,7 @@ wheels = [
 [[package]]
 name = "rpds-py"
 version = "0.30.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 resolution-markers = [
     "python_full_version < '3.11'",
 ]
@@ -7328,7 +7328,7 @@ wheels = [
 [[package]]
 name = "rpds-py"
 version = "2026.5.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
     "python_full_version == '3.13.*'",
@@ -7471,7 +7471,7 @@ wheels = [
 [[package]]
 name = "ruamel-yaml"
 version = "0.19.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
@@ -7480,7 +7480,7 @@ wheels = [
 [[package]]
 name = "ruff"
 version = "0.15.13"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/21/a7d5c126d5b557715ef81098f3db2fe20f622a039ff2e626af28d674ab80/ruff-0.15.13.tar.gz", hash = "sha256:f9d89f17f7ba7fb2ed42921f0df75da797a9a5d71bc39049e2c687cf2baf44b7", size = 4678180, upload-time = "2026-05-14T13:44:37.869Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/61/11d458dc6ac22504fd8e237b29dfd40504c7fbbcc8930402cfe51a8e63ed/ruff-0.15.13-py3-none-linux_armv6l.whl", hash = "sha256:444b580fc72fd6887e650acd3e575e18cdc79dbcf42fb4030b491057921f61f8", size = 10738279, upload-time = "2026-05-14T13:44:18.7Z" },
@@ -7505,7 +7505,7 @@ wheels = [
 [[package]]
 name = "s3transfer"
 version = "0.18.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "botocore" },
 ]
@@ -7517,14 +7517,14 @@ wheels = [
 [[package]]
 name = "scikit-learn"
 version = "1.7.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
     { name = "joblib", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version < '3.11'" },
     { name = "threadpoolctl", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/c2/a7855e41c9d285dfe86dc50b250978105dce513d6e459ea66a6aeb0e1e0c/scikit_learn-1.7.2.tar.gz", hash = "sha256:20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda", size = 7193136, upload-time = "2025-09-09T08:21:29.075Z" }
@@ -7564,7 +7564,7 @@ wheels = [
 [[package]]
 name = "scikit-learn"
 version = "1.8.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
     "python_full_version == '3.13.*'",
@@ -7573,8 +7573,8 @@ resolution-markers = [
 ]
 dependencies = [
     { name = "joblib", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "threadpoolctl", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585, upload-time = "2025-12-10T07:08:53.618Z" }
@@ -7620,12 +7620,12 @@ wheels = [
 [[package]]
 name = "scikit-network"
 version = "0.33.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/46/6d/28b00fbef9ff7d8ba31861bf16705a1a74a1696fb65aab2a7c584f966bec/scikit_network-0.33.5.tar.gz", hash = "sha256:ae2149d9a280fdc4bbadd5f8a7b17c8af61c054bc3f834792bc61483e6783c12", size = 1784205, upload-time = "2025-11-19T09:45:14.402Z" }
 wheels = [
@@ -7654,12 +7654,12 @@ wheels = [
 [[package]]
 name = "scipy"
 version = "1.15.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -7713,7 +7713,7 @@ wheels = [
 [[package]]
 name = "scipy"
 version = "1.17.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
     "python_full_version == '3.13.*'",
@@ -7721,7 +7721,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -7790,7 +7790,7 @@ wheels = [
 [[package]]
 name = "secretstorage"
 version = "3.5.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "jeepney" },
@@ -7803,7 +7803,7 @@ wheels = [
 [[package]]
 name = "sentry-sdk"
 version = "2.61.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "urllib3" },
@@ -7816,7 +7816,7 @@ wheels = [
 [[package]]
 name = "setuptools"
 version = "81.0.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0d/1c/73e719955c59b8e424d015ab450f51c0af856ae46ea2da83eba51cc88de1/setuptools-81.0.0.tar.gz", hash = "sha256:487b53915f52501f0a79ccfd0c02c165ffe06631443a886740b91af4b7a5845a", size = 1198299, upload-time = "2026-02-06T21:10:39.601Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/e3/c164c88b2e5ce7b24d667b9bd83589cf4f3520d97cad01534cd3c4f55fdb/setuptools-81.0.0-py3-none-any.whl", hash = "sha256:fdd925d5c5d9f62e4b74b30d6dd7828ce236fd6ed998a08d81de62ce5a6310d6", size = 1062021, upload-time = "2026-02-06T21:10:37.175Z" },
@@ -7825,7 +7825,7 @@ wheels = [
 [[package]]
 name = "shellingham"
 version = "1.5.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
@@ -7834,7 +7834,7 @@ wheels = [
 [[package]]
 name = "six"
 version = "1.17.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
@@ -7864,16 +7864,16 @@ requires-dist = [
 [[package]]
 name = "skops"
 version = "0.14.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "packaging" },
     { name = "prettytable" },
-    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c8/9f/46448c4e41a4c5ee4bdb74b3758af48e5ff0faeffe40f4e301bfc7594894/skops-0.14.0.tar.gz", hash = "sha256:6c8c0e047f691a3a582c3258943eecafcbfd79c8c7eef66260f3703e363254f0", size = 608084, upload-time = "2026-04-20T18:23:55.336Z" }
 wheels = [
@@ -7883,7 +7883,7 @@ wheels = [
 [[package]]
 name = "slowapi"
 version = "0.1.9"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "limits" },
 ]
@@ -7895,7 +7895,7 @@ wheels = [
 [[package]]
 name = "smmap"
 version = "5.0.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1f/ea/49c993d6dfdd7338c9b1000a0f36817ed7ec84577ae2e52f890d1a4ff909/smmap-5.0.3.tar.gz", hash = "sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c", size = 22506, upload-time = "2026-03-09T03:43:26.1Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl", hash = "sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f", size = 24390, upload-time = "2026-03-09T03:43:24.361Z" },
@@ -7904,7 +7904,7 @@ wheels = [
 [[package]]
 name = "sniffio"
 version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
@@ -7913,7 +7913,7 @@ wheels = [
 [[package]]
 name = "snowballstemmer"
 version = "3.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/63/ee/67eef9600338e245ad7838230969a34c823ddbdbccc5e1fc43cd75b55bc9/snowballstemmer-3.1.0.tar.gz", hash = "sha256:fd9e34526b23340cd23ffea6c9f9760974ecc2c2ac9e1d81401443ccdb2a801f", size = 122523, upload-time = "2026-05-24T19:04:19.691Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/83/ddbf4533c62dd32667ef1238952abef155f3d3391f5be69a352ad1638a42/snowballstemmer-3.1.0-py3-none-any.whl", hash = "sha256:17e6d1da216aa07db6dad37139ea70cf13c4b2e9a096f6e64a9648fc657d3154", size = 104550, upload-time = "2026-05-24T19:04:18.026Z" },
@@ -7922,7 +7922,7 @@ wheels = [
 [[package]]
 name = "soupsieve"
 version = "2.8.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
@@ -7931,7 +7931,7 @@ wheels = [
 [[package]]
 name = "sphinx"
 version = "4.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "alabaster" },
     { name = "babel" },
@@ -7959,7 +7959,7 @@ wheels = [
 [[package]]
 name = "sphinx-autobuild"
 version = "2024.10.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 resolution-markers = [
     "python_full_version < '3.11'",
 ]
@@ -7979,7 +7979,7 @@ wheels = [
 [[package]]
 name = "sphinx-autobuild"
 version = "2025.8.25"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
     "python_full_version == '3.13.*'",
@@ -8002,7 +8002,7 @@ wheels = [
 [[package]]
 name = "sphinx-click"
 version = "6.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "click" },
     { name = "docutils" },
@@ -8016,7 +8016,7 @@ wheels = [
 [[package]]
 name = "sphinx-reredirects"
 version = "0.1.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "sphinx" },
 ]
@@ -8028,7 +8028,7 @@ wheels = [
 [[package]]
 name = "sphinx-tabs"
 version = "3.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "docutils" },
     { name = "pygments" },
@@ -8042,7 +8042,7 @@ wheels = [
 [[package]]
 name = "sphinxcontrib-applehelp"
 version = "1.0.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/32/df/45e827f4d7e7fcc84e853bcef1d836effd762d63ccb86f43ede4e98b478c/sphinxcontrib-applehelp-1.0.4.tar.gz", hash = "sha256:828f867945bbe39817c210a1abfd1bc4895c8b73fcaade56d45357a348a07d7e", size = 24766, upload-time = "2023-01-23T09:41:54.435Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/06/c1/5e2cafbd03105ce50d8500f9b4e8a6e8d02e22d0475b574c3b3e9451a15f/sphinxcontrib_applehelp-1.0.4-py3-none-any.whl", hash = "sha256:29d341f67fb0f6f586b23ad80e072c8e6ad0b48417db2bde114a4c9746feb228", size = 120601, upload-time = "2023-01-23T09:41:52.364Z" },
@@ -8051,7 +8051,7 @@ wheels = [
 [[package]]
 name = "sphinxcontrib-devhelp"
 version = "1.0.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/98/33/dc28393f16385f722c893cb55539c641c9aaec8d1bc1c15b69ce0ac2dbb3/sphinxcontrib-devhelp-1.0.2.tar.gz", hash = "sha256:ff7f1afa7b9642e7060379360a67e9c41e8f3121f2ce9164266f61b9f4b338e4", size = 17398, upload-time = "2020-02-29T04:14:43.378Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/09/5de5ed43a521387f18bdf5f5af31d099605c992fd25372b2b9b825ce48ee/sphinxcontrib_devhelp-1.0.2-py2.py3-none-any.whl", hash = "sha256:8165223f9a335cc1af7ffe1ed31d2871f325254c0423bc0c4c7cd1c1e4734a2e", size = 84690, upload-time = "2020-02-29T04:14:40.765Z" },
@@ -8060,7 +8060,7 @@ wheels = [
 [[package]]
 name = "sphinxcontrib-htmlhelp"
 version = "2.0.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b3/47/64cff68ea3aa450c373301e5bebfbb9fce0a3e70aca245fcadd4af06cd75/sphinxcontrib-htmlhelp-2.0.1.tar.gz", hash = "sha256:0cbdd302815330058422b98a113195c9249825d681e18f11e8b1f78a2f11efff", size = 27967, upload-time = "2023-01-31T17:29:20.935Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6e/ee/a1f5e39046cbb5f8bc8fba87d1ddf1c6643fbc9194e58d26e606de4b9074/sphinxcontrib_htmlhelp-2.0.1-py3-none-any.whl", hash = "sha256:c38cb46dccf316c79de6e5515e1770414b797162b23cd3d06e67020e1d2a6903", size = 99833, upload-time = "2023-01-31T17:29:18.489Z" },
@@ -8069,7 +8069,7 @@ wheels = [
 [[package]]
 name = "sphinxcontrib-jsmath"
 version = "1.0.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b2/e8/9ed3830aeed71f17c026a07a5097edcf44b692850ef215b161b8ad875729/sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8", size = 5787, upload-time = "2019-01-21T16:10:16.347Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl", hash = "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178", size = 5071, upload-time = "2019-01-21T16:10:14.333Z" },
@@ -8078,7 +8078,7 @@ wheels = [
 [[package]]
 name = "sphinxcontrib-qthelp"
 version = "1.0.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b1/8e/c4846e59f38a5f2b4a0e3b27af38f2fcf904d4bfd82095bf92de0b114ebd/sphinxcontrib-qthelp-1.0.3.tar.gz", hash = "sha256:4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72", size = 21658, upload-time = "2020-02-29T04:19:10.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/14/05f9206cf4e9cfca1afb5fd224c7cd434dcc3a433d6d9e4e0264d29c6cdb/sphinxcontrib_qthelp-1.0.3-py2.py3-none-any.whl", hash = "sha256:bd9fc24bcb748a8d51fd4ecaade681350aa63009a347a8c14e637895444dfab6", size = 90609, upload-time = "2020-02-29T04:19:08.451Z" },
@@ -8087,7 +8087,7 @@ wheels = [
 [[package]]
 name = "sphinxcontrib-serializinghtml"
 version = "1.1.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b5/72/835d6fadb9e5d02304cf39b18f93d227cd93abd3c41ebf58e6853eeb1455/sphinxcontrib-serializinghtml-1.1.5.tar.gz", hash = "sha256:aa5f6de5dfdf809ef505c4895e51ef5c9eac17d0f287933eb49ec495280b6952", size = 21019, upload-time = "2021-05-22T16:07:43.043Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/77/5464ec50dd0f1c1037e3c93249b040c8fc8078fdda97530eeb02424b6eea/sphinxcontrib_serializinghtml-1.1.5-py2.py3-none-any.whl", hash = "sha256:352a9a00ae864471d3a7ead8d7d79f5fc0b57e8b3f95e9867eb9eb28999b92fd", size = 94021, upload-time = "2021-05-22T16:07:41.627Z" },
@@ -8096,7 +8096,7 @@ wheels = [
 [[package]]
 name = "sqlalchemy"
 version = "2.0.50"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
     { name = "typing-extensions" },
@@ -8151,7 +8151,7 @@ wheels = [
 [[package]]
 name = "sqlparse"
 version = "0.5.5"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
@@ -8160,7 +8160,7 @@ wheels = [
 [[package]]
 name = "sse-starlette"
 version = "3.4.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "starlette" },
@@ -8173,7 +8173,7 @@ wheels = [
 [[package]]
 name = "starlette"
 version = "0.52.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
@@ -8186,7 +8186,7 @@ wheels = [
 [[package]]
 name = "tabulate"
 version = "0.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ec/fe/802052aecb21e3797b8f7902564ab6ea0d60ff8ca23952079064155d1ae1/tabulate-0.9.0.tar.gz", hash = "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c", size = 81090, upload-time = "2022-10-06T17:21:48.54Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl", hash = "sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f", size = 35252, upload-time = "2022-10-06T17:21:44.262Z" },
@@ -8195,7 +8195,7 @@ wheels = [
 [[package]]
 name = "tenacity"
 version = "9.1.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
@@ -8204,7 +8204,7 @@ wheels = [
 [[package]]
 name = "tensorflow"
 version = "2.21.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "absl-py" },
     { name = "astunparse" },
@@ -8213,12 +8213,12 @@ dependencies = [
     { name = "google-pasta" },
     { name = "grpcio" },
     { name = "h5py" },
-    { name = "keras", version = "3.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "keras", version = "3.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "keras", version = "3.12.2", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "keras", version = "3.14.1", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "libclang" },
     { name = "ml-dtypes" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "opt-einsum" },
     { name = "packaging" },
     { name = "protobuf" },
@@ -8251,7 +8251,7 @@ wheels = [
 [[package]]
 name = "termcolor"
 version = "3.3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/46/79/cf31d7a93a8fdc6aa0fbb665be84426a8c5a557d9240b6239e9e11e35fc5/termcolor-3.3.0.tar.gz", hash = "sha256:348871ca648ec6a9a983a13ab626c0acce02f515b9e1983332b17af7979521c5", size = 14434, upload-time = "2025-12-29T12:55:21.882Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl", hash = "sha256:cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5", size = 7734, upload-time = "2025-12-29T12:55:20.718Z" },
@@ -8260,7 +8260,7 @@ wheels = [
 [[package]]
 name = "threadpoolctl"
 version = "3.6.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
@@ -8269,7 +8269,7 @@ wheels = [
 [[package]]
 name = "tiktoken"
 version = "0.13.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "regex" },
     { name = "requests" },
@@ -8330,7 +8330,7 @@ wheels = [
 [[package]]
 name = "tinycss2"
 version = "1.4.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "webencodings" },
 ]
@@ -8342,7 +8342,7 @@ wheels = [
 [[package]]
 name = "toml"
 version = "0.10.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
@@ -8351,7 +8351,7 @@ wheels = [
 [[package]]
 name = "tomli"
 version = "2.4.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
@@ -8405,7 +8405,7 @@ wheels = [
 [[package]]
 name = "tornado"
 version = "6.5.6"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/50/57/6d7303a77ae439d9189108f76c0c4fd89ee5e2cc8387bffb55232565c4ed/tornado-6.5.6.tar.gz", hash = "sha256:9a365179fe8ff6b8766f602c0f67c185d778193e9bdd828b19f0b6ed7764177d", size = 518139, upload-time = "2026-05-27T15:35:54.646Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/0d/b4f481e18c5a51864e6d12b9a05ecf72919696680b747c958c3fc1f4fbae/tornado-6.5.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:65fcfaafb079435c2c19dc9e07c0f1cf0fa9051759ed0a7d0a3ba7ea7f64919c", size = 447737, upload-time = "2026-05-27T15:35:38.122Z" },
@@ -8422,7 +8422,7 @@ wheels = [
 [[package]]
 name = "tqdm"
 version = "4.67.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
@@ -8434,7 +8434,7 @@ wheels = [
 [[package]]
 name = "traitlets"
 version = "5.15.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/22/40f55b26baeab80c2d7b3f1db0682f8954e4617fee7d90ce634022ef05c6/traitlets-5.15.0.tar.gz", hash = "sha256:4fead733f81cf1c4c938e06f8ca4633896833c9d89eff878159457f4d4392971", size = 163197, upload-time = "2026-05-06T08:05:58.016Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/98/a9937a969d018a23badfea0b381f66783649d48e0ea6c41923265c3cbeb3/traitlets-5.15.0-py3-none-any.whl", hash = "sha256:fb36a18867a6803deab09f3c5e0fa81bb7b26a5c9e82501c9933f759166eff40", size = 85877, upload-time = "2026-05-06T08:05:55.853Z" },
@@ -8443,7 +8443,7 @@ wheels = [
 [[package]]
 name = "ty"
 version = "0.0.24"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7a/96/652a425030f95dc2c9548d9019e52502e17079e1daeefbc4036f1c0905b4/ty-0.0.24.tar.gz", hash = "sha256:9fe42f6b98207bdaef51f71487d6d087f2cb02555ee3939884d779b2b3cc8bfc", size = 5354286, upload-time = "2026-03-19T16:55:57.035Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/e5/34457ee11708e734ba81ad65723af83030e484f961e281d57d1eecf08951/ty-0.0.24-py3-none-linux_armv6l.whl", hash = "sha256:1ab4f1f61334d533a3fdf5d9772b51b1300ac5da4f3cdb0be9657a3ccb2ce3e7", size = 10394877, upload-time = "2026-03-19T16:55:54.246Z" },
@@ -8467,7 +8467,7 @@ wheels = [
 [[package]]
 name = "typer"
 version = "0.26.4"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "annotated-doc" },
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -8482,7 +8482,7 @@ wheels = [
 [[package]]
 name = "types-pyyaml"
 version = "6.0.12.20260518"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b8/83/4a1afc3fbfcf5b8d46fc390cd95ed6b0dc9010a265f4e9f46314efffa37a/types_pyyaml-6.0.12.20260518.tar.gz", hash = "sha256:d917f83fb38462550338c1297faedd860b3ec83912b96b1e3d73255f7473e466", size = 17850, upload-time = "2026-05-18T06:01:58.675Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl", hash = "sha256:d2150f75a231c9fe9c7463bd29487d93e60bac90400287351384bc2284eba7cd", size = 20312, upload-time = "2026-05-18T06:01:57.368Z" },
@@ -8491,7 +8491,7 @@ wheels = [
 [[package]]
 name = "types-toml"
 version = "0.10.8.20260518"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4b/11/6ece999e91f2ccb848ab4420f3f4816e78ac0541f739e6864affdaaa5737/types_toml-0.10.8.20260518.tar.gz", hash = "sha256:80e10facd24fdeda9d5c672187d72be3ac284843788d67f5aae59e3e016db6fe", size = 9419, upload-time = "2026-05-18T06:02:16.719Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/91/25/489751806bf5c95e4007f8e17409199c54d31e49ffbea07c5729b1286c8e/types_toml-0.10.8.20260518-py3-none-any.whl", hash = "sha256:0e564ab05f6fde62a315b3b5a9b6624fda569399795d30a37e64705a70459303", size = 9669, upload-time = "2026-05-18T06:02:15.86Z" },
@@ -8500,7 +8500,7 @@ wheels = [
 [[package]]
 name = "typing-extensions"
 version = "4.15.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
@@ -8509,7 +8509,7 @@ wheels = [
 [[package]]
 name = "typing-inspect"
 version = "0.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "mypy-extensions" },
     { name = "typing-extensions" },
@@ -8522,7 +8522,7 @@ wheels = [
 [[package]]
 name = "typing-inspection"
 version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
@@ -8534,7 +8534,7 @@ wheels = [
 [[package]]
 name = "tzdata"
 version = "2026.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
@@ -8543,7 +8543,7 @@ wheels = [
 [[package]]
 name = "uncalled-for"
 version = "0.3.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b5/82/345cc927f7fbdae6065e7768759932fcc827fc20b29b45dfbafa2f1f7da4/uncalled_for-0.3.2.tar.gz", hash = "sha256:89f5dbcd71e2b8f47c030b1fa302e6cce2ec795d1ac565eeb6525c5fe55cb8a2", size = 50032, upload-time = "2026-05-06T13:38:25.204Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/25/2c87754f3a9e692315f7b811244090e68f362979fc8886b3fbd2985a1d8c/uncalled_for-0.3.2-py3-none-any.whl", hash = "sha256:0ff60b142c7d1f8070bde9d42afaa70aedc77dcc10998c227687e9c15713418e", size = 11444, upload-time = "2026-05-06T13:38:24.025Z" },
@@ -8552,7 +8552,7 @@ wheels = [
 [[package]]
 name = "urllib3"
 version = "2.7.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
@@ -8561,7 +8561,7 @@ wheels = [
 [[package]]
 name = "uuid-utils"
 version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/a1/822ceef22d1c139cffebe4b1b660cfaa10253d5c770aa2598dc8e9497593/uuid_utils-0.16.0.tar.gz", hash = "sha256:d6902d4375dfba4c9902c736bb82d3c040417b67f7d0fa48910ddfdb1ac95de7", size = 42596, upload-time = "2026-05-19T07:44:23.28Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/78/fc830a25597001586770f0436a4917aac21fcdaf7ac2824bbe168ccdc724/uuid_utils-0.16.0-cp310-cp310-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:a632fead2a6505a8df3318d5e95503739b9aa1c518521cd93d83ce00699b78f8", size = 566691, upload-time = "2026-05-19T07:45:14.2Z" },
@@ -8674,7 +8674,7 @@ wheels = [
 [[package]]
 name = "uvicorn"
 version = "0.48.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
@@ -8699,7 +8699,7 @@ standard = [
 [[package]]
 name = "uvloop"
 version = "0.22.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250, upload-time = "2025-10-16T22:17:19.342Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/14/ecceb239b65adaaf7fde510aa8bd534075695d1e5f8dadfa32b5723d9cfb/uvloop-0.22.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ef6f0d4cc8a9fa1f6a910230cd53545d9a14479311e87e3cb225495952eb672c", size = 1343335, upload-time = "2025-10-16T22:16:11.43Z" },
@@ -8743,7 +8743,7 @@ wheels = [
 [[package]]
 name = "virtualenv"
 version = "21.4.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "distlib" },
     { name = "filelock" },
@@ -8759,7 +8759,7 @@ wheels = [
 [[package]]
 name = "waitress"
 version = "3.0.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bf/cb/04ddb054f45faa306a230769e868c28b8065ea196891f09004ebace5b184/waitress-3.0.2.tar.gz", hash = "sha256:682aaaf2af0c44ada4abfb70ded36393f0e307f4ab9456a215ce0020baefc31f", size = 179901, upload-time = "2024-11-16T20:02:35.195Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/57/a27182528c90ef38d82b636a11f606b0cbb0e17588ed205435f8affe3368/waitress-3.0.2-py3-none-any.whl", hash = "sha256:c56d67fd6e87c2ee598b76abdd4e96cfad1f24cacdea5078d382b1f9d7b5ed2e", size = 56232, upload-time = "2024-11-16T20:02:33.858Z" },
@@ -8768,7 +8768,7 @@ wheels = [
 [[package]]
 name = "watchfiles"
 version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "anyio" },
 ]
@@ -8885,7 +8885,7 @@ wheels = [
 [[package]]
 name = "wcwidth"
 version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
@@ -8894,7 +8894,7 @@ wheels = [
 [[package]]
 name = "webencodings"
 version = "0.5.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
@@ -8903,7 +8903,7 @@ wheels = [
 [[package]]
 name = "websocket-client"
 version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
@@ -8912,7 +8912,7 @@ wheels = [
 [[package]]
 name = "websockets"
 version = "16.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/74/221f58decd852f4b59cc3354cccaf87e8ef695fede361d03dc9a7396573b/websockets-16.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:04cdd5d2d1dacbad0a7bf36ccbcd3ccd5a30ee188f2560b7a62a30d14107b31a", size = 177343, upload-time = "2026-01-10T09:22:21.28Z" },
@@ -8980,7 +8980,7 @@ wheels = [
 [[package]]
 name = "werkzeug"
 version = "3.1.8"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
@@ -8992,7 +8992,7 @@ wheels = [
 [[package]]
 name = "wheel"
 version = "0.47.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "packaging" },
 ]
@@ -9004,7 +9004,7 @@ wheels = [
 [[package]]
 name = "whenever"
 version = "0.7.3"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
@@ -9071,7 +9071,7 @@ wheels = [
 [[package]]
 name = "wrapt"
 version = "2.2.1"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2d/9f/06263fcd8ad6c405f05a3905fd7a84dd3176eb5ad46e44bccc0cd16348bb/wrapt-2.2.1.tar.gz", hash = "sha256:6744f504375775d7609c82c8d3d94af1c9a6f05586984536905908ba905277b9", size = 127620, upload-time = "2026-05-22T14:49:43.056Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b4/8b/84bc1ea68b620fe0e2696a8cff07e82f4b962d952ab14efee8955997bb70/wrapt-2.2.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0f68f478004475d97906686e702ddbddeaf717c0b68ad2794384308f2dc713ae", size = 80093, upload-time = "2026-05-22T14:47:27.074Z" },
@@ -9157,7 +9157,7 @@ wheels = [
 [[package]]
 name = "wtforms"
 version = "3.2.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
@@ -9169,7 +9169,7 @@ wheels = [
 [[package]]
 name = "xxhash"
 version = "3.7.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/2f/e183a1b407002f5af81822bee18b61cdb94b8670208ef34734d8d2b8ebe9/xxhash-3.7.0.tar.gz", hash = "sha256:6cc4eefbb542a5d6ffd6d70ea9c502957c925e800f998c5630ecc809d6702bae", size = 82022, upload-time = "2026-04-25T11:10:32.553Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/92/49/e4b575b4ed170a7f640c8bd69cfadfa81c7b700191fde5e72228762b9f73/xxhash-3.7.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cd8ab85c916a58d5c8656ea15e3ce9df836fe2f120a74c296e01d69fab2614b4", size = 33426, upload-time = "2026-04-25T11:05:15.702Z" },
@@ -9326,7 +9326,7 @@ wheels = [
 [[package]]
 name = "yarl"
 version = "1.24.2"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 dependencies = [
     { name = "idna" },
     { name = "multidict" },
@@ -9442,7 +9442,7 @@ wheels = [
 [[package]]
 name = "zipp"
 version = "4.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
@@ -9451,7 +9451,7 @@ wheels = [
 [[package]]
 name = "zstandard"
 version = "0.25.0"
-source = { registry = "https://pypi.org/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fd/aa/3e0508d5a5dd96529cdc5a97011299056e14c6505b678fd58938792794b1/zstandard-0.25.0.tar.gz", hash = "sha256:7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b", size = 711513, upload-time = "2025-09-14T22:15:54.002Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/7a/28efd1d371f1acd037ac64ed1c5e2b41514a6cc937dd6ab6a13ab9f0702f/zstandard-0.25.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e59fdc271772f6686e01e1b3b74537259800f57e24280be3f29c8a0deb1904dd", size = 795256, upload-time = "2025-09-14T22:15:56.415Z" },


### PR DESCRIPTION
## Summary
- Adds regression test run detail page with test cases table, trace drawer, and assessment review components
- Adds "Regression Test" type filter and column to the evaluation runs table  
- Adds route definitions for regression test run pages
- Stores guideline text in assessment metadata for `Guidelines` and `ExpectationsGuidelines` scorers, enabling the UI to display the original guideline alongside each assessment

## Test plan
- [ ] Manual verification of regression test run page rendering
- [ ] Verify guideline text appears in test-case drawer assessments

This pull request was co-authored by Claude.